### PR TITLE
feat: add first-time navigation tour

### DIFF
--- a/src/boot/onboardingTour.ts
+++ b/src/boot/onboardingTour.ts
@@ -6,21 +6,16 @@ import { hasCompletedOnboarding, startOnboardingTour } from 'src/composables/use
 export default boot(async ({ router }) => {
   router.isReady().then(() => {
     const nostr = useNostrStore()
+    let lastPrefix: string | null = null
     const run = async () => {
       const prefix = (nostr.pubkey || 'anon').slice(0, 8)
+      if (prefix === lastPrefix) return
+      lastPrefix = prefix
       if (hasCompletedOnboarding(prefix)) return
       await nextTick()
-      startOnboardingTour(prefix)
+      setTimeout(() => startOnboardingTour(prefix), 300)
     }
-    if (nostr.pubkey) {
-      run()
-    } else {
-      const stop = watch(() => nostr.pubkey, (val) => {
-        if (val) {
-          stop()
-          run()
-        }
-      })
-    }
+    run()
+    watch(() => nostr.pubkey, run)
   })
 })

--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -35,7 +35,7 @@
       <q-item-label header>{{
         $t("MainHeader.menu.settings.title")
       }}</q-item-label>
-      <q-item clickable @click="gotoWallet" data-tour="nav-wallet">
+      <q-item clickable @click="gotoWallet" data-tour="nav-dashboard nav-wallet">
         <q-item-section avatar>
           <q-icon name="account_balance_wallet" />
         </q-item-section>

--- a/src/components/OnboardingTour.vue
+++ b/src/components/OnboardingTour.vue
@@ -32,32 +32,38 @@ const ui = useUiStore()
 
 const steps = [
   {
-    target: '[data-tour="nav-toggle"]',
+    target: '[data-tour~="nav-toggle"]',
     text: 'Open the sidebar to jump between pages. You can revisit this tour anytime from Settings.',
     anchor: 'bottom middle',
     self: 'top middle',
     onNext: () => ui.openMainNav(),
   },
   {
-    target: '[data-tour="nav-wallet"]',
+    target: '[data-tour~="nav-dashboard"]',
+    text: 'Your overview: balances, recent activity, and quick links.',
+    anchor: 'right middle',
+    self: 'left middle',
+  },
+  {
+    target: '[data-tour~="nav-wallet"]',
     text: 'Deposit or withdraw funds and review your transactions here.',
     anchor: 'right middle',
     self: 'left middle',
   },
   {
-    target: '[data-tour="nav-find-creators"]',
+    target: '[data-tour~="nav-find-creators"]',
     text: 'Discover creators and start supporting them with a few taps.',
     anchor: 'right middle',
     self: 'left middle',
   },
   {
-    target: '[data-tour="nav-subscriptions"]',
+    target: '[data-tour~="nav-subscriptions"]',
     text: 'Manage who you support and adjust contribution levels anytime.',
     anchor: 'right middle',
     self: 'left middle',
   },
   {
-    target: '[data-tour="nav-settings"]',
+    target: '[data-tour~="nav-settings"]',
     text: 'Update account preferences, notifications, and security. You can replay the tutorial here.',
     anchor: 'right middle',
     self: 'left middle',
@@ -90,8 +96,7 @@ async function showStep() {
   await nextTick()
   const el = document.querySelector(step.target) as HTMLElement | null
   if (!el) {
-    index.value++
-    showStep()
+    setTimeout(showStep, 300)
     return
   }
   current.value = { ...step, el }


### PR DESCRIPTION
## Summary
- ensure onboarding tour starts for anonymous users
- add dashboard step and improve tour element checks
- wire menu wallet item with dashboard and wallet tour targets

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fe6ecaa48330aa871e94dfe9ab37