### PR TITLE
fix: standardize welcome map icon sizing

### DIFF
--- a/src/components/NavigationMap.vue
+++ b/src/components/NavigationMap.vue
@@ -27,10 +27,16 @@
         expanded-icon="keyboard_arrow_down"
       >
         <template v-if="item.iconComponent" #header>
-          <q-item-section avatar>
-            <component :is="item.iconComponent" class="themed-icon" />
-          </q-item-section>
-          <q-item-section>{{ item.menuItem }}</q-item-section>
+          <div class="nav-map-header">
+            <q-item-section avatar>
+              <component
+                :is="item.iconComponent"
+                class="themed-icon nav-map-icon"
+                aria-hidden="true"
+              />
+            </q-item-section>
+            <q-item-section>{{ item.menuItem }}</q-item-section>
+          </div>
         </template>
         <div class="px-4 pb-4 text-sm">
           <div class="fan-content">

--- a/src/components/icons/CreatorHubIcon.vue
+++ b/src/components/icons/CreatorHubIcon.vue
@@ -1,11 +1,15 @@
 <template>
   <svg
     viewBox="0 0 24 24"
+    width="1em"
+    height="1em"
     fill="none"
     stroke="currentColor"
     stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"
+    aria-hidden="true"
+    focusable="false"
   >
     <circle cx="12" cy="12" r="3" />
     <circle cx="21" cy="6" r="2" />

--- a/src/components/icons/FindCreatorsIcon.vue
+++ b/src/components/icons/FindCreatorsIcon.vue
@@ -1,11 +1,15 @@
 <template>
   <svg
     viewBox="0 0 24 24"
+    width="1em"
+    height="1em"
     fill="none"
     stroke="currentColor"
-    stroke-width="3"
+    stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"
+    aria-hidden="true"
+    focusable="false"
   >
     <circle cx="11" cy="11" r="7" />
     <line x1="21" y1="21" x2="16.65" y2="16.65" />

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -165,6 +165,20 @@ body.body--light {
   color: #ffffff;
 }
 
+/* Welcome navigation icon sizing */
+.nav-map-icon {
+  /* Use font-size so child SVGs sized 1em follow this */
+  font-size: 20px;
+  line-height: 1;
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+}
+
+#map-container .nav-map-header .q-item__section--avatar {
+  min-width: 32px; /* closer to QIcon spacing; adjust if needed */
+}
+
 /* Utility components */
 .panel-container {
   background-color: var(--panel-bg-color);


### PR DESCRIPTION
## Summary
- align NavigationMap icons with 20px sizing utility
- normalize FindCreators and CreatorHub inline SVGs to 1em / stroke-2
- tighten avatar spacing for navigation map header

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*


------
https://chatgpt.com/codex/tasks/task_e_68a98e1db45c8330abb9716049d577f6