### PR TITLE
fix: unify theme tokens and header toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,23 @@ Fundstr — Quasar/Vite SPA (pnpm). Staging auto-deploys on every push to `devel
 - Local build passes.
 - `pnpm test` (if tests exist) passes.
 - After push to `develop`, staging loads without console errors; `deploy.txt` updated.
+
+## Theme Tokens
+| Token | Purpose |
+|-------|---------|
+| `--text-1` | Primary text color |
+| `--text-2` | Muted/secondary text color |
+| `--text-inverse` | Text on inverted surfaces |
+| `--surface-1` | Page background |
+| `--surface-2` | Card/panel background |
+| `--surface-contrast-border` | Subtle surface border |
+| `--accent-500` | Brand accent base |
+| `--accent-600` | Active/pressed accent |
+| `--accent-200` | Accent outline/hover |
+| `--chip-bg` | Chip background |
+| `--chip-text` | Chip text color |
+| `--tab-active` | Active tab text/indicator |
+| `--tab-inactive` | Inactive tab text |
+| `--disabled-text` | Disabled text color |
+
+Utility classes: `.text-1`, `.text-2`, `.text-inverse`, `.bg-surface-1`, `.bg-surface-2`.

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -2,16 +2,16 @@
   <q-header class="bg-transparent">
     <q-toolbar class="app-toolbar" dense>
       <div class="left-controls row items-center no-wrap" v-if="!isWelcomePage">
-        <q-btn
-          v-if="isMessengerPage"
-          flat
-          dense
-          round
-          icon="menu"
-          :color="chatButtonColor"
-          aria-label="Toggle Chats"
-          @click.stop="toggleMessengerDrawer"
-        >
+          <q-btn
+            v-if="isMessengerPage"
+            flat
+            dense
+            round
+            icon="chat"
+            :color="chatButtonColor"
+            aria-label="Toggle Chats"
+            @click.stop="toggleMessengerDrawer"
+          >
           <q-tooltip>Chats</q-tooltip>
         </q-btn>
         <q-btn
@@ -114,20 +114,6 @@
       </div>
     </q-toolbar>
   </q-header>
-  <div v-if="$q.screen.lt.md" class="mobile-nav-toggle">
-    <q-btn
-      ref="mobileNavBtn"
-      round
-      flat
-      :icon="ui.mainNavOpen ? 'close' : 'menu'"
-      color="primary"
-      class="mobile-nav-btn"
-      aria-label="Toggle main menu"
-      aria-controls="app-nav"
-      :aria-expanded="String(ui.mainNavOpen)"
-      @click="ui.toggleMainNav"
-    />
-  </div>
 </template>
 
 <script>import windowMixin from 'src/mixins/windowMixin'
@@ -156,10 +142,9 @@ export default defineComponent({
     const messenger = useMessengerStore();
     const $q = useQuasar();
     const mainNavBtn = ref(null);
-    const mobileNavBtn = ref(null);
 
     const focusNavBtn = () => {
-      (mobileNavBtn.value || mainNavBtn.value)?.focus();
+      mainNavBtn.value?.focus();
     };
     const onKeydown = (e) => {
       if (e.key === "Escape" && ui.mainNavOpen) {
@@ -265,10 +250,9 @@ export default defineComponent({
       toggleMessengerDrawer,
       toggleDarkMode,
       darkIcon,
-      chatButtonColor,
-      mainNavBtn,
-      mobileNavBtn,
-    };
+        chatButtonColor,
+        mainNavBtn,
+      };
   },
 });
 </script>
@@ -308,15 +292,4 @@ export default defineComponent({
   transform: translateX(var(--nav-offset-x, 0));
 }
 
-.mobile-nav-toggle {
-  position: fixed;
-  top: calc(env(safe-area-inset-top) + 8px);
-  left: calc(env(safe-area-inset-left) + 8px);
-  z-index: 12000;
-}
-
-.mobile-nav-btn {
-  width: 44px;
-  height: 44px;
-}
 </style>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -118,6 +118,19 @@ body,
   --due-soon-bg-dark: color-mix(in srgb, var(--q-warning) 30%, transparent);
   --due-soon-bg-light: color-mix(in srgb, var(--q-warning) 15%, transparent);
   --border-subtle: 1px solid var(--border-subtle-light);
+  /* theme token defaults */
+  --text-1: #111827;
+  --text-2: #6b7280;
+  --text-inverse: #ffffff;
+  --surface-1: #f9fafb;
+  --surface-2: #ffffff;
+  --surface-contrast-border: var(--border-subtle-light);
+  --accent-500: var(--q-primary);
+  --accent-600: color-mix(in srgb, var(--q-primary) 85%, black);
+  --accent-200: color-mix(in srgb, var(--q-primary) 25%, white);
+  --tab-active: var(--q-primary);
+  --tab-inactive: #6b7280;
+  --disabled-text: #9ca3af;
 }
 
 body.body--dark {
@@ -137,6 +150,18 @@ body.body--dark {
   --progress-ring-fill: var(--progress-ring-fill-dark);
   --progress-ring-track: var(--progress-ring-track-dark);
   --due-soon-bg: var(--due-soon-bg-dark);
+  --text-1: #f9fafb;
+  --text-2: #9ca3af;
+  --text-inverse: #000000;
+  --surface-1: #0e141b;
+  --surface-2: var(--panel-dark);
+  --surface-contrast-border: var(--border-subtle-dark);
+  --accent-500: var(--q-primary);
+  --accent-600: color-mix(in srgb, var(--q-primary) 80%, white);
+  --accent-200: color-mix(in srgb, var(--q-primary) 25%, black);
+  --tab-active: var(--q-primary);
+  --tab-inactive: var(--muted-dark);
+  --disabled-text: var(--q-color-grey-6);
 }
 
 body.body--light {
@@ -156,6 +181,18 @@ body.body--light {
   --progress-ring-fill: var(--progress-ring-fill-light);
   --progress-ring-track: var(--progress-ring-track-light);
   --due-soon-bg: var(--due-soon-bg-light);
+  --text-1: #111827;
+  --text-2: #6b7280;
+  --text-inverse: #ffffff;
+  --surface-1: #f9fafb;
+  --surface-2: var(--panel-light);
+  --surface-contrast-border: var(--border-subtle-light);
+  --accent-500: var(--q-primary);
+  --accent-600: color-mix(in srgb, var(--q-primary) 85%, black);
+  --accent-200: color-mix(in srgb, var(--q-primary) 25%, white);
+  --tab-active: var(--q-primary);
+  --tab-inactive: var(--muted-light);
+  --disabled-text: var(--q-color-grey-5);
 }
 
 .themed-icon {
@@ -289,6 +326,45 @@ body.body--dark .received {
   border-radius: 4px;
   padding: 4px 12px;
   font-weight: 500;
+}
+
+/* utility classes for theme tokens */
+.text-1 {
+  color: var(--text-1) !important;
+}
+
+.text-2 {
+  color: var(--text-2) !important;
+}
+
+.text-inverse {
+  color: var(--text-inverse) !important;
+}
+
+.bg-surface-1 {
+  background-color: var(--surface-1) !important;
+}
+
+.bg-surface-2 {
+  background-color: var(--surface-2) !important;
+  border: 1px solid var(--surface-contrast-border);
+}
+
+.q-chip {
+  background-color: var(--chip-bg) !important;
+  color: var(--chip-text) !important;
+}
+
+.q-tab {
+  color: var(--tab-inactive);
+}
+
+.q-tab.q-tab--active {
+  color: var(--tab-active);
+}
+
+.q-tab__indicator {
+  background: var(--tab-active);
 }
 
 .bucket-card,

--- a/src/layouts/BlankLayout.vue
+++ b/src/layouts/BlankLayout.vue
@@ -1,9 +1,9 @@
 <template>
-  <q-layout
-    view="lHh Lpr lFf"
-    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
-    :style="navStyleVars"
-  >
+    <q-layout
+      view="lHh Lpr lFf"
+      class="bg-surface-1 text-1"
+      :style="navStyleVars"
+    >
     <MainHeader />
     <AppNavDrawer />
     <q-page-container class="text-body1">

--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -1,9 +1,9 @@
 <template>
-  <q-layout
-    view="lHh Lpr lFf"
-    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
-    :style="navStyleVars"
-  >
+    <q-layout
+      view="lHh Lpr lFf"
+      class="bg-surface-1 text-1"
+      :style="navStyleVars"
+    >
     <MainHeader />
     <AppNavDrawer />
     <q-page-container class="text-body1">

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <q-layout
     view="lHh Lpr lFf"
-    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
+    class="bg-surface-1 text-1"
     :style="navStyleVars"
   >
     <MainHeader />

--- a/src/pages/BucketsPage.vue
+++ b/src/pages/BucketsPage.vue
@@ -1,30 +1,15 @@
 <template>
-  <q-page
-    :class="[
-      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
-      'q-pa-md',
-    ]"
-  >
+  <q-page class="q-pa-md bg-surface-1 text-1">
     <div class="q-gutter-md">
-      <q-card
-        :class="
-          $q.dark.isActive ? 'bg-grey-9 text-white' : 'bg-white text-dark'
-        "
-        class="q-pa-md"
-      >
+    <q-card class="q-pa-md bg-surface-2 text-1">
         <div class="text-h5">Buckets</div>
-        <div class="text-subtitle2 text-grey-6 q-mb-md">
+        <div class="text-subtitle2 text-2 q-mb-md">
           Organize your tokens
         </div>
         <SummaryStats :total="totalActiveBalance" :active-count="activeCount" />
       </q-card>
 
-      <q-card
-        :class="
-          $q.dark.isActive ? 'bg-grey-9 text-white' : 'bg-white text-dark'
-        "
-        class="q-pa-md"
-      >
+    <q-card class="q-pa-md bg-surface-2 text-1">
         <BucketManager />
       </q-card>
     </div>

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -62,51 +62,39 @@
           <!-- ///////////////////////////////////////////
       ////////////////// TABLES /////////////////
       /////////////////////////////////////////// -->
-          <q-expansion-item expand-icon-class="hidden" v-model="expandHistory">
-            <template v-slot:header="{ expanded }">
-              <q-item-section class="item-center text-center">
-                <span
-                  ><q-icon
-                    color="primary"
-                    :name="
-                      expanded ? 'keyboard_arrow_up' : 'keyboard_arrow_down'
-                    "
-                /></span>
-              </q-item-section>
-            </template>
-            <q-tabs
-              v-model="tab"
-              no-caps
-              :class="$q.dark.isActive ? 'bg-dark' : 'bg-white'"
-            >
-              <q-tab
-                name="history"
-                class="text-secondary"
-                :label="$t('WalletPage.tabs.history.label')"
-              ></q-tab>
-              <q-tab
-                name="invoices"
-                class="text-secondary"
-                :label="$t('WalletPage.tabs.invoices.label')"
-              ></q-tab>
-              <!-- <q-tab name="tokens" label="Tokens"></q-tab> -->
-              <q-tab
-                name="mints"
-                class="text-secondary"
-                :label="$t('WalletPage.tabs.mints.label')"
-              ></q-tab>
-              <q-tab
-                name="buckets"
-                class="text-secondary"
-                :label="$t('WalletPage.tabs.buckets.label')"
-              ></q-tab>
-            </q-tabs>
+            <q-expansion-item expand-icon-class="hidden" v-model="expandHistory">
+              <template v-slot:header="{ expanded }">
+                <q-item-section class="item-center text-center">
+                  <span
+                    ><q-icon
+                      color="primary"
+                      :name="
+                        expanded ? 'keyboard_arrow_up' : 'keyboard_arrow_down'
+                      "
+                  /></span>
+                </q-item-section>
+              </template>
+              <q-tabs v-model="tab" no-caps class="bg-surface-2">
+                <q-tab
+                  name="history"
+                  :label="$t('WalletPage.tabs.history.label')"
+                ></q-tab>
+                <q-tab
+                  name="invoices"
+                  :label="$t('WalletPage.tabs.invoices.label')"
+                ></q-tab>
+                <!-- <q-tab name="tokens" label="Tokens"></q-tab> -->
+                <q-tab
+                  name="mints"
+                  :label="$t('WalletPage.tabs.mints.label')"
+                ></q-tab>
+                <q-tab
+                  name="buckets"
+                  :label="$t('WalletPage.tabs.buckets.label')"
+                ></q-tab>
+              </q-tabs>
 
-            <q-tab-panels
-              :class="$q.dark.isActive ? 'bg-dark' : 'bg-white'"
-              v-model="tab"
-              animated
-            >
+              <q-tab-panels class="bg-surface-2" v-model="tab" animated>
               <!-- ////////////////// HISTORY LIST ///////////////// -->
 
               <q-tab-panel name="history">


### PR DESCRIPTION
## Summary
- remove duplicate mobile menu toggle and swap messenger toggle icon
- add WCAG-compliant theme tokens and utility classes
- apply token-based styling to layouts, tabs and bucket pages

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a9989d0e8c8330ba686835b6dad1bb