### PR TITLE
feat: improve onboarding tour

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,5 +54,5 @@ Utility classes: `.text-1`, `.text-2`, `.text-inverse`, `.bg-surface-1`, `.bg-su
 - Bump to `welcome.seen:v2`/`welcome_seen_v2` when revising the flow to force users through the new onboarding.
 
 ## Onboarding Tour
-- Local storage key `fundstr:onboarding:v1:<pubkey>:done` tracks if the user finished the in-app tour.
-- Bump to `fundstr:onboarding:v2` when the tour changes and should be shown again.
+- Local storage key `fundstr:onboarding:v2:<pubkey>:done` tracks if the user finished the in-app tour.
+- Bump to `fundstr:onboarding:v3` when the tour changes and should be shown again.

--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -35,14 +35,20 @@
       <q-item-label header>{{
         $t("MainHeader.menu.settings.title")
       }}</q-item-label>
-      <q-item clickable @click="gotoWallet" data-tour="nav-dashboard nav-wallet">
+      <q-item clickable @click="gotoDashboard" data-tour="nav-dashboard">
+        <q-item-section avatar>
+          <q-icon name="dashboard" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>{{ $t("MainHeader.menu.dashboard.title") }}</q-item-label>
+        </q-item-section>
+      </q-item>
+      <q-item clickable @click="gotoWallet" data-tour="nav-wallet">
         <q-item-section avatar>
           <q-icon name="account_balance_wallet" />
         </q-item-section>
         <q-item-section>
-          <q-item-label>{{
-            $t("FullscreenHeader.actions.back.label")
-          }}</q-item-label>
+          <q-item-label>{{ $t("MainHeader.menu.wallet.title") }}</q-item-label>
         </q-item-section>
       </q-item>
       <q-item clickable @click="gotoSettings" data-tour="nav-settings">
@@ -206,6 +212,7 @@ function goto(path: string) {
   router.push(path);
   ui.closeMainNav();
 }
+const gotoDashboard = () => goto("/");
 const gotoWallet = () => goto("/wallet");
 const gotoSettings = () => goto("/settings");
 const gotoFindCreators = () => goto("/find-creators");

--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -97,6 +97,6 @@ export const LOCAL_STORAGE_KEYS = {
   CREATORPROFILE_PICTURE: "creatorProfile.picture",
   CREATORPROFILE_PUBKEY: "creatorProfile.pubkey",
   CREATORPROFILE_RELAYS: "creatorProfile.relays",
-  // bump to `fundstr:onboarding:v2` if the tour changes and users should see it again
-  FUNDSTR_ONBOARDING_DONE: "fundstr:onboarding:v1",
+  // bump to `fundstr:onboarding:v3` if the tour changes and users should see it again
+  FUNDSTR_ONBOARDING_DONE: "fundstr:onboarding:v2",
 } as const;

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle:
       "افتح الشريط الجانبي للتنقل بين الصفحات. يمكنك إعادة الجولة من الإعدادات.",
     navDashboard: "نظرة عامة: الأرصدة، آخر النشاط وروابط سريعة.",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle:
       "Öffne die Seitenleiste, um zwischen Seiten zu wechseln. Du kannst die Tour jederzeit über Einstellungen erneut abspielen.",
     navDashboard: "Deine Übersicht: Kontostände, Aktivitäten und Schnellzugriffe.",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle:
       "Άνοιξε την πλευρική μπάρα για να αλλάζεις σελίδες. Μπορείς να ξαναδείς την περιήγηση από τις Ρυθμίσεις.",
     navDashboard:

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -107,6 +107,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" },
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -2007,12 +2008,12 @@ export const messages = {
     },
   },
   OnboardingTour: {
-    navToggle: "Open the sidebar to switch pages. Replay this tour from Settings.",
-    navDashboard: "Your overview: balances, activity, and quick links.",
-    navWallet: "Deposit or withdraw funds and review your transactions here.",
-    navFindCreators: "Discover creators and start supporting them with a few taps.",
-    navSubscriptions: "Manage who you support and adjust contribution levels anytime.",
-    navSettings: "Update preferences, notifications, and security. Replay the tutorial here.",
+    navToggle: "Tap the menu button to open the sidebar.",
+    navDashboard: "This is your dashboard with balances and activity. Click Next to continue.",
+    navWallet: "Manage deposits and withdrawals in the wallet. Click Next to continue.",
+    navFindCreators: "Discover creators to support. Click Next to continue.",
+    navSubscriptions: "Manage who you support and adjust contribution levels. Click Next to continue.",
+    navSettings: "Update preferences and security in Settings. Click Next to finish.",
     skip: "Skip tour",
     gotIt: "Got it",
     next: "Next",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle:
       "Abre la barra lateral para cambiar de página. Repite este recorrido desde Ajustes.",
     navDashboard: "Tu resumen: saldos, actividad reciente y accesos rápidos.",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle:
       "Ouvre la barre latérale pour changer de page. Relance ce tutoriel via les paramètres.",
     navDashboard: "Vue d’ensemble : soldes, activité récente et raccourcis.",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle:
       "Apri la barra laterale per cambiare pagina. Puoi ripetere il tour dalle Impostazioni.",
     navDashboard: "La tua panoramica: saldi, attività recente e scorciatoie.",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle:
       "サイドバーを開いてページを移動。設定からいつでもツアーを再実行できます。",
     navDashboard: "概要：残高、最近のアクティビティ、ショートカット。",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle: "Öppna sidomenyn för att byta sida. Kör om turen via Inställningar.",
     navDashboard: "Din överblick: saldon, senaste aktivitet och snabblänkar.",
     navWallet: "Sätt in eller ta ut pengar och se dina transaktioner här.",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle: "เปิดแถบด้านข้างเพื่อสลับหน้า ดูทัวร์นี้อีกครั้งได้ที่การตั้งค่า",
     navDashboard: "ภาพรวม: ยอดคงเหลือ กิจกรรมล่าสุด และลิงก์ด่วน",
     navWallet: "ฝากหรือถอนเงินและดูธุรกรรมได้ที่นี่",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle:
       "Sayfalar arasında geçmek için kenar çubuğunu aç. Turu Ayarlar'dan tekrar oynatabilirsin.",
     navDashboard: "Genel bakış: bakiyeler, son etkinlik ve hızlı bağlantılar.",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -106,6 +106,7 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      dashboard: { title: "Dashboard" }, // TODO: translate
       wallet: { title: "@:FullscreenHeader.actions.back.label" },
       nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
       restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
@@ -1992,6 +1993,7 @@ export const messages = {
     },
   },
   OnboardingTour: {
+    // TODO: update onboarding tour messages
     navToggle: "打开侧栏切换页面。可在设置中再次查看此引导。",
     navDashboard: "概览：余额、近期活动和快捷入口。",
     navWallet: "在此存取资金并查看交易记录。",

--- a/test/onboardingTour.component.spec.ts
+++ b/test/onboardingTour.component.spec.ts
@@ -17,7 +17,7 @@ describe('OnboardingTour component', () => {
       global: { plugins: [[Quasar, {}], i18n] },
     })
     ;(wrapper.vm as any).finish()
-    expect(LocalStorage.getItem('fundstr:onboarding:v1:test:done')).toBeNull()
+    expect(LocalStorage.getItem('fundstr:onboarding:v2:test:done')).toBeNull()
   })
 
   it('marks done when a step was shown', () => {
@@ -27,13 +27,13 @@ describe('OnboardingTour component', () => {
     })
     ;(wrapper.vm as any).shownAtLeastOneStep = true
     ;(wrapper.vm as any).finish()
-    expect(LocalStorage.getItem('fundstr:onboarding:v1:test2:done')).toBe('1')
+    expect(LocalStorage.getItem('fundstr:onboarding:v2:test2:done')).toBe('1')
   })
 
   it('resetOnboarding clears key', async () => {
-    LocalStorage.set('fundstr:onboarding:v1:abc:done', '1')
+    LocalStorage.set('fundstr:onboarding:v2:abc:done', '1')
     const { resetOnboarding } = await import('src/composables/useOnboardingTour')
     resetOnboarding('abc')
-    expect(LocalStorage.getItem('fundstr:onboarding:v1:abc:done')).toBeNull()
+    expect(LocalStorage.getItem('fundstr:onboarding:v2:abc:done')).toBeNull()
   })
 })

--- a/test/vitest/__tests__/onboardingTour.spec.ts
+++ b/test/vitest/__tests__/onboardingTour.spec.ts
@@ -14,7 +14,7 @@ vi.mock('quasar', () => ({
       delete storage[key]
     }
   },
-  QTooltip: { template: '<div><slot/></div>' },
+  QMenu: { template: '<div><slot/></div>' },
   QBtn: { template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot/></button>' }
 }))
 
@@ -82,7 +82,7 @@ describe('Onboarding tour', () => {
     await nextTick()
     await wrapper.find('button.skip-btn').trigger('click')
 
-    const key = `fundstr:onboarding:v1:${prefix}:done`
+    const key = `fundstr:onboarding:v2:${prefix}:done`
     expect(storage[key]).toBe('1')
 
     const onboarding = await import('src/composables/useOnboardingTour')
@@ -95,11 +95,15 @@ describe('Onboarding tour', () => {
     expect(startSpy).not.toHaveBeenCalled()
   })
 
-  it('shows nav toggle when nav is initially closed and opens nav on next', async () => {
+  it('shows nav toggle when nav is initially closed and advances on toggle click', async () => {
     const prefix = 'abcdef12'
     const navToggle = document.createElement('div')
     navToggle.setAttribute('data-tour', 'nav-toggle')
+    navToggle.addEventListener('click', uiStore.openMainNav)
     document.body.appendChild(navToggle)
+    const navDashboard = document.createElement('div')
+    navDashboard.setAttribute('data-tour', 'nav-dashboard')
+    document.body.appendChild(navDashboard)
 
     const OnboardingTour = (await import('src/components/OnboardingTour.vue')).default
     const wrapper = mount(OnboardingTour, {
@@ -112,10 +116,11 @@ describe('Onboarding tour', () => {
     await vi.runAllTimersAsync()
     expect(wrapper.html()).toContain('OnboardingTour.navToggle')
 
-    await wrapper.findAll('button').at(1)!.trigger('click')
+    navToggle.click()
     await nextTick()
     await vi.runAllTimersAsync()
     expect(uiStore.openMainNav).toHaveBeenCalled()
+    expect(document.body.innerHTML).toContain('OnboardingTour.navDashboard')
   })
 
   it('starts at dashboard when nav is already open', async () => {


### PR DESCRIPTION
## Summary
- replace tooltip with interactive menu and support advance-on-click steps
- separate dashboard and wallet nav targets and clarify onboarding text
- bump onboarding tour localStorage key to v2

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa6f1dc248330b71ff46c8db88b7e