### PR TITLE
refactor: expand onboarding step schema

### DIFF
--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -1,10 +1,31 @@
 export type OnboardingAdvanceMode = 'auto' | 'manual'
 
+export type OnboardingRequiredAction =
+  | 'click'
+  | 'type'
+  | 'select'
+  | 'open'
+  | 'custom'
+
+export type OnboardingPlacement =
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left'
+  | 'auto'
+
 export interface OnboardingStep {
+  id: string
+  route?: string
+  ensure?: () => Promise<void> | void
   target: string
-  text: string
-  anchor: string
-  self: string
-  requiredAction?: 'click' | 'open'
+  placement?: OnboardingPlacement
+  offset?: number
+  padding?: number
+  instruction: string
+  requiredAction?: OnboardingRequiredAction
   advanceMode?: OnboardingAdvanceMode
+  completeWhen: () => boolean
+  timeoutMs?: number
+  a11yLabel?: string
 }

--- a/test/onboardingTour.component.spec.ts
+++ b/test/onboardingTour.component.spec.ts
@@ -4,6 +4,7 @@ import { LocalStorage, Quasar } from 'quasar'
 import { mount } from '@vue/test-utils'
 import OnboardingTour from 'src/components/OnboardingTour.vue'
 import { i18n } from 'src/boot/i18n'
+vi.mock('vue-router', () => ({ useRouter: () => ({ currentRoute: { value: { path: '/' } } }) }))
 
 describe('OnboardingTour component', () => {
   beforeEach(() => {

--- a/test/vitest/__tests__/onboardingTour.spec.ts
+++ b/test/vitest/__tests__/onboardingTour.spec.ts
@@ -23,6 +23,11 @@ vi.mock('vue-i18n', () => ({
   useI18n: () => ({ t: (s: string) => s })
 }))
 
+// mock router
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ currentRoute: { value: { path: '/' } } })
+}))
+
 // mock stores
 const nostrStore = reactive<{ pubkey: string | null }>({ pubkey: null })
 vi.mock('src/stores/nostr', () => ({


### PR DESCRIPTION
## Summary
- broaden onboarding step type to handle placement, padding, completion predicates and accessibility details
- rework OnboardingTour component to consume new schema and poll for completion
- mock vue-router in tests

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab13a79408330b44aa12c7031ed88