### PR TITLE
Implement basic creator search and discovery

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { NostrProvider } from './nostr';
 import Header from './components/Header';
 import CreatorSetupPage from './pages/CreatorSetupPage';
 import SupportCreatorPage from './pages/SupportCreatorPage';
+import DiscoverPage from './pages/DiscoverPage';
 import MyProfilePage from './pages/MyProfilePage';
 
 export default function App() {
@@ -13,6 +14,7 @@ export default function App() {
         <Header tab={tab} onTab={setTab} />
         {tab === 'creator' && <CreatorSetupPage />}
         {tab === 'supporter' && <SupportCreatorPage />}
+        {tab === 'discover' && <DiscoverPage />}
         {tab === 'profile' && <MyProfilePage />}
         <footer style={{ marginTop: 64, color: '#888' }}>Nostr Patreon MVP - Demo</footer>
       </div>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders application header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = screen.getByText(/Nostr Patreon MVP/i);
+  expect(header).toBeInTheDocument();
 });

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -8,6 +8,7 @@ export default function Header({ onTab, tab }) {
       <h1>Nostr Patreon MVP</h1>
       <button onClick={() => onTab('creator')}>Creator</button>
       <button onClick={() => onTab('supporter')}>Support a Creator</button>
+      <button onClick={() => onTab('discover')}>Discover</button>
       <button onClick={() => onTab('profile')}>My Profile</button>
       <div style={{ marginLeft: 'auto', textAlign: 'right' }}>
         {nostrUser ? (

--- a/src/nostr.js
+++ b/src/nostr.js
@@ -34,6 +34,28 @@ export function nsecEncode(sk) {
   return window.NostrTools.nip19.nsecEncode(sk);
 }
 
+export function npubDecode(npub) {
+  try {
+    return window.NostrTools.nip19.decode(npub).data;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveNip05(identifier) {
+  const parts = identifier.split('@');
+  if (parts.length !== 2) return null;
+  const [name, domain] = parts;
+  try {
+    const res = await fetch(`https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name)}`);
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json.names?.[name] || null;
+  } catch {
+    return null;
+  }
+}
+
 function saveKeys(sk, pk) {
   localStorage.setItem("nostr_sk", sk);
   localStorage.setItem("nostr_pk", pk);
@@ -227,7 +249,8 @@ export function NostrProvider({ children }) {
       nostrUser, error, setError, createNewKeypair, logout,
       publishNostrEvent, fetchLatestEvent, fetchEventsFromRelay,
       relays, addRelay, removeRelay, relayStatus,
-      publishProfile, fetchProfile
+      publishProfile, fetchProfile,
+      npubDecode, resolveNip05
     }}>
       {children}
     </NostrContext.Provider>

--- a/src/pages/DiscoverPage.js
+++ b/src/pages/DiscoverPage.js
@@ -1,0 +1,48 @@
+import React, { useState, useEffect } from 'react';
+import { useNostr, DEFAULT_RELAYS, KIND_MVP_TIER, KIND_PROFILE } from '../nostr';
+import ProfileCard from '../components/ProfileCard';
+
+export default function DiscoverPage() {
+  const { fetchEventsFromRelay } = useNostr();
+  const [events, setEvents] = useState([]);
+  const [keyword, setKeyword] = useState('');
+  const [filtered, setFiltered] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      const prof = await fetchEventsFromRelay({ kinds: [KIND_PROFILE], limit: 100 }, DEFAULT_RELAYS[0]);
+      const tiers = await fetchEventsFromRelay({ kinds: [KIND_MVP_TIER], limit: 100 }, DEFAULT_RELAYS[0]);
+      const all = [...prof, ...tiers];
+      setEvents(all);
+      setFiltered(all);
+    }
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleFilter() {
+    const term = keyword.trim().toLowerCase();
+    if (!term) { setFiltered(events); return; }
+    setFiltered(events.filter(ev => {
+      const content = ev.content?.toLowerCase() || '';
+      if (content.includes(term)) return true;
+      return ev.tags?.some(t => t[0] === 't' && t[1].toLowerCase().includes(term));
+    }));
+  }
+
+  return (
+    <div>
+      <h2>Discover Creators</h2>
+      <input value={keyword} placeholder="Filter by tag or keyword" onChange={e => setKeyword(e.target.value)} />
+      <button onClick={handleFilter}>Apply</button>
+      <ul style={{ paddingLeft: 0 }}>
+        {filtered.map(ev => (
+          <li key={ev.id} style={{ listStyle: 'none', marginBottom: 10 }}>
+            <ProfileCard pubkey={ev.pubkey} />
+            {ev.kind === KIND_MVP_TIER && <pre>{ev.content}</pre>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/SupportCreatorPage.js
+++ b/src/pages/SupportCreatorPage.js
@@ -5,7 +5,8 @@ import RelayManager from '../components/RelayManager';
 import ProfileCard from '../components/ProfileCard';
 
 export default function SupportCreatorPage() {
-  const { nostrUser, publishNostrEvent, fetchLatestEvent } = useNostr();
+  const { nostrUser, publishNostrEvent, fetchLatestEvent, npubDecode, resolveNip05 } = useNostr();
+  const [inputId, setInputId] = useState('');
   const [creatorKey, setCreatorKey] = useState('');
   const [creatorProfile, setCreatorProfile] = useState(null);
   const [tier, setTier] = useState(null);
@@ -13,12 +14,23 @@ export default function SupportCreatorPage() {
 
   async function handleFetchCreatorTier() {
     setError(null);
-    if (!creatorKey) return;
+    let pk = inputId.trim();
+    if (!pk) return;
+    if (pk.includes('@') && !pk.match(/^[a-f0-9]{64}$/i)) {
+      const resolved = await resolveNip05(pk);
+      if (!resolved) { setError('NIP-05 identifier not found.'); return; }
+      pk = resolved;
+    } else if (pk.startsWith('npub')) {
+      const decoded = npubDecode(pk);
+      if (!decoded) { setError('Invalid npub.'); return; }
+      pk = decoded;
+    }
+    setCreatorKey(pk);
     try {
-      const tierEvent = await fetchLatestEvent(creatorKey, KIND_MVP_TIER, DEFAULT_RELAYS[0]);
+      const tierEvent = await fetchLatestEvent(pk, KIND_MVP_TIER, DEFAULT_RELAYS[0]);
       if (!tierEvent) { setTier(null); setError('No tier found for this pubkey.'); return; }
       setTier(JSON.parse(tierEvent.content));
-      const profEvent = await fetchLatestEvent(creatorKey, KIND_PROFILE, DEFAULT_RELAYS[0]);
+      const profEvent = await fetchLatestEvent(pk, KIND_PROFILE, DEFAULT_RELAYS[0]);
       if (profEvent) {
         try { setCreatorProfile(JSON.parse(profEvent.content)); } catch { }
       }
@@ -50,8 +62,13 @@ export default function SupportCreatorPage() {
     <div>
       <RelayManager />
       <h2>Support a Creator</h2>
-      <input placeholder="Creator Pubkey" value={creatorKey} onChange={e => setCreatorKey(e.target.value)} />
+      <input
+        placeholder="Creator npub or NIP-05"
+        value={inputId}
+        onChange={e => setInputId(e.target.value)}
+      />
       <button onClick={handleFetchCreatorTier}>Find Tier</button>
+      {creatorKey && <div style={{ fontSize: '0.8em', marginTop: 4 }}>Pubkey: {creatorKey}</div>}
       {creatorProfile && (
         <ProfileCard pubkey={creatorKey} />
       )}


### PR DESCRIPTION
## Summary
- decode npub strings and resolve NIP‑05 identifiers via new helpers
- expose helpers in Nostr context
- enhance Support Creator page with npub/NIP‑05 search
- add Discover page for filtering events by keyword or tag
- update header navigation and routing
- fix test to look for app header

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*