### PR TITLE
Fix failing test

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Nostr Patreon MVP heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /Nostr Patreon MVP/i });
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update `App.test.js` to look for the "Nostr Patreon MVP" heading instead of CRA placeholder text

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*