### PR TITLE
Add Cashu wallet spending for tier payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ The demo now includes a very small Cashu wallet implementation. Users can
 publish wallet metadata and token events using the Cashu tab. Stored token
 events follow the [NIP-60](https://nips.nostr.com/60) draft so they can be
 synchronized across Nostr clients.
+
+Cashu tokens stored in the wallet can now be used to pay creator tiers.
+When a recurring pledge payment is due a "Pay with Cashu" option will
+appear if tokens are available. The token is sent to the creator via a
+Nostr DM and the local token event is deleted.

--- a/src/pages/CashuWalletPage.js
+++ b/src/pages/CashuWalletPage.js
@@ -1,8 +1,14 @@
 import React, { useState, useEffect } from 'react';
-import { useNostr, DEFAULT_RELAYS } from '../nostr';
+import { useNostr } from '../nostr';
 
 export default function CashuWalletPage() {
-  const { nostrUser, publishNostrEvent, fetchLatestEvent, fetchEventsFromRelay } = useNostr();
+  const {
+    nostrUser,
+    fetchCashuWallet,
+    fetchCashuTokens,
+    publishCashuWallet,
+    addCashuToken
+  } = useNostr();
   const [wallet, setWallet] = useState(null);
   const [mint, setMint] = useState('');
   const [tokens, setTokens] = useState([]);
@@ -13,9 +19,9 @@ export default function CashuWalletPage() {
     if (!nostrUser) return;
     (async () => {
       try {
-        const w = await fetchLatestEvent(nostrUser.pk, 17375, DEFAULT_RELAYS[0]);
-        if (w) setWallet(JSON.parse(w.content));
-        const ts = await fetchEventsFromRelay({ authors: [nostrUser.pk], kinds: [7375] }, DEFAULT_RELAYS[0]);
+        const w = await fetchCashuWallet(nostrUser.pk);
+        if (w) setWallet(w);
+        const ts = await fetchCashuTokens(nostrUser.pk);
         setTokens(ts);
       } catch {}
     })();
@@ -25,11 +31,7 @@ export default function CashuWalletPage() {
     if (!nostrUser) return;
     try {
       setError(null);
-      await publishNostrEvent({
-        kind: 17375,
-        tags: [["mint", mint]],
-        content: JSON.stringify({ mint })
-      });
+      await publishCashuWallet({ mint });
       alert('Wallet event published');
     } catch (e) { setError('Failed: ' + e.message); }
   }
@@ -38,11 +40,7 @@ export default function CashuWalletPage() {
     if (!nostrUser || !newToken) return;
     try {
       setError(null);
-      await publishNostrEvent({
-        kind: 7375,
-        tags: [],
-        content: JSON.stringify({ mint, proofs: [newToken] })
-      });
+      await addCashuToken({ mint, proofs: [newToken] });
       alert('Token event published');
     } catch (e) { setError('Failed: ' + e.message); }
   }


### PR DESCRIPTION
## Summary
- support Cashu wallet events and tokens in nostr context
- connect Cashu wallet page to the new helpers
- allow paying recurring pledges with stored Cashu tokens
- document the Cashu payment option

## Testing
- `npm test --silent` *(fails: react-scripts not found)*