### PR TITLE
feat: improve first run onboarding flow

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1807,6 +1807,7 @@ import { useRestoreStore } from "src/stores/restore";
 import { useDexieStore } from "../stores/dexie";
 import { useReceiveTokensStore } from "../stores/receiveTokensStore";
 import { resetOnboarding, startOnboardingTour } from "src/composables/useOnboardingTour";
+import { useFirstRunStore } from "src/stores/firstRun";
 import { useStorageStore } from "src/stores/storage";
 import { useI18n } from "vue-i18n";
 
@@ -2118,8 +2119,12 @@ export default defineComponent({
     showTour: async function () {
       const prefix = (useNostrStore().pubkey || 'anon').slice(0, 8)
       resetOnboarding(prefix)
+      const firstRunStore = useFirstRunStore()
       this.$router.push('/wallet').then(() => {
-        setTimeout(() => startOnboardingTour(prefix), 300)
+        setTimeout(() => {
+          firstRunStore.tourStarted = true
+          startOnboardingTour(prefix)
+        }, 300)
       })
     },
     nukeWallet: async function () {

--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -97,6 +97,7 @@ export const LOCAL_STORAGE_KEYS = {
   CREATORPROFILE_PICTURE: "creatorProfile.picture",
   CREATORPROFILE_PUBKEY: "creatorProfile.pubkey",
   CREATORPROFILE_RELAYS: "creatorProfile.relays",
+  FIRST_RUN_DONE: "fundstr:firstRunDone",
   // bump to `fundstr:onboarding:v4` if the tour changes and users should see it again
   FUNDSTR_ONBOARDING_DONE: "fundstr:onboarding:v3",
 } as const;

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import { useQuasar } from 'quasar'
@@ -72,6 +72,7 @@ import { useMnemonicStore } from 'src/stores/mnemonic'
 import { useStorageStore } from 'src/stores/storage'
 import { useNostrStore } from 'src/stores/nostr'
 import { useNdk } from 'src/composables/useNdk'
+import { useFirstRunStore } from 'src/stores/firstRun'
 
 const { t } = useI18n()
 const welcome = useWelcomeStore()
@@ -83,6 +84,7 @@ const storageStore = useStorageStore()
 const nostr = useNostrStore()
 const showSeedDialog = ref(false)
 const showChecklist = ref(false)
+const firstRunStore = useFirstRunStore()
 
 onMounted(() => {
   const env = import.meta.env.VITE_APP_ENV
@@ -106,7 +108,7 @@ function finishOnboarding() {
   welcome.closeWelcome()
   // remember that the welcome flow has been completed on this device
   markWelcomeSeen()
-  router.push('/')
+  firstRunStore.beginFirstRun(router)
 }
 
 const slides = [
@@ -168,5 +170,9 @@ onMounted(() => {
       }
     })
     .catch(() => {})
+})
+
+onUnmounted(() => {
+  firstRunStore.cancelTimeout()
 })
 </script>

--- a/src/stores/firstRun.ts
+++ b/src/stores/firstRun.ts
@@ -1,0 +1,52 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { useLocalStorage } from '@vueuse/core';
+import { LOCAL_STORAGE_KEYS } from 'src/constants/localStorageKeys';
+import { startOnboardingTour } from 'src/composables/useOnboardingTour';
+import { useNostrStore } from 'src/stores/nostr';
+import type { Router } from 'vue-router';
+
+export const useFirstRunStore = defineStore('firstRun', () => {
+  const suppressModals = ref(false);
+  const tourStarted = ref(false);
+  const firstRunCompleted = useLocalStorage<boolean>(
+    LOCAL_STORAGE_KEYS.FIRST_RUN_DONE,
+    false
+  );
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  function cancelTimeout() {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function beginFirstRun(router: Router) {
+    if (firstRunCompleted.value) {
+      router.push('/');
+      return;
+    }
+
+    suppressModals.value = true;
+    router.replace('/about');
+    cancelTimeout();
+    timer = setTimeout(() => {
+      const nostr = useNostrStore();
+      const prefix = (nostr.pubkey || 'anon').slice(0, 8);
+      tourStarted.value = true;
+      startOnboardingTour(prefix);
+      suppressModals.value = false;
+      firstRunCompleted.value = true;
+    }, 5000);
+  }
+
+  return {
+    suppressModals,
+    tourStarted,
+    firstRunCompleted,
+    beginFirstRun,
+    cancelTimeout,
+  };
+});

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -28,6 +28,7 @@ import { useI18n } from "vue-i18n";
 import { maybeRepublishNutzapProfile } from "./creatorHub";
 import { useCreatorProfileStore } from "./creatorProfile";
 import { i18n } from "src/boot/i18n";
+import { useFirstRunStore } from "./firstRun";
 
 export type Mint = {
   url: string;
@@ -148,10 +149,13 @@ export const useMintsStore = defineStore("mints", {
       }
     };
 
+    const firstRunStore = useFirstRunStore();
     if (!isValidUrl(activeMintUrl.value)) {
       activeMintUrl.value = "";
       uiStoreGlobal.setTab("mints");
-      showAddMintDialog.value = true;
+      if (!firstRunStore.suppressModals) {
+        showAddMintDialog.value = true;
+      }
     }
 
     return {


### PR DESCRIPTION
## Summary
- suppress auto mint dialog during first run and while tour starts
- show /about interstitial after welcome then start tour with delay
- track first-run completion to skip sequence later

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aab4df4fc483308b203ca40f02d505