### PR TITLE
fix: restore welcome map icon sizing and alignment

### DIFF
--- a/src/components/NavigationMap.vue
+++ b/src/components/NavigationMap.vue
@@ -8,6 +8,7 @@
       aria-label="Toggle between fan and creator modes"
       :active-color="mode === 'fan' ? 'accent' : 'primary'"
       :indicator-color="mode === 'fan' ? 'accent' : 'primary'"
+      :indicator-style="{ height: '3px' }"
     >
       <q-tab name="fan" label="Fan" :aria-selected="mode === 'fan'" />
       <q-tab name="creator" label="Creator" :aria-selected="mode === 'creator'" />
@@ -27,16 +28,14 @@
         expanded-icon="keyboard_arrow_down"
       >
         <template v-if="item.iconComponent" #header>
-          <div class="nav-map-header">
-            <q-item-section avatar>
-              <component
-                :is="item.iconComponent"
-                class="themed-icon nav-map-icon"
-                aria-hidden="true"
-              />
-            </q-item-section>
-            <q-item-section>{{ item.menuItem }}</q-item-section>
-          </div>
+          <q-item-section avatar>
+            <component
+              :is="item.iconComponent"
+              class="themed-icon nav-map-icon"
+              aria-hidden="true"
+            />
+          </q-item-section>
+          <q-item-section>{{ item.menuItem }}</q-item-section>
         </template>
         <div class="px-4 pb-4 text-sm">
           <div class="fan-content">

--- a/src/components/icons/CreatorHubIcon.vue
+++ b/src/components/icons/CreatorHubIcon.vue
@@ -5,7 +5,7 @@
     height="1em"
     fill="none"
     stroke="currentColor"
-    stroke-width="2"
+    stroke-width="2.5"
     stroke-linecap="round"
     stroke-linejoin="round"
     aria-hidden="true"

--- a/src/components/icons/FindCreatorsIcon.vue
+++ b/src/components/icons/FindCreatorsIcon.vue
@@ -5,7 +5,7 @@
     height="1em"
     fill="none"
     stroke="currentColor"
-    stroke-width="2"
+    stroke-width="2.5"
     stroke-linecap="round"
     stroke-linejoin="round"
     aria-hidden="true"

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -168,15 +168,11 @@ body.body--light {
 /* Welcome navigation icon sizing */
 .nav-map-icon {
   /* Use font-size so child SVGs sized 1em follow this */
-  font-size: 20px;
+  font-size: 24px;
   line-height: 1;
   display: inline-block;
   width: 1em;
   height: 1em;
-}
-
-#map-container .nav-map-header .q-item__section--avatar {
-  min-width: 32px; /* closer to QIcon spacing; adjust if needed */
 }
 
 /* Utility components */


### PR DESCRIPTION
## Summary
- remove custom header wrapper so expansion items use default avatar/side spacing
- standardize map icons to 24px box with thicker strokes
- strengthen tab indicator for better visibility

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a991fbf6e88330a7366b569c85b49d