### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ Cashu tokens stored in the wallet can now be used to pay creator tiers.
 When a recurring pledge payment is due a "Pay with Cashu" option will
 appear if tokens are available. The token is sent to the creator via a
 Nostr DM and the local token event is deleted.
+
+## Dark Mode
+
+The header now includes a button to toggle between light and dark
+themes. Your preference is stored in `localStorage` so it persists
+across visits.

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { NostrProvider } from './nostr';
 import Header from './components/Header';
 import CreatorSetupPage from './pages/CreatorSetupPage';
@@ -10,10 +10,20 @@ import UserActivityPage from './pages/UserActivityPage';
 
 export default function App() {
   const [tab, setTab] = useState('creator');
+  const [darkMode, setDarkMode] = useState(() =>
+    localStorage.getItem('theme') === 'dark'
+  );
+
+  useEffect(() => {
+    document.body.dataset.theme = darkMode ? 'dark' : 'light';
+    localStorage.setItem('theme', darkMode ? 'dark' : 'light');
+  }, [darkMode]);
+
+  const toggleDarkMode = () => setDarkMode((m) => !m);
   return (
     <NostrProvider>
       <div style={{ maxWidth: 800, margin: '0 auto', padding: 32 }}>
-        <Header tab={tab} onTab={setTab} />
+        <Header tab={tab} onTab={setTab} darkMode={darkMode} onToggleDarkMode={toggleDarkMode} />
         {tab === 'creator' && <CreatorSetupPage />}
         {tab === 'supporter' && <SupportCreatorPage />}
         {tab === 'profile' && <MyProfilePage />}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNostr } from '../nostr';
 
-export default function Header({ onTab, tab }) {
+export default function Header({ onTab, tab, darkMode, onToggleDarkMode }) {
   const { nostrUser, loginWithExtension, logout, error, hasNip07 } = useNostr();
   return (
     <header style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '2rem' }}>
@@ -12,6 +12,9 @@ export default function Header({ onTab, tab }) {
       <button onClick={() => onTab('wallet')}>Cashu Wallet</button>
       <button onClick={() => onTab('follows')}>Follows</button>
       <button onClick={() => onTab('activity')}>Activity</button>
+      <button onClick={onToggleDarkMode}>
+        {darkMode ? 'Light Mode' : 'Dark Mode'}
+      </button>
       <div style={{ marginLeft: 'auto', textAlign: 'right' }}>
         {nostrUser ? (
           <>


### PR DESCRIPTION
## Summary
- implement a theme toggle stored in localStorage
- display a Dark/Light Mode button in the header
- document dark mode in the README

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*