### PR TITLE
feat: gate welcome flow per device

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,7 @@ Fundstr — Quasar/Vite SPA (pnpm). Staging auto-deploys on every push to `devel
 | `--disabled-text` | Disabled text color |
 
 Utility classes: `.text-1`, `.text-2`, `.text-inverse`, `.bg-surface-1`, `.bg-surface-2`.
+
+## Welcome Gate
+- Local storage key `welcome.seen:v1` tracks if the onboarding was shown on a device.
+- Bump to `welcome.seen:v2` when revising the flow to force users through the new onboarding.

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export default configure(() => ({
-  boot: ['cashu', 'i18n', 'node-globals'],
+  boot: ['welcomeGate', 'cashu', 'i18n', 'node-globals'],
   css: ['app.scss', 'base.scss', 'buckets.scss'],
   extras: ['roboto-font', 'material-icons'],
   build: {

--- a/src/boot/welcomeGate.ts
+++ b/src/boot/welcomeGate.ts
@@ -1,0 +1,22 @@
+import { boot } from 'quasar/wrappers'
+import { hasSeenWelcome } from 'src/composables/useWelcomeGate'
+
+// router guard to ensure the welcome flow is shown only once per device
+export default boot(({ router }) => {
+  router.beforeEach((to, _from, next) => {
+    const seen = hasSeenWelcome()
+    const isWelcome = to.path.startsWith('/welcome')
+
+    if (!seen && !isWelcome) {
+      next({ path: '/welcome', query: { first: '1' } })
+      return
+    }
+
+    if (seen && isWelcome && to.query.allow !== '1') {
+      next('/wallet')
+      return
+    }
+
+    next()
+  })
+})

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1808,6 +1808,7 @@ import { useDexieStore } from "../stores/dexie";
 import { useReceiveTokensStore } from "../stores/receiveTokensStore";
 import { useWelcomeStore } from "src/stores/welcome";
 import { useStorageStore } from "src/stores/storage";
+import { resetWelcome } from 'src/composables/useWelcomeGate'
 import { useI18n } from "vue-i18n";
 
 export default defineComponent({
@@ -2116,6 +2117,7 @@ export default defineComponent({
       await this.generateNPCConnection();
     },
     showOnboarding: function () {
+      resetWelcome();
       const store = useWelcomeStore();
       store.welcomeCompleted = false;
       this.$router.push("/welcome?first=1");

--- a/src/composables/useWelcomeGate.ts
+++ b/src/composables/useWelcomeGate.ts
@@ -1,0 +1,33 @@
+import { LocalStorage } from 'quasar'
+
+// storage key for tracking if the welcome flow has been seen on this device
+const KEY = 'welcome.seen:v1'
+
+function getStorage() {
+  // use Quasar LocalStorage if available, otherwise fall back to the native API
+  try {
+    // accessing LocalStorage may throw if plugin not available
+    LocalStorage.getItem(KEY)
+    return LocalStorage
+  } catch {
+    return window.localStorage
+  }
+}
+
+export function hasSeenWelcome(): boolean {
+  const storage: any = getStorage()
+  const val = storage.getItem(KEY)
+  return val === '1' || val === true
+}
+
+export function markWelcomeSeen(): void {
+  const storage: any = getStorage()
+  if (storage.set) storage.set(KEY, '1')
+  else storage.setItem(KEY, '1')
+}
+
+export function resetWelcome(): void {
+  const storage: any = getStorage()
+  if (storage.remove) storage.remove(KEY)
+  else storage.removeItem(KEY)
+}

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -502,8 +502,8 @@ export const messages = {
             'This wallet marks pending outgoing ecash as reserved (and subtracts it from your balance) to prevent double-spend attempts. This button will unset all reserved tokens so they can be used again. If you do this, your wallet might include spent proofs. Press the "Remove spent proofs" button to get rid of them.',
         },
         show_onboarding: {
-          button: "Show onboarding",
-          description: "Show the onboarding screen again.",
+          button: "Show Welcome again (this device)",
+          description: "Reset the Welcome flag on this device and show the onboarding screen again.",
         },
         reset_wallet: {
           button: "Reset wallet data",

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -67,6 +67,7 @@ import TaskChecklist from 'src/components/welcome/TaskChecklist.vue'
 import RevealSeedDialog from 'src/components/welcome/RevealSeedDialog.vue'
 import type { WelcomeTask } from 'src/types/welcome'
 import { useWelcomeStore, LAST_WELCOME_SLIDE } from 'src/stores/welcome'
+import { markWelcomeSeen } from 'src/composables/useWelcomeGate'
 import { useMnemonicStore } from 'src/stores/mnemonic'
 import { useStorageStore } from 'src/stores/storage'
 import { useNostrStore } from 'src/stores/nostr'
@@ -93,6 +94,8 @@ function downloadBackup() {
 function finishOnboarding() {
   showChecklist.value = false
   welcome.closeWelcome()
+  // remember that the welcome flow has been completed on this device
+  markWelcomeSeen()
   router.push('/')
 }
 


### PR DESCRIPTION
## Summary
- gate routes through a new welcome flow guard that only shows onboarding once per device
- persist completion in `welcome.seen:v1` and expose reset control in Settings
- ensure finishing onboarding marks it seen and quasar boot loads the guard

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a99c633810833091ae8d19f4d45504