### PR TITLE
Integrate NIP-07 extension login

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNostr } from '../nostr';
 
 export default function Header({ onTab, tab }) {
-  const { nostrUser, createNewKeypair, logout, error } = useNostr();
+  const { nostrUser, loginWithExtension, logout, error, hasNip07 } = useNostr();
   return (
     <header style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '2rem' }}>
       <h1>Nostr Patreon MVP</h1>
@@ -13,13 +13,19 @@ export default function Header({ onTab, tab }) {
         {nostrUser ? (
           <>
             <div style={{ fontSize: '0.8em' }}>
-              <strong>npub:</strong> {nostrUser.npub.slice(0, 16)}...<br />
-              <strong>nsec:</strong> {nostrUser.nsec.slice(0, 10)}...
-              <br /><button style={{ marginTop: 3 }} onClick={logout}>Forget Key</button>
+              <strong>npub:</strong> {nostrUser.npub.slice(0, 16)}...
+              <br />
+              <button style={{ marginTop: 3 }} onClick={logout}>Logout</button>
             </div>
           </>
         ) : (
-          <button onClick={createNewKeypair}>Create New Key Pair</button>
+          <>
+            {hasNip07 ? (
+              <button onClick={loginWithExtension}>Login with Nostr Extension</button>
+            ) : (
+              <span style={{ color: 'gray' }}>Nostr extension not detected</span>
+            )
+          </>
         )}
         {error && <div style={{ color: 'red', fontSize: '0.85em' }}>{error}</div>}
       </div>

--- a/src/nostr.js
+++ b/src/nostr.js
@@ -14,35 +14,8 @@ export function useNostr() {
   return useContext(NostrContext);
 }
 
-// Utility functions using window.NostrTools (from CDN)
-function generatePrivateKey() {
-  return window.NostrTools.generatePrivateKey();
-}
-function getPublicKey(sk) {
-  return window.NostrTools.getPublicKey(sk);
-}
-function getEventHash(ev) {
-  return window.NostrTools.getEventHash(ev);
-}
-function signEvent(ev, sk) {
-  return window.NostrTools.getSignature(ev, sk);
-}
 export function npubEncode(pk) {
   return window.NostrTools.nip19.npubEncode(pk);
-}
-export function nsecEncode(sk) {
-  return window.NostrTools.nip19.nsecEncode(sk);
-}
-
-function saveKeys(sk, pk) {
-  localStorage.setItem("nostr_sk", sk);
-  localStorage.setItem("nostr_pk", pk);
-}
-function loadKeys() {
-  const sk = localStorage.getItem("nostr_sk");
-  const pk = localStorage.getItem("nostr_pk");
-  if (sk && pk) return { sk, pk };
-  return null;
 }
 function saveRelays(relays) {
   localStorage.setItem("nostr_relays", JSON.stringify(relays));
@@ -60,16 +33,11 @@ export function NostrProvider({ children }) {
   const [relays, setRelays] = useState(loadRelays());
   const [relayStatus, setRelayStatus] = useState({});
   const [error, setError] = useState(null);
+  const [hasNip07, setHasNip07] = useState(false);
 
   useEffect(() => {
-    const keys = loadKeys();
-    if (keys) {
-      setNostrUser({
-        sk: keys.sk,
-        pk: keys.pk,
-        npub: npubEncode(keys.pk),
-        nsec: nsecEncode(keys.sk)
-      });
+    if (window.nostr && window.nostr.getPublicKey && window.nostr.signEvent) {
+      setHasNip07(true);
     }
   }, []);
 
@@ -104,35 +72,32 @@ export function NostrProvider({ children }) {
     setRelays(relays.filter(r => r !== relay));
   }
 
-  function createNewKeypair() {
+  async function loginWithExtension() {
+    if (!hasNip07) return;
     try {
-      const sk = generatePrivateKey();
-      const pk = getPublicKey(sk);
-      saveKeys(sk, pk);
-      setNostrUser({ sk, pk, npub: npubEncode(pk), nsec: nsecEncode(sk) });
+      const pk = await window.nostr.getPublicKey();
+      setNostrUser({ pk, npub: npubEncode(pk) });
       setError(null);
     } catch (e) {
-      setError("Failed to generate keys: " + e.message);
+      setError("Failed to get public key: " + e.message);
     }
   }
 
   function logout() {
-    localStorage.removeItem("nostr_sk");
-    localStorage.removeItem("nostr_pk");
     setNostrUser(null);
     setError(null);
   }
 
   async function publishNostrEvent(eventTemplate) {
-    if (!nostrUser) throw new Error("Generate your keypair first!");
+    if (!nostrUser) throw new Error("Connect your Nostr extension first!");
+    if (!hasNip07) throw new Error("NIP-07 extension not available");
     try {
       const template = {
         ...eventTemplate,
         pubkey: nostrUser.pk,
         created_at: Math.floor(Date.now() / 1000)
       };
-      template.id = getEventHash(template);
-      template.sig = signEvent(template, nostrUser.sk);
+      const signed = await window.nostr.signEvent(template);
 
       let errors = [];
       let successes = 0;
@@ -142,7 +107,7 @@ export function NostrProvider({ children }) {
             const ws = new window.WebSocket(relayUrl);
             let isHandled = false;
             ws.onopen = () => {
-              ws.send(JSON.stringify(["EVENT", template]));
+              ws.send(JSON.stringify(["EVENT", signed]));
               setTimeout(() => { if (!isHandled) ws.close(); }, 1000);
             };
             ws.onerror = () => { errors.push(relayUrl); ws.close(); resolve(); };
@@ -153,7 +118,7 @@ export function NostrProvider({ children }) {
       ));
       if (successes === 0) throw new Error(errors.join("; "));
       setError(null);
-      return template;
+      return signed;
     } catch (err) {
       setError("Publish failed: " + err.message);
       throw err;
@@ -205,7 +170,7 @@ export function NostrProvider({ children }) {
 
   // Profile functions
   async function publishProfile(profile) {
-    if (!nostrUser) throw new Error("Generate your keypair first!");
+    if (!nostrUser) throw new Error("Connect your Nostr extension first!");
     return await publishNostrEvent({
       kind: KIND_PROFILE,
       tags: [],
@@ -224,7 +189,7 @@ export function NostrProvider({ children }) {
 
   return (
     <NostrContext.Provider value={{
-      nostrUser, error, setError, createNewKeypair, logout,
+      nostrUser, error, setError, loginWithExtension, logout, hasNip07,
       publishNostrEvent, fetchLatestEvent, fetchEventsFromRelay,
       relays, addRelay, removeRelay, relayStatus,
       publishProfile, fetchProfile

--- a/src/pages/CreatorSetupPage.js
+++ b/src/pages/CreatorSetupPage.js
@@ -32,7 +32,7 @@ export default function CreatorSetupPage() {
   }, [nostrUser]);
 
   async function handlePublishTier() {
-    if (!nostrUser) return alert('Generate your key pair first');
+    if (!nostrUser) return alert('Connect your Nostr extension first');
     try {
       setError(null);
       const event = {
@@ -51,7 +51,7 @@ export default function CreatorSetupPage() {
     <div>
       <RelayManager />
       <h2>Creator Setup</h2>
-      {!nostrUser && <div style={{ color: 'gray' }}>Generate or load your Nostr key to use creator functions.</div>}
+      {!nostrUser && <div style={{ color: 'gray' }}>Login with your Nostr extension to use creator functions.</div>}
       <div>
         <input placeholder="Tier Title" value={tier.title} onChange={e => setTier({ ...tier, title: e.target.value })} disabled={!nostrUser} />
         <input placeholder="Amount (in sats)" type="number" value={tier.amount} onChange={e => setTier({ ...tier, amount: e.target.value })} disabled={!nostrUser} />

--- a/src/pages/MyProfilePage.js
+++ b/src/pages/MyProfilePage.js
@@ -33,7 +33,7 @@ export default function MyProfilePage() {
   return (
     <section>
       <h2>My Profile</h2>
-      {!nostrUser && <div style={{ color: 'gray' }}>Generate your Nostr key to use profile functions.</div>}
+      {!nostrUser && <div style={{ color: 'gray' }}>Login with your Nostr extension to use profile functions.</div>}
       <input placeholder="Name" value={profile.name} onChange={e => setProfile({ ...profile, name: e.target.value })} disabled={!nostrUser} />
       <input placeholder="Picture URL" value={profile.picture} onChange={e => setProfile({ ...profile, picture: e.target.value })} disabled={!nostrUser} />
       <textarea placeholder="Bio/About" value={profile.about} onChange={e => setProfile({ ...profile, about: e.target.value })} disabled={!nostrUser} />

--- a/src/pages/SupportCreatorPage.js
+++ b/src/pages/SupportCreatorPage.js
@@ -28,7 +28,7 @@ export default function SupportCreatorPage() {
   }
 
   async function handlePledgeSupport() {
-    if (!nostrUser || !tier) { setError('Generate your keypair and load a tier.'); return; }
+    if (!nostrUser || !tier) { setError('Connect your Nostr extension and load a tier.'); return; }
     try {
       setError(null);
       const event = {


### PR DESCRIPTION
## Summary
- integrate NIP‑07 and remove local keypair handling
- allow login via browser extension
- update signing to use `window.nostr.signEvent`
- tweak UI copy for extension-based login

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*