### PR TITLE
test: cover onboarding tour boot flow when nav toggle missing

### DIFF
--- a/src/components/OnboardingTour.vue
+++ b/src/components/OnboardingTour.vue
@@ -14,8 +14,8 @@
     <div class="onboarding-body">
       <div class="q-mb-sm">{{ current.text }}</div>
       <div class="row justify-end q-gutter-sm">
-        <q-btn flat dense class="skip-btn" @click="skip">{{ $t('OnboardingTour.skip') }}</q-btn>
-        <q-btn flat dense color="primary" @click="next">{{ isLast ? $t('OnboardingTour.gotIt') : $t('OnboardingTour.next') }}</q-btn>
+        <q-btn flat dense class="skip-btn" @click="skip">{{ t('OnboardingTour.skip') }}</q-btn>
+        <q-btn flat dense color="primary" @click="next">{{ isLast ? t('OnboardingTour.gotIt') : t('OnboardingTour.next') }}</q-btn>
       </div>
     </div>
   </q-tooltip>

--- a/test/vitest/__tests__/onboardingTour.spec.ts
+++ b/test/vitest/__tests__/onboardingTour.spec.ts
@@ -136,4 +136,26 @@ describe('Onboarding tour', () => {
     await vi.runAllTimersAsync()
     expect(wrapper.html()).toContain('OnboardingTour.navDashboard')
   })
+
+  it('boots at dashboard when nav is open and nav toggle missing', async () => {
+    uiStore.mainNavOpen = true
+    nostrStore.pubkey = 'fedcba9876543210'
+    const prefix = nostrStore.pubkey.slice(0, 8)
+
+    const navDashboard = document.createElement('div')
+    navDashboard.setAttribute('data-tour', 'nav-dashboard')
+    document.body.appendChild(navDashboard)
+
+    const onboarding = await import('src/composables/useOnboardingTour')
+    const startSpy = vi.spyOn(onboarding, 'startOnboardingTour')
+
+    const bootModule = await import('src/boot/onboardingTour')
+    await bootModule.default({ router: { isReady: () => Promise.resolve() } })
+    await nextTick()
+    await nextTick()
+    await vi.runAllTimersAsync()
+    await nextTick()
+    expect(startSpy).toHaveBeenCalledWith(prefix)
+    expect(document.body.innerHTML).toContain('OnboardingTour.navDashboard')
+  })
 })


### PR DESCRIPTION
## Summary
- ensure onboarding tour tooltip uses `t` helper instead of `$t`
- add boot flow test when nav is open and nav toggle is absent

## Testing
- `pnpm test`
- `pnpm vitest run test/vitest/__tests__/onboardingTour.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aa9d2751b88330a3a0bc74369f56c8