### PR TITLE
Add Cashu wallet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Supporters can optionally connect a Nostr Wallet Connect (NIP-47) compatible wal
 When a recurring pledge payment is due the app can send a `pay_invoice` request
 to the connected wallet. If no wallet is connected, the app will show the
 invoice so it can be paid manually.
+
+## Cashu Wallet (NIP-60)
+
+The demo now includes a very small Cashu wallet implementation. Users can
+publish wallet metadata and token events using the Cashu tab. Stored token
+events follow the [NIP-60](https://nips.nostr.com/60) draft so they can be
+synchronized across Nostr clients.

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import Header from './components/Header';
 import CreatorSetupPage from './pages/CreatorSetupPage';
 import SupportCreatorPage from './pages/SupportCreatorPage';
 import MyProfilePage from './pages/MyProfilePage';
+import CashuWalletPage from './pages/CashuWalletPage';
 
 export default function App() {
   const [tab, setTab] = useState('creator');
@@ -14,6 +15,7 @@ export default function App() {
         {tab === 'creator' && <CreatorSetupPage />}
         {tab === 'supporter' && <SupportCreatorPage />}
         {tab === 'profile' && <MyProfilePage />}
+        {tab === 'wallet' && <CashuWalletPage />}
         <footer style={{ marginTop: 64, color: '#888' }}>Nostr Patreon MVP - Demo</footer>
       </div>
     </NostrProvider>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -9,6 +9,7 @@ export default function Header({ onTab, tab }) {
       <button onClick={() => onTab('creator')}>Creator</button>
       <button onClick={() => onTab('supporter')}>Support a Creator</button>
       <button onClick={() => onTab('profile')}>My Profile</button>
+      <button onClick={() => onTab('wallet')}>Cashu Wallet</button>
       <div style={{ marginLeft: 'auto', textAlign: 'right' }}>
         {nostrUser ? (
           <>

--- a/src/pages/CashuWalletPage.js
+++ b/src/pages/CashuWalletPage.js
@@ -1,0 +1,71 @@
+import React, { useState, useEffect } from 'react';
+import { useNostr, DEFAULT_RELAYS } from '../nostr';
+
+export default function CashuWalletPage() {
+  const { nostrUser, publishNostrEvent, fetchLatestEvent, fetchEventsFromRelay } = useNostr();
+  const [wallet, setWallet] = useState(null);
+  const [mint, setMint] = useState('');
+  const [tokens, setTokens] = useState([]);
+  const [newToken, setNewToken] = useState('');
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!nostrUser) return;
+    (async () => {
+      try {
+        const w = await fetchLatestEvent(nostrUser.pk, 17375, DEFAULT_RELAYS[0]);
+        if (w) setWallet(JSON.parse(w.content));
+        const ts = await fetchEventsFromRelay({ authors: [nostrUser.pk], kinds: [7375] }, DEFAULT_RELAYS[0]);
+        setTokens(ts);
+      } catch {}
+    })();
+  }, [nostrUser]);
+
+  async function handlePublishWallet() {
+    if (!nostrUser) return;
+    try {
+      setError(null);
+      await publishNostrEvent({
+        kind: 17375,
+        tags: [["mint", mint]],
+        content: JSON.stringify({ mint })
+      });
+      alert('Wallet event published');
+    } catch (e) { setError('Failed: ' + e.message); }
+  }
+
+  async function handleAddToken() {
+    if (!nostrUser || !newToken) return;
+    try {
+      setError(null);
+      await publishNostrEvent({
+        kind: 7375,
+        tags: [],
+        content: JSON.stringify({ mint, proofs: [newToken] })
+      });
+      alert('Token event published');
+    } catch (e) { setError('Failed: ' + e.message); }
+  }
+
+  return (
+    <div>
+      <h2>Cashu Wallet</h2>
+      {!nostrUser && <div style={{ color: 'gray' }}>Login with your Nostr extension first.</div>}
+      <div style={{ marginBottom: 20 }}>
+        <input placeholder="Mint URL" value={mint} onChange={e => setMint(e.target.value)} disabled={!nostrUser} />
+        <button onClick={handlePublishWallet} disabled={!nostrUser}>Publish Wallet</button>
+      </div>
+      <div style={{ marginBottom: 20 }}>
+        <input placeholder="New proof" value={newToken} onChange={e => setNewToken(e.target.value)} disabled={!nostrUser} />
+        <button onClick={handleAddToken} disabled={!nostrUser}>Add Token</button>
+      </div>
+      <h3>Stored Tokens</h3>
+      <ul>
+        {tokens.map(ev => (
+          <li key={ev.id}>{ev.content.slice(0, 64)}...</li>
+        ))}
+      </ul>
+      {error && <div style={{ color: 'red' }}>{error}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple Cashu wallet page
- link Cashu wallet from the header and main app
- document NIP-60 Cashu wallet feature

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*