### PR TITLE
feat: centralize onboarding tour storage key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,7 @@ Utility classes: `.text-1`, `.text-2`, `.text-inverse`, `.bg-surface-1`, `.bg-su
 ## Welcome Gate
 - Local storage key `welcome.seen:v1` and cookie `welcome_seen_v1` track if the onboarding was shown on a device.
 - Bump to `welcome.seen:v2`/`welcome_seen_v2` when revising the flow to force users through the new onboarding.
+
+## Onboarding Tour
+- Local storage key `fundstr:onboarding:v1:<pubkey>:done` tracks if the user finished the in-app tour.
+- Bump to `fundstr:onboarding:v2` when the tour changes and should be shown again.

--- a/src/composables/useOnboardingTour.ts
+++ b/src/composables/useOnboardingTour.ts
@@ -1,11 +1,10 @@
 import { LocalStorage } from 'quasar'
 import { createApp } from 'vue'
 import OnboardingTour from 'src/components/OnboardingTour.vue'
-
-const KEY_PREFIX = 'fundstr:onboarding:v1:'
+import { LOCAL_STORAGE_KEYS } from 'src/constants/localStorageKeys'
 
 function key(prefix: string) {
-  return `${KEY_PREFIX}${prefix}:done`
+  return `${LOCAL_STORAGE_KEYS.FUNDSTR_ONBOARDING_DONE}:${prefix}:done`
 }
 
 export function hasCompletedOnboarding(prefix: string): boolean {

--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -97,4 +97,6 @@ export const LOCAL_STORAGE_KEYS = {
   CREATORPROFILE_PICTURE: "creatorProfile.picture",
   CREATORPROFILE_PUBKEY: "creatorProfile.pubkey",
   CREATORPROFILE_RELAYS: "creatorProfile.relays",
+  // bump to `fundstr:onboarding:v2` if the tour changes and users should see it again
+  FUNDSTR_ONBOARDING_DONE: "fundstr:onboarding:v1",
 } as const;


### PR DESCRIPTION
## Summary
- define `FUNDSTR_ONBOARDING_DONE` key and document version bump strategy
- use shared constant in onboarding tour composable

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa03dffd0483309ebade38cbf2cc0e