### PR TITLE
Add private key login

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNostr } from '../nostr';
 import styles from './Header.module.css';
 import DarkModeToggle from './DarkModeToggle';
 
 export default function Header({ onTab, tab, darkMode, onToggleDarkMode }) {
-  const { nostrUser, loginWithExtension, logout, error, hasNip07 } = useNostr();
+  const { nostrUser, loginWithExtension, loginWithPrivateKey, logout, error, hasNip07 } = useNostr();
+  const [privKey, setPrivKey] = useState('');
   return (
     <header className={styles.header}>
       <h1>Nostr Patreon MVP</h1>
@@ -31,6 +32,15 @@ export default function Header({ onTab, tab, darkMode, onToggleDarkMode }) {
             ) : (
               <span className={styles.notDetected}>Nostr extension not detected</span>
             )}
+            <div>
+              <input
+                type="text"
+                placeholder="nsec..."
+                value={privKey}
+                onChange={e => setPrivKey(e.target.value)}
+              />
+              <button onClick={() => loginWithPrivateKey(privKey)}>Login with Private Key</button>
+            </div>
           </>
         )}
         {error && <div className={styles.error}>{error}</div>}

--- a/src/nostr.js
+++ b/src/nostr.js
@@ -47,6 +47,21 @@ export function NostrProvider({ children }) {
     }
   }
 
+  function loginWithPrivateKey(nsec) {
+    try {
+      const decoded = window.NostrTools.nip19.decode(nsec);
+      if (decoded.type !== 'nsec') {
+        throw new Error('Invalid nsec string');
+      }
+      const sk = decoded.data;
+      const pk = window.NostrTools.getPublicKey(sk);
+      setNostrUser({ pk, sk, npub: npubEncode(pk) });
+      setError(null);
+    } catch (e) {
+      setError('Failed to use private key: ' + e.message);
+    }
+  }
+
   function logout() {
     setNostrUser(null);
     setError(null);
@@ -314,7 +329,7 @@ export function NostrProvider({ children }) {
 
   return (
     <NostrContext.Provider value={{
-      nostrUser, error, setError, loginWithExtension, logout, hasNip07,
+      nostrUser, error, setError, loginWithExtension, loginWithPrivateKey, logout, hasNip07,
       publishNostrEvent, fetchLatestEvent, fetchEventsFromRelay,
       relays, addRelay, removeRelay, relayStatus,
       publishProfile, fetchProfile,


### PR DESCRIPTION
## Summary
- support login with a raw `nsec` private key
- show private key input in the header

## Testing
- `npm test --silent` *(fails: react-scripts not found)*