### PR TITLE
fix: theme-aware icons on Welcome map

### DIFF
--- a/src/components/NavigationMap.vue
+++ b/src/components/NavigationMap.vue
@@ -16,8 +16,8 @@
       <q-expansion-item
         v-for="(item, idx) in items"
         :key="item.id"
-        :label="item.menuItem"
-        :icon="item.icon"
+        :label="item.iconComponent ? void 0 : item.menuItem"
+        :icon="item.iconComponent ? void 0 : item.icon"
         group="navigation"
         class="border-b accordion-item"
         :class="{ open: openIndex === idx }"
@@ -26,6 +26,12 @@
         expand-icon="keyboard_arrow_down"
         expanded-icon="keyboard_arrow_down"
       >
+        <template v-if="item.iconComponent" #header>
+          <q-item-section avatar>
+            <component :is="item.iconComponent" class="themed-icon" />
+          </q-item-section>
+          <q-item-section>{{ item.menuItem }}</q-item-section>
+        </template>
         <div class="px-4 pb-4 text-sm">
           <div class="fan-content">
             <h4 class="font-semibold mb-2">{{ $t('AboutPage.navigation.fanPerspective') }}</h4>

--- a/src/components/icons/CreatorHubIcon.vue
+++ b/src/components/icons/CreatorHubIcon.vue
@@ -1,0 +1,20 @@
+<template>
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <circle cx="12" cy="12" r="3" />
+    <circle cx="21" cy="6" r="2" />
+    <circle cx="21" cy="18" r="2" />
+    <circle cx="3" cy="12" r="2" />
+    <line x1="13.5" y1="10.5" x2="19.5" y2="7.5" />
+    <line x1="13.5" y1="13.5" x2="19.5" y2="16.5" />
+    <line x1="10.5" y1="12" x2="5" y2="12" />
+  </svg>
+</template>
+
+<script setup lang="ts"></script>

--- a/src/components/icons/FindCreatorsIcon.vue
+++ b/src/components/icons/FindCreatorsIcon.vue
@@ -1,0 +1,15 @@
+<template>
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <circle cx="11" cy="11" r="7" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+</template>
+
+<script setup lang="ts"></script>

--- a/src/composables/navigationItems.ts
+++ b/src/composables/navigationItems.ts
@@ -1,10 +1,13 @@
-import { computed } from 'vue'
+import { computed, type Component } from 'vue'
 import { useI18n } from 'vue-i18n'
+import FindCreatorsIcon from 'src/components/icons/FindCreatorsIcon.vue'
+import CreatorHubIcon from 'src/components/icons/CreatorHubIcon.vue'
 
 export interface NavigationItem {
   id: string
   menuItem: string
-  icon: string
+  icon?: string
+  iconComponent?: Component
   fanText: string
   creatorText: string
 }
@@ -29,14 +32,14 @@ export function useNavigationItems() {
     {
       id: 'findCreators',
       menuItem: t('MainHeader.menu.findCreators.title'),
-      icon: 'img:icons/find-creators.svg',
+      iconComponent: FindCreatorsIcon,
       fanText: t('AboutPage.navigation.items.findCreators.fan'),
       creatorText: t('AboutPage.navigation.items.findCreators.creator'),
     },
     {
       id: 'creatorHub',
       menuItem: t('MainHeader.menu.creatorHub.title'),
-      icon: 'img:icons/creator-hub.svg',
+      iconComponent: CreatorHubIcon,
       fanText: t('AboutPage.navigation.items.creatorHub.fan'),
       creatorText: t('AboutPage.navigation.items.creatorHub.creator'),
     },

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -158,6 +158,13 @@ body.body--light {
   --due-soon-bg: var(--due-soon-bg-light);
 }
 
+.themed-icon {
+  color: #111827;
+}
+.body--dark .themed-icon {
+  color: #ffffff;
+}
+
 /* Utility components */
 .panel-container {
   background-color: var(--panel-bg-color);


### PR DESCRIPTION
## Summary
- add themable Find Creators and Creator Hub SVG icons
- use custom header slot to render icons in NavigationMap
- style `.themed-icon` to switch colors with Quasar's dark mode

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a98a76c490833084c9a14895d16b7a