### PR TITLE
Relay info via NIP-11

### DIFF
--- a/src/nip11.js
+++ b/src/nip11.js
@@ -1,0 +1,13 @@
+export async function fetchNip11(relayUrl, name) {
+  try {
+    const httpUrl = relayUrl.replace(/^ws(s?):\/\//, 'http$1://');
+    const url = name ? `${httpUrl}/?name=${encodeURIComponent(name)}` : httpUrl;
+    const resp = await fetch(url, { headers: { Accept: 'application/nostr+json' } });
+    if (!resp.ok) throw new Error('HTTP ' + resp.status);
+    const data = await resp.json();
+    return data;
+  } catch (err) {
+    console.warn('Failed to fetch NIP-11 for', relayUrl, err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add helper to request NIP‑11 metadata
- store relay metadata and load it when relays are modified
- display relay name, description and NIP support in RelayManager

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*