### PR TITLE
Extract component styles into CSS modules

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { useNostr } from '../nostr';
+import styles from './Header.module.css';
 
 export default function Header({ onTab, tab, darkMode, onToggleDarkMode }) {
   const { nostrUser, loginWithExtension, logout, error, hasNip07 } = useNostr();
   return (
-    <header style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '2rem' }}>
+    <header className={styles.header}>
       <h1>Nostr Patreon MVP</h1>
       <button onClick={() => onTab('creator')}>Creator</button>
       <button onClick={() => onTab('supporter')}>Support a Creator</button>
@@ -15,13 +16,13 @@ export default function Header({ onTab, tab, darkMode, onToggleDarkMode }) {
       <button onClick={onToggleDarkMode}>
         {darkMode ? 'Light Mode' : 'Dark Mode'}
       </button>
-      <div style={{ marginLeft: 'auto', textAlign: 'right' }}>
+      <div className={styles.userArea}>
         {nostrUser ? (
           <>
-            <div style={{ fontSize: '0.8em' }}>
+            <div className={styles.userInfo}>
               <strong>npub:</strong> {nostrUser.npub.slice(0, 16)}...
               <br />
-              <button style={{ marginTop: 3 }} onClick={logout}>Logout</button>
+              <button className={styles.logoutButton} onClick={logout}>Logout</button>
             </div>
           </>
         ) : (
@@ -29,11 +30,11 @@ export default function Header({ onTab, tab, darkMode, onToggleDarkMode }) {
             {hasNip07 ? (
               <button onClick={loginWithExtension}>Login with Nostr Extension</button>
             ) : (
-              <span style={{ color: 'gray' }}>Nostr extension not detected</span>
+              <span className={styles.notDetected}>Nostr extension not detected</span>
             )
           </>
         )}
-        {error && <div style={{ color: 'red', fontSize: '0.85em' }}>{error}</div>}
+        {error && <div className={styles.error}>{error}</div>}
       </div>
     </header>
   );

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -1,0 +1,28 @@
+.header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.userArea {
+  margin-left: auto;
+  text-align: right;
+}
+
+.userInfo {
+  font-size: 0.8em;
+}
+
+.logoutButton {
+  margin-top: 3px;
+}
+
+.error {
+  color: red;
+  font-size: 0.85em;
+}
+
+.notDetected {
+  color: gray;
+}

--- a/src/components/ProfileCard.js
+++ b/src/components/ProfileCard.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNostr, npubEncode } from '../nostr';
+import styles from './ProfileCard.module.css';
 
 export default function ProfileCard({ pubkey }) {
   const { fetchProfile } = useNostr();
@@ -16,11 +17,11 @@ export default function ProfileCard({ pubkey }) {
 
   if (!pubkey) return null;
   return (
-    <div style={{ margin: '16px 0', border: '1px solid #eee', borderRadius: 10, padding: 10 }}>
-      <div style={{ fontWeight: 700 }}>User: {npubEncode(pubkey).slice(0, 14)}...</div>
+    <div className={styles.card}>
+      <div className={styles.username}>User: {npubEncode(pubkey).slice(0, 14)}...</div>
       {profile && (
         <div>
-          {profile.picture && <img src={profile.picture} alt="" style={{ width: 36, borderRadius: '50%', margin: 6 }} />}
+          {profile.picture && <img src={profile.picture} alt="" className={styles.avatar} />}
           {profile.name && <div><b>Name:</b> {profile.name}</div>}
           {profile.about && <div><b>Bio:</b> {profile.about}</div>}
         </div>

--- a/src/components/ProfileCard.module.css
+++ b/src/components/ProfileCard.module.css
@@ -1,0 +1,16 @@
+.card {
+  margin: 16px 0;
+  border: 1px solid #eee;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.username {
+  font-weight: 700;
+}
+
+.avatar {
+  width: 36px;
+  border-radius: 50%;
+  margin: 6px;
+}


### PR DESCRIPTION
## Summary
- add `Header.module.css` and `ProfileCard.module.css`
- replace inline styles in `Header` and `ProfileCard` with class names

## Testing
- `npm test --silent` *(fails: react-scripts not found)*