### PR TITLE
feat: add first-time navigation tour

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export default configure(() => ({
-  boot: ['welcomeGate', 'cashu', 'i18n', 'node-globals'],
+  boot: ['welcomeGate', 'cashu', 'i18n', 'node-globals', 'onboardingTour'],
   css: ['app.scss', 'base.scss', 'buckets.scss'],
   extras: ['roboto-font', 'material-icons'],
   build: {

--- a/src/boot/onboardingTour.ts
+++ b/src/boot/onboardingTour.ts
@@ -1,0 +1,26 @@
+import { boot } from 'quasar/wrappers'
+import { watch, nextTick } from 'vue'
+import { useNostrStore } from 'src/stores/nostr'
+import { hasCompletedOnboarding, startOnboardingTour } from 'src/composables/useOnboardingTour'
+
+export default boot(async ({ router }) => {
+  router.isReady().then(() => {
+    const nostr = useNostrStore()
+    const run = async () => {
+      const prefix = (nostr.pubkey || 'anon').slice(0, 8)
+      if (hasCompletedOnboarding(prefix)) return
+      await nextTick()
+      startOnboardingTour(prefix)
+    }
+    if (nostr.pubkey) {
+      run()
+    } else {
+      const stop = watch(() => nostr.pubkey, (val) => {
+        if (val) {
+          stop()
+          run()
+        }
+      })
+    }
+  })
+})

--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -35,7 +35,7 @@
       <q-item-label header>{{
         $t("MainHeader.menu.settings.title")
       }}</q-item-label>
-      <q-item clickable @click="gotoWallet">
+      <q-item clickable @click="gotoWallet" data-tour="nav-wallet">
         <q-item-section avatar>
           <q-icon name="account_balance_wallet" />
         </q-item-section>
@@ -45,7 +45,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable @click="gotoSettings">
+      <q-item clickable @click="gotoSettings" data-tour="nav-settings">
         <q-item-section avatar>
           <q-icon name="settings" />
         </q-item-section>
@@ -58,7 +58,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable @click="gotoFindCreators">
+      <q-item clickable @click="gotoFindCreators" data-tour="nav-find-creators">
         <q-item-section avatar>
           <FindCreatorsIcon class="themed-icon q-icon" />
         </q-item-section>
@@ -110,7 +110,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable @click="gotoSubscriptions">
+      <q-item clickable @click="gotoSubscriptions" data-tour="nav-subscriptions">
         <q-item-section avatar>
           <q-icon name="auto_awesome_motion" />
         </q-item-section>

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -14,20 +14,21 @@
           >
           <q-tooltip>Chats</q-tooltip>
         </q-btn>
-        <q-btn
-          v-if="!ui.mainNavOpen"
-          flat
-          dense
-          round
-          icon="menu"
-          color="primary"
-          aria-label="Open navigation"
-          :aria-expanded="String(ui.mainNavOpen)"
-          aria-controls="app-nav"
-          @click="ui.toggleMainNav"
-          ref="mainNavBtn"
-          :disable="ui.globalMutexLock"
-        >
+          <q-btn
+            v-if="!ui.mainNavOpen"
+            flat
+            dense
+            round
+            icon="menu"
+            color="primary"
+            aria-label="Open navigation"
+            :aria-expanded="String(ui.mainNavOpen)"
+            aria-controls="app-nav"
+            @click="ui.toggleMainNav"
+            ref="mainNavBtn"
+            :disable="ui.globalMutexLock"
+            data-tour="nav-toggle"
+          >
           <q-tooltip>Menu</q-tooltip>
         </q-btn>
       </div>

--- a/src/components/OnboardingTour.vue
+++ b/src/components/OnboardingTour.vue
@@ -1,0 +1,128 @@
+<template>
+  <q-tooltip
+    v-if="current"
+    v-model="show"
+    :target="current.el"
+    :anchor="current.anchor"
+    :self="current.self"
+    class="onboarding-tooltip"
+    no-parent-event
+    persistent
+    transition-show="fade"
+    transition-hide="fade"
+  >
+    <div class="onboarding-body">
+      <div class="q-mb-sm">{{ current.text }}</div>
+      <div class="row justify-end q-gutter-sm">
+        <q-btn flat dense class="skip-btn" @click="skip">Skip tour</q-btn>
+        <q-btn flat dense color="primary" @click="next">{{ isLast ? 'Got it' : 'Next' }}</q-btn>
+      </div>
+    </div>
+  </q-tooltip>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, nextTick, onMounted } from 'vue'
+import { LocalStorage } from 'quasar'
+import { useUiStore } from 'src/stores/ui'
+
+const props = defineProps<{ pubkeyPrefix: string; onFinish: () => void }>()
+
+const ui = useUiStore()
+
+const steps = [
+  {
+    target: '[data-tour="nav-toggle"]',
+    text: 'Open the sidebar to jump between pages. You can revisit this tour anytime from Settings.',
+    anchor: 'bottom middle',
+    self: 'top middle',
+    onNext: () => ui.openMainNav(),
+  },
+  {
+    target: '[data-tour="nav-wallet"]',
+    text: 'Deposit or withdraw funds and review your transactions here.',
+    anchor: 'right middle',
+    self: 'left middle',
+  },
+  {
+    target: '[data-tour="nav-find-creators"]',
+    text: 'Discover creators and start supporting them with a few taps.',
+    anchor: 'right middle',
+    self: 'left middle',
+  },
+  {
+    target: '[data-tour="nav-subscriptions"]',
+    text: 'Manage who you support and adjust contribution levels anytime.',
+    anchor: 'right middle',
+    self: 'left middle',
+  },
+  {
+    target: '[data-tour="nav-settings"]',
+    text: 'Update account preferences, notifications, and security. You can replay the tutorial here.',
+    anchor: 'right middle',
+    self: 'left middle',
+  },
+]
+
+const index = ref(0)
+const current = ref<any>(null)
+const show = ref(false)
+
+const storageKey = `fundstr:onboarding:v1:${props.pubkeyPrefix}:done`
+
+function markDone() {
+  LocalStorage.set(storageKey, '1')
+}
+
+function finish() {
+  markDone()
+  props.onFinish()
+}
+
+const isLast = computed(() => index.value === steps.length - 1)
+
+async function showStep() {
+  const step = steps[index.value]
+  if (!step) {
+    finish()
+    return
+  }
+  await nextTick()
+  const el = document.querySelector(step.target) as HTMLElement | null
+  if (!el) {
+    index.value++
+    showStep()
+    return
+  }
+  current.value = { ...step, el }
+  show.value = true
+}
+
+function next() {
+  show.value = false
+  current.value?.onNext?.()
+  index.value++
+  setTimeout(showStep, 200)
+}
+
+function skip() {
+  finish()
+}
+
+onMounted(showStep)
+</script>
+
+<style scoped>
+.onboarding-tooltip {
+  max-width: 260px;
+  padding: 8px 12px;
+  background: var(--surface-2);
+  color: var(--text-1);
+  border: 1px solid var(--surface-contrast-border);
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+.onboarding-tooltip .skip-btn {
+  color: var(--text-1);
+}
+</style>

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1806,6 +1806,7 @@ import { usePRStore } from "../stores/payment-request";
 import { useRestoreStore } from "src/stores/restore";
 import { useDexieStore } from "../stores/dexie";
 import { useReceiveTokensStore } from "../stores/receiveTokensStore";
+import { resetOnboarding, startOnboardingTour } from "src/composables/useOnboardingTour";
 import { useStorageStore } from "src/stores/storage";
 import { useI18n } from "vue-i18n";
 
@@ -2114,8 +2115,12 @@ export default defineComponent({
       await this.resetNip46Signer();
       await this.generateNPCConnection();
     },
-    showTour: function () {
-      this.$router.push('/tour');
+    showTour: async function () {
+      const prefix = (useNostrStore().pubkey || 'anon').slice(0, 8)
+      resetOnboarding(prefix)
+      this.$router.push('/wallet').then(() => {
+        setTimeout(() => startOnboardingTour(prefix), 300)
+      })
     },
     nukeWallet: async function () {
       // create a backup just in case

--- a/src/composables/useOnboardingTour.ts
+++ b/src/composables/useOnboardingTour.ts
@@ -1,0 +1,30 @@
+import { LocalStorage } from 'quasar'
+import { createApp } from 'vue'
+import OnboardingTour from 'src/components/OnboardingTour.vue'
+
+const KEY_PREFIX = 'fundstr:onboarding:v1:'
+
+function key(prefix: string) {
+  return `${KEY_PREFIX}${prefix}:done`
+}
+
+export function hasCompletedOnboarding(prefix: string): boolean {
+  return LocalStorage.getItem(key(prefix)) === '1'
+}
+
+export function resetOnboarding(prefix: string): void {
+  LocalStorage.remove(key(prefix))
+}
+
+export function startOnboardingTour(prefix: string): void {
+  const el = document.createElement('div')
+  document.body.appendChild(el)
+  const app = createApp(OnboardingTour, {
+    pubkeyPrefix: prefix,
+    onFinish: () => {
+      app.unmount()
+      el.remove()
+    }
+  })
+  app.mount(el)
+}

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -502,8 +502,8 @@ export const messages = {
             'This wallet marks pending outgoing ecash as reserved (and subtracts it from your balance) to prevent double-spend attempts. This button will unset all reserved tokens so they can be used again. If you do this, your wallet might include spent proofs. Press the "Remove spent proofs" button to get rid of them.',
         },
         show_onboarding: {
-          button: "Show the tour again",
-          description: "Open the onboarding tour again without resetting the Welcome flag.",
+          button: "Replay tutorial",
+          description: "Restart the onboarding tour from the beginning.",
         },
         reset_wallet: {
           button: "Reset wallet data",


### PR DESCRIPTION
## Summary
- add onboarding tour boot hook and reusable tour component
- persist completion per-account and allow replay from settings
- wire navigation buttons with tour anchors

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9f8e2f14c8330b127c9d3ec9d18a8