### PR TITLE
Harden welcome gate and add tour route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,5 +50,5 @@ Fundstr — Quasar/Vite SPA (pnpm). Staging auto-deploys on every push to `devel
 Utility classes: `.text-1`, `.text-2`, `.text-inverse`, `.bg-surface-1`, `.bg-surface-2`.
 
 ## Welcome Gate
-- Local storage key `welcome.seen:v1` tracks if the onboarding was shown on a device.
-- Bump to `welcome.seen:v2` when revising the flow to force users through the new onboarding.
+- Local storage key `welcome.seen:v1` and cookie `welcome_seen_v1` track if the onboarding was shown on a device.
+- Bump to `welcome.seen:v2`/`welcome_seen_v2` when revising the flow to force users through the new onboarding.

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,6 +1,9 @@
 <IfModule mod_rewrite.c>
   Options -MultiViews
   RewriteEngine On
+  # when welcome cookie present, block access to /welcome and send to /wallet
+  RewriteCond %{HTTP_COOKIE} welcome_seen_v1=1 [NC]
+  RewriteRule ^welcome/?$ /wallet [R=302,L]
   RewriteCond %{REQUEST_FILENAME} !-f
   RewriteRule ^ index.html [QSA,L]
 </IfModule>

--- a/src/boot/welcomeGate.ts
+++ b/src/boot/welcomeGate.ts
@@ -7,12 +7,16 @@ export default boot(({ router }) => {
     const seen = hasSeenWelcome()
     const isWelcome = to.path.startsWith('/welcome')
 
+    const env = import.meta.env.VITE_APP_ENV
+    const allow =
+      to.query.allow === '1' && (env === 'development' || env === 'staging')
+
     if (!seen && !isWelcome) {
       next({ path: '/welcome', query: { first: '1' } })
       return
     }
 
-    if (seen && isWelcome && to.query.allow !== '1') {
+    if (seen && isWelcome && !allow) {
       next('/wallet')
       return
     }

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1672,7 +1672,7 @@
               <q-item>
                 <q-item-section>
                   <div class="row">
-                    <q-btn dense flat outline click @click="showOnboarding">
+                    <q-btn dense flat outline click @click="showTour">
                       {{
                         $t("Settings.advanced.developer.show_onboarding.button")
                       }}
@@ -1806,9 +1806,7 @@ import { usePRStore } from "../stores/payment-request";
 import { useRestoreStore } from "src/stores/restore";
 import { useDexieStore } from "../stores/dexie";
 import { useReceiveTokensStore } from "../stores/receiveTokensStore";
-import { useWelcomeStore } from "src/stores/welcome";
 import { useStorageStore } from "src/stores/storage";
-import { resetWelcome } from 'src/composables/useWelcomeGate'
 import { useI18n } from "vue-i18n";
 
 export default defineComponent({
@@ -2116,11 +2114,8 @@ export default defineComponent({
       await this.resetNip46Signer();
       await this.generateNPCConnection();
     },
-    showOnboarding: function () {
-      resetWelcome();
-      const store = useWelcomeStore();
-      store.welcomeCompleted = false;
-      this.$router.push("/welcome?first=1");
+    showTour: function () {
+      this.$router.push('/tour');
     },
     nukeWallet: async function () {
       // create a backup just in case

--- a/src/composables/useWelcomeGate.ts
+++ b/src/composables/useWelcomeGate.ts
@@ -1,7 +1,8 @@
-import { LocalStorage } from 'quasar'
+import { LocalStorage, Cookies } from 'quasar'
 
-// storage key for tracking if the welcome flow has been seen on this device
+// storage keys for tracking if the welcome flow has been seen on this device
 const KEY = 'welcome.seen:v1'
+const COOKIE_KEY = 'welcome_seen_v1'
 
 function getStorage() {
   // use Quasar LocalStorage if available, otherwise fall back to the native API
@@ -17,17 +18,33 @@ function getStorage() {
 export function hasSeenWelcome(): boolean {
   const storage: any = getStorage()
   const val = storage.getItem(KEY)
-  return val === '1' || val === true
+  if (val === '1' || val === true) return true
+
+  // check for persisted cookie or legacy flags and migrate
+  if (Cookies.get(COOKIE_KEY) === '1') {
+    markWelcomeSeen()
+    return true
+  }
+
+  const legacy = storage.getItem('cashu.welcome.completed')
+  if (legacy === '1' || legacy === true) {
+    markWelcomeSeen()
+    return true
+  }
+
+  return false
 }
 
 export function markWelcomeSeen(): void {
   const storage: any = getStorage()
   if (storage.set) storage.set(KEY, '1')
   else storage.setItem(KEY, '1')
+  Cookies.set(COOKIE_KEY, '1', { maxAge: 31536000, path: '/' })
 }
 
 export function resetWelcome(): void {
   const storage: any = getStorage()
   if (storage.remove) storage.remove(KEY)
   else storage.removeItem(KEY)
+  Cookies.remove(COOKIE_KEY, { path: '/' })
 }

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -502,8 +502,8 @@ export const messages = {
             'This wallet marks pending outgoing ecash as reserved (and subtracts it from your balance) to prevent double-spend attempts. This button will unset all reserved tokens so they can be used again. If you do this, your wallet might include spent proofs. Press the "Remove spent proofs" button to get rid of them.',
         },
         show_onboarding: {
-          button: "Show Welcome again (this device)",
-          description: "Reset the Welcome flag on this device and show the onboarding screen again.",
+          button: "Show the tour again",
+          description: "Open the onboarding tour again without resetting the Welcome flag.",
         },
         reset_wallet: {
           button: "Reset wallet data",

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -54,7 +54,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { useQuasar } from 'quasar'
 import WelcomeSlideFeatures from './welcome/WelcomeSlideFeatures.vue'
 import WelcomeSlideNostr from './welcome/WelcomeSlideNostr.vue'
@@ -67,7 +67,7 @@ import TaskChecklist from 'src/components/welcome/TaskChecklist.vue'
 import RevealSeedDialog from 'src/components/welcome/RevealSeedDialog.vue'
 import type { WelcomeTask } from 'src/types/welcome'
 import { useWelcomeStore, LAST_WELCOME_SLIDE } from 'src/stores/welcome'
-import { markWelcomeSeen } from 'src/composables/useWelcomeGate'
+import { markWelcomeSeen, hasSeenWelcome } from 'src/composables/useWelcomeGate'
 import { useMnemonicStore } from 'src/stores/mnemonic'
 import { useStorageStore } from 'src/stores/storage'
 import { useNostrStore } from 'src/stores/nostr'
@@ -76,12 +76,22 @@ import { useNdk } from 'src/composables/useNdk'
 const { t } = useI18n()
 const welcome = useWelcomeStore()
 const router = useRouter()
+const route = useRoute()
 const $q = useQuasar()
 const mnemonicStore = useMnemonicStore()
 const storageStore = useStorageStore()
 const nostr = useNostrStore()
 const showSeedDialog = ref(false)
 const showChecklist = ref(false)
+
+onMounted(() => {
+  const env = import.meta.env.VITE_APP_ENV
+  const allow =
+    route.query.allow === '1' && (env === 'development' || env === 'staging')
+  if (route.path.startsWith('/welcome') && hasSeenWelcome() && !allow) {
+    router.replace('/wallet')
+  }
+})
 
 function revealSeed() {
   showSeedDialog.value = true

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -111,6 +111,13 @@ const routes = [
     ],
   },
   {
+    path: "/tour",
+    component: () => import("layouts/BlankLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/WelcomePage.vue") },
+    ],
+  },
+  {
     path: "/onboarding",
     redirect: "/welcome?first=1",
   },


### PR DESCRIPTION
## Summary
- store welcome gate state in localStorage and cookie
- redirect visitors with existing flag away from /welcome both client and server side
- expose /tour to replay the onboarding from settings

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a99fb044e083308f96b5f8bc4e9e5b