### PR TITLE
fix: drawer toggle layering and icon theming

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -17,6 +17,20 @@
     @hide="ui.closeMainNav()"
     @keyup.esc="ui.closeMainNav()"
   >
+    <div>
+      <q-btn
+        flat
+        dense
+        round
+        icon="close"
+        color="primary"
+        aria-label="Close navigation"
+        @click="ui.closeMainNav()"
+        class="q-mb-sm"
+      >
+        <q-tooltip>Close</q-tooltip>
+      </q-btn>
+    </div>
     <q-list>
       <q-item-label header>{{
         $t("MainHeader.menu.settings.title")
@@ -46,7 +60,7 @@
       </q-item>
       <q-item clickable @click="gotoFindCreators">
         <q-item-section avatar>
-          <q-icon name="img:icons/find-creators.svg" color="white" />
+          <FindCreatorsIcon class="themed-icon q-icon" />
         </q-item-section>
         <q-item-section>
           <q-item-label>{{
@@ -59,7 +73,7 @@
       </q-item>
       <q-item clickable @click="gotoCreatorHub">
         <q-item-section avatar>
-          <q-icon name="img:icons/creator-hub.svg" color="white" />
+          <CreatorHubIcon class="themed-icon q-icon" />
         </q-item-section>
         <q-item-section>
           <q-item-label>{{
@@ -179,6 +193,8 @@ import { useI18n } from "vue-i18n";
 import { useQuasar } from "quasar";
 import EssentialLink from "components/EssentialLink.vue";
 import { NAV_DRAWER_WIDTH } from "src/constants/layout";
+import FindCreatorsIcon from "src/components/icons/FindCreatorsIcon.vue";
+import CreatorHubIcon from "src/components/icons/CreatorHubIcon.vue";
 
 const ui = useUiStore();
 const router = useRouter();
@@ -262,7 +278,7 @@ const essentialLinks = [
 }
 
 .main-nav-safe {
-  padding-left: calc(env(safe-area-inset-left) + 60px);
+  padding-left: calc(env(safe-area-inset-left) + 8px);
   padding-top: calc(env(safe-area-inset-top) + 8px);
 }
 </style>

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -15,12 +15,13 @@
           <q-tooltip>Chats</q-tooltip>
         </q-btn>
         <q-btn
+          v-if="!ui.mainNavOpen"
           flat
           dense
           round
           icon="menu"
           color="primary"
-          aria-label="Toggle main menu"
+          aria-label="Open navigation"
           :aria-expanded="String(ui.mainNavOpen)"
           aria-controls="app-nav"
           @click="ui.toggleMainNav"
@@ -126,6 +127,7 @@ import {
   onMounted,
   onBeforeUnmount,
   nextTick,
+  watch,
 } from "vue";
 import { useRoute } from "vue-router";
 import { useUiStore } from "src/stores/ui";
@@ -155,6 +157,13 @@ export default defineComponent({
 
     onMounted(() => window.addEventListener("keydown", onKeydown));
     onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
+
+    watch(
+      () => ui.mainNavOpen,
+      (open) => {
+        if (!open) nextTick(focusNavBtn);
+      },
+    );
 
     const toggleDarkMode = () => {
       console.log("toggleDarkMode", $q.dark.isActive);
@@ -260,8 +269,8 @@ export default defineComponent({
 .q-header {
   position: sticky;
   top: 0;
-  /* Keep header above Quasar drawer/scrim layers on mobile overlays */
-  z-index: 11000;
+  /* Allow navigation drawer overlay to sit above the header */
+  z-index: 950;
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
## Summary
- ensure navigation drawer overlays header and hide menu button while open
- add accessible close control inside drawer
- theme Find Creators and Creator Hub icons to follow light/dark modes

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`
- `pnpm exec quasar build -m spa`


------
https://chatgpt.com/codex/tasks/task_e_68a9aa1e1ae8833089b6fc35a9487580