### PR TITLE
Refactor About page layout and theming

### DIFF
--- a/src/components/BaseContainer.vue
+++ b/src/components/BaseContainer.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="max-w-screen-xl mx-auto px-4">
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+// simple layout container
+</script>

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -1,47 +1,48 @@
 <template>
   <div class="about-page antialiased">
     <!-- Header -->
-    <header class="text-center py-16 px-4 fade-in-section">
-      <h1 class="text-5xl md:text-7xl font-extrabold mb-6">
-        About <span class="gradient-text">Fundstr</span>
-      </h1>
-      <p class="max-w-3xl mx-auto text-lg md:text-xl">
-        A privacy-first Bitcoin wallet, social chat, and creator-monetisation
-        hub built on the open-source Cashu ecash protocol and the decentralised
-        Nostr network.
-      </p>
-      <div
-        class="alpha-warning mt-8 max-w-3xl mx-auto flex items-start gap-3 animate-pulse"
-        role="alert"
-      >
-        <span class="text-3xl">⚠️</span>
+    <header class="pt-24 pb-12 fade-in-section">
+      <BaseContainer class="text-center">
+        <h1 class="text-5xl md:text-7xl font-extrabold mb-6">
+          About <span class="gradient-text">Fundstr</span>
+        </h1>
+        <p class="text-lg md:text-xl max-w-prose mx-auto">
+          A privacy-first Bitcoin wallet, social chat, and creator-monetisation
+          hub built on the open-source Cashu ecash protocol and the decentralised
+          Nostr network.
+        </p>
+      </BaseContainer>
+    </header>
+    <div class="alpha-warning fade-in-section">
+      <BaseContainer class="flex items-start gap-3" role="alert">
+        <q-icon name="warning" size="32px" class="text-accent" aria-hidden="true" />
         <p>
           Fundstr is experimental alpha software. Features may break or change,
           and loss of funds is possible. Use only small amounts you can afford
           to lose.
         </p>
-      </div>
-    </header>
+      </BaseContainer>
+    </div>
 
     <!-- Vision -->
-    <section id="vision" class="py-16 px-4 fade-in-section">
-      <div class="max-w-4xl mx-auto text-center">
+    <section id="vision" class="py-12 md:py-20 fade-in-section">
+      <BaseContainer class="text-center">
         <h2 class="text-3xl md:text-5xl font-bold mb-6 gradient-text">
           Your Money, Your Network
         </h2>
-        <p class="text-lg md:text-xl">
+        <p class="text-lg md:text-xl max-w-prose mx-auto">
           We believe in a world where your financial life and social
           interactions are truly your own. Fundstr is an experiment in creating
           a parallel, peer-to-peer economy—free from corporate gatekeepers,
           surveillance, and unpredictable fees. It’s a gateway to a more
           sovereign way of connecting and transacting.
         </p>
-      </div>
+      </BaseContainer>
     </section>
 
     <!-- Site Overview -->
-    <section id="site-overview" class="py-16 px-4 fade-in-section">
-      <div class="max-w-6xl mx-auto text-center">
+    <section id="site-overview" class="py-12 md:py-20 fade-in-section">
+      <BaseContainer class="text-center">
         <h2 class="text-3xl md:text-5xl font-bold mb-6 gradient-text">
           {{ $t("AboutPage.siteOverview.title") }}
         </h2>
@@ -52,13 +53,21 @@
             v-for="card in siteOverviewCards"
             :key="card.route"
             :to="card.route"
-            class="interactive-card block no-underline p-6 md:p-8 flex flex-col cursor-pointer"
+            class="interactive-card block no-underline p-6 md:p-8 flex flex-col cursor-pointer focus:outline-none focus:ring-2 focus:ring-accent-500"
             :aria-label="$t(card.titleKey)"
           >
+            <component
+              v-if="card.iconComponent"
+              :is="card.iconComponent"
+              class="w-8 h-8 mb-4 text-accent"
+              aria-hidden="true"
+            />
             <q-icon
+              v-else
               :name="card.icon"
-              size="2.5rem"
-              class="text-white mb-4"
+              size="32px"
+              class="mb-4 text-accent"
+              aria-hidden="true"
             />
             <p class="text-accent font-semibold">
               {{ tOr(card.titleKey) }}
@@ -68,156 +77,54 @@
             </p>
           </router-link>
         </div>
-      </div>
+      </BaseContainer>
     </section>
 
     <!-- How Ecash Works -->
-    <section id="how-it-works" class="py-16 px-4 fade-in-section">
-      <div class="max-w-5xl mx-auto text-center">
+    <section id="how-it-works" class="py-12 md:py-20 fade-in-section">
+      <BaseContainer class="text-center">
         <h2 class="text-3xl md:text-5xl font-bold mb-6 gradient-text">
           How Ecash Works
         </h2>
-        <p class="text-lg md:text-xl mb-12">
+        <p class="text-lg md:text-xl mb-12 max-w-prose mx-auto">
           The loop is simple: Bitcoin in → private e-cash out → social payments
           everywhere.
         </p>
-
-        <!-- Flow Grid -->
-        <div class="grid grid-cols-1 md:grid-cols-3 items-center gap-6">
-          <!-- Step 1 -->
-          <button
-            type="button"
-            class="step-card interactive-card p-6 flex flex-col items-center focus:outline-none"
-            @click="dialogStep1 = true"
-            @keyup.enter="dialogStep1 = true"
-            tabindex="0"
-          >
-            <svg
-              class="w-12 h-12 mb-4 text-yellow-400"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M23.112 13.506c.353-2.353-1.444-3.415-3.897-4.2l.797-3.194-1.948-.485-.776 3.111c-.511-.127-1.035-.246-1.555-.364l.784-3.144-1.948-.486-.797 3.194c-.422-.096-.84-.19-1.246-.29l-.001-.006-2.688-.669-.518 2.075s1.444.331 1.415.352c.79.197.933.716.909 1.13l-2.195 8.8c-.096.238-.34.596-.89.461.02.028-1.415-.353-1.415-.353l-.966 2.385 2.538.631c.472.119.934.241 1.392.357l-.806 3.245 1.948.486.797-3.194c.529.143 1.042.274 1.547.398l-.793 3.179 1.948.485.805-3.244c3.324.63 5.827.376 6.885-2.633.849-2.417-.042-3.814-1.794-4.728 1.277-.295 2.237-1.135 2.497-2.873zm-4.462 6.26c-.605 2.417-4.696 1.108-6.025.781l1.076-4.32c1.329.332 5.585.991 4.949 3.539zm.605-6.29c-.553 2.211-3.96 1.086-5.063.811l.974-3.906c1.102.275 4.67.79 4.09 3.095z"
-              />
-            </svg>
-            <h3 class="font-semibold text-xl mb-2">Your Bitcoin</h3>
+        <div class="flex flex-col md:flex-row items-center justify-center gap-8">
+          <div class="flex flex-col items-center text-center max-w-xs">
+            <q-icon name="currency_bitcoin" size="32px" class="mb-4 text-accent" aria-hidden="true" />
+            <h3 class="font-semibold text-lg mb-1">Your Bitcoin</h3>
             <p class="text-sm">From any wallet</p>
-          </button>
-
-          <!-- Step 2 -->
-          <button
-            type="button"
-            class="step-card interactive-card p-6 flex flex-col items-center focus:outline-none"
-            @click="dialogStep2 = true"
-            @keyup.enter="dialogStep2 = true"
-            tabindex="0"
-          >
-            <svg
-              class="w-12 h-12 mb-4 text-indigo-400"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"
-              />
-            </svg>
-            <h3 class="font-semibold text-xl mb-2">The Mint</h3>
-            <p class="text-sm">Swaps for Ecash</p>
-          </button>
-
-          <!-- Step 3 -->
-          <button
-            type="button"
-            class="step-card interactive-card p-6 flex flex-col items-center focus:outline-none"
-            @click="dialogStep3 = true"
-            @keyup.enter="dialogStep3 = true"
-            tabindex="0"
-          >
-            <svg
-              class="w-12 h-12 mb-4 text-pink-400"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-              />
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M2.458 12C3.732 7.943 7.523 5 12 5c4.477 0 8.268 2.943 9.542 7-1.274 4.057-5.065 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-              />
-            </svg>
-            <h3 class="font-semibold text-xl mb-2">Fundstr Wallet</h3>
-            <p class="text-sm">Private & ready to spend</p>
-          </button>
+          </div>
+          <q-icon name="arrow_downward" size="32px" class="md:hidden text-1" aria-hidden="true" />
+          <q-icon name="arrow_forward" size="32px" class="hidden md:block text-1" aria-hidden="true" />
+          <div class="flex flex-col items-center text-center max-w-xs">
+            <q-icon name="account_balance" size="32px" class="mb-4 text-accent" aria-hidden="true" />
+            <h3 class="font-semibold text-lg mb-1">The Mint</h3>
+            <p class="text-sm">Issues ecash tokens</p>
+          </div>
+          <q-icon name="arrow_downward" size="32px" class="md:hidden text-1" aria-hidden="true" />
+          <q-icon name="arrow_forward" size="32px" class="hidden md:block text-1" aria-hidden="true" />
+          <div class="flex flex-col items-center text-center max-w-xs">
+            <q-icon name="account_balance_wallet" size="32px" class="mb-4 text-accent" aria-hidden="true" />
+            <h3 class="font-semibold text-lg mb-1">Fundstr Wallet</h3>
+            <p class="text-sm">Spend privately</p>
+          </div>
         </div>
-
-        <!-- Dialogs -->
-        <q-dialog v-model="dialogStep1">
-          <q-card>
-            <q-card-section class="text-h6">Your Bitcoin</q-card-section>
-            <q-card-section>
-              Start with sats from any wallet. For example, swap 100k sats for
-              ecash to send privately.
-            </q-card-section>
-            <q-card-actions align="right">
-              <q-btn flat label="Close" v-close-popup />
-            </q-card-actions>
-          </q-card>
-        </q-dialog>
-
-        <q-dialog v-model="dialogStep2">
-          <q-card>
-            <q-card-section class="text-h6">The Mint</q-card-section>
-            <q-card-section>
-              The mint issues blind signed tokens in exchange for your bitcoin.
-              Example: deposit 100k sats and receive ecash you can split and
-              spend.
-            </q-card-section>
-            <q-card-actions align="right">
-              <q-btn flat label="Close" v-close-popup />
-            </q-card-actions>
-          </q-card>
-        </q-dialog>
-
-        <q-dialog v-model="dialogStep3">
-          <q-card>
-            <q-card-section class="text-h6">Fundstr Wallet</q-card-section>
-            <q-card-section>
-              Store and send ecash privately. For instance, forward tokens to a
-              friend or redeem them back for bitcoin later.
-            </q-card-section>
-            <q-card-actions align="right">
-              <q-btn flat label="Close" v-close-popup />
-            </q-card-actions>
-          </q-card>
-        </q-dialog>
-      </div>
+      </BaseContainer>
     </section>
 
     <!-- Built for the Sovereign Individual -->
-    <section id="who-for" class="py-16 px-4 fade-in-section">
-      <div class="max-w-6xl mx-auto text-center">
+    <section id="who-for" class="py-12 md:py-20 fade-in-section">
+      <BaseContainer class="text-center">
         <h2 class="text-3xl md:text-5xl font-bold mb-12 gradient-text">
           Built for the Sovereign Individual
         </h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
           <!-- Card 1 -->
-          <div class="interactive-card p-6">
-            <div class="text-4xl mb-4">🖌️</div>
-            <h3 class="font-semibold text-xl mb-2">Content Creators</h3>
+          <div class="interactive-card p-6 flex flex-col items-center text-center h-full focus:outline-none focus:ring-2 focus:ring-accent-500">
+            <q-icon name="brush" size="32px" class="mb-4 text-accent" aria-hidden="true" />
+            <h3 class="font-semibold text-lg mb-2">Content Creators</h3>
             <p class="text-sm">
               Monetize your audience directly, free from de-platforming and high
               fees.
@@ -225,9 +132,9 @@
           </div>
 
           <!-- Card 2 -->
-          <div class="interactive-card p-6">
-            <div class="text-4xl mb-4">🛡️</div>
-            <h3 class="font-semibold text-xl mb-2">Privacy Advocates</h3>
+          <div class="interactive-card p-6 flex flex-col items-center text-center h-full focus:outline-none focus:ring-2 focus:ring-accent-500">
+            <q-icon name="shield" size="32px" class="mb-4 text-accent" aria-hidden="true" />
+            <h3 class="font-semibold text-lg mb-2">Privacy Advocates</h3>
             <p class="text-sm">
               Transact with confidence that your financial life isn't being
               tracked.
@@ -235,9 +142,9 @@
           </div>
 
           <!-- Card 3 -->
-          <div class="interactive-card p-6">
-            <div class="text-4xl mb-4">🔗</div>
-            <h3 class="font-semibold text-xl mb-2">Nostr Users</h3>
+          <div class="interactive-card p-6 flex flex-col items-center text-center h-full focus:outline-none focus:ring-2 focus:ring-accent-500">
+            <q-icon name="link" size="32px" class="mb-4 text-accent" aria-hidden="true" />
+            <h3 class="font-semibold text-lg mb-2">Nostr Users</h3>
             <p class="text-sm">
               Upgrade your zaps to be truly private and integrate payments
               seamlessly.
@@ -245,34 +152,34 @@
           </div>
 
           <!-- Card 4 -->
-          <div class="interactive-card p-6">
-            <div class="text-4xl mb-4">🌐</div>
-            <h3 class="font-semibold text-xl mb-2">Global Citizens</h3>
+          <div class="interactive-card p-6 flex flex-col items-center text-center h-full focus:outline-none focus:ring-2 focus:ring-accent-500">
+            <q-icon name="public" size="32px" class="mb-4 text-accent" aria-hidden="true" />
+            <h3 class="font-semibold text-lg mb-2">Global Citizens</h3>
             <p class="text-sm">
               Move value across borders instantly, without relying on
               traditional banking.
             </p>
           </div>
         </div>
-      </div>
+      </BaseContainer>
     </section>
 
     <!-- Navigation Map -->
-    <section id="navigation-map" class="py-16 px-4 fade-in-section">
-      <div class="max-w-6xl mx-auto text-center">
+    <section id="navigation-map" class="py-12 md:py-20 fade-in-section">
+      <BaseContainer class="text-center">
         <h2 class="text-3xl md:text-5xl font-bold mb-6 gradient-text">
           Navigation Map
         </h2>
-        <p class="text-lg md:text-xl mb-12">
+        <p class="text-lg md:text-xl mb-12 max-w-prose mx-auto">
           Every page explained from both the Creator and Fan perspectives.
         </p>
         <NavigationMap :items="navigationItems" />
-      </div>
+      </BaseContainer>
     </section>
 
     <!-- Trust Through Transparency -->
-    <section id="trust" class="py-16 px-4 fade-in-section">
-      <div class="max-w-6xl mx-auto text-center">
+    <section id="trust" class="py-12 md:py-20 fade-in-section">
+      <BaseContainer class="text-center">
         <h2 class="text-3xl md:text-5xl font-bold mb-12 gradient-text">
           Trust Through Transparency
         </h2>
@@ -496,12 +403,12 @@
             </div>
           </details>
         </div>
-      </div>
+      </BaseContainer>
     </section>
 
     <!-- FAQ -->
-    <section id="faq" class="py-16 px-4 fade-in-section">
-      <div class="max-w-4xl mx-auto">
+    <section id="faq" class="py-12 md:py-20 fade-in-section">
+      <BaseContainer>
         <h2
           class="text-3xl md:text-5xl font-bold mb-12 text-center gradient-text"
         >
@@ -684,7 +591,7 @@
             </p>
           </details>
         </div>
-      </div>
+      </BaseContainer>
     </section>
 
     <!-- Footer -->
@@ -764,14 +671,13 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+import { onMounted, type Component } from "vue";
 import { useI18n } from "vue-i18n";
 import NavigationMap from "src/components/NavigationMap.vue";
+import BaseContainer from "src/components/BaseContainer.vue";
+import FindCreatorsIcon from "src/components/icons/FindCreatorsIcon.vue";
+import CreatorHubIcon from "src/components/icons/CreatorHubIcon.vue";
 import { useNavigationItems } from "src/composables/navigationItems";
-
-const dialogStep1 = ref(false);
-const dialogStep2 = ref(false);
-const dialogStep3 = ref(false);
 
 const { t } = useI18n();
 const tOr = (key: string, fallback = "") => {
@@ -783,7 +689,8 @@ interface SiteOverviewCard {
   route: string;
   titleKey: string;
   descriptionKey: string;
-  icon: string;
+  icon?: string;
+  iconComponent?: Component;
 }
 
 const siteOverviewCards: SiteOverviewCard[] = [
@@ -797,13 +704,13 @@ const siteOverviewCards: SiteOverviewCard[] = [
     route: "/find-creators",
     titleKey: "MainHeader.menu.findCreators.title",
     descriptionKey: "AboutPage.siteOverview.findCreators.description",
-    icon: "img:icons/find-creators.svg",
+    iconComponent: FindCreatorsIcon,
   },
   {
     route: "/creator-hub",
     titleKey: "MainHeader.menu.creatorHub.title",
     descriptionKey: "AboutPage.siteOverview.creatorHub.description",
-    icon: "img:icons/creator-hub.svg",
+    iconComponent: CreatorHubIcon,
   },
   {
     route: "/my-profile",
@@ -893,31 +800,31 @@ onMounted(() => {
 
 <style scoped>
 .about-page {
-  --color-accent: var(--q-accent);
-  --color-accent-rgb: var(--q-accent-rgb, 34, 211, 238);
+  --color-accent: var(--accent-500);
+  --color-accent-rgb: var(--accent-500-rgb, 34, 211, 238);
   font-family: "Inter", sans-serif;
-  background-color: #0a0a0a;
-  background-image: radial-gradient(#1e293b 1px, transparent 1px);
+  background-color: var(--surface-1);
+  background-image: radial-gradient(var(--surface-2) 1px, transparent 1px);
   background-size: 20px 20px;
-  color: #e2e8f0;
+  color: var(--text-1);
 }
 
 .gradient-text {
-  background: linear-gradient(90deg, #a78bfa, #f472b6);
+  background: linear-gradient(90deg, var(--accent-500), var(--accent-600));
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
 }
 
 .gradient-bg {
-  background: linear-gradient(90deg, #a78bfa, #f472b6);
+  background: linear-gradient(90deg, var(--accent-500), var(--accent-600));
 }
 
 .interactive-card {
-  background-color: rgba(15, 23, 42, 0.5);
-  color: #e2e8f0;
+  background-color: var(--surface-2);
+  color: var(--text-1);
   backdrop-filter: blur(4px);
-  border: 1px solid #1e293b;
+  border: 1px solid var(--surface-contrast-border);
   border-radius: 0.75rem;
   transition: all 0.3s ease;
   text-decoration: none;
@@ -926,7 +833,7 @@ onMounted(() => {
 .interactive-card:hover {
   transform: translateY(-5px);
   box-shadow: 0 0 25px rgba(var(--color-accent-rgb), 0.2);
-  border-color: rgba(var(--color-accent-rgb), 0.4);
+  border-color: var(--accent-200);
   text-decoration: none;
 }
 
@@ -951,36 +858,6 @@ onMounted(() => {
   transform: rotate(180deg);
 }
 
-.step-card {
-  position: relative;
-}
-
-.step-card::after {
-  content: "→";
-  position: absolute;
-  top: 50%;
-  right: -1.5rem;
-  transform: translateY(-50%);
-  font-size: 2rem;
-  color: currentColor;
-}
-
-.step-card:last-child::after {
-  content: "";
-}
-
-@media (max-width: 768px) {
-  .step-card::after {
-    content: "↓";
-    top: auto;
-    bottom: -1.5rem;
-    left: 50%;
-    right: auto;
-    transform: translateX(-50%);
-    font-size: 1.5rem;
-  }
-}
-
 .fade-in-section {
   opacity: 0;
   transform: translateY(20px);
@@ -999,20 +876,12 @@ blockquote {
 }
 
 .alpha-warning {
-  background-color: rgba(120, 53, 15, 0.2);
-  border: 1px solid rgba(245, 158, 11, 0.3);
-  color: #fcd34d;
+  background-color: var(--surface-2);
+  border: 1px solid var(--accent-200);
+  color: var(--text-1);
   border-radius: 0.5rem;
-  padding: 1.5rem;
-  font-size: 1.25rem;
-  font-weight: 700;
-  box-shadow: 0 0 10px rgba(245, 158, 11, 0.5);
-}
-
-@media (min-width: 768px) {
-  .alpha-warning {
-    font-size: 1.5rem;
-  }
+  padding: 1rem;
+  box-shadow: 0 0 10px rgba(var(--color-accent-rgb), 0.25);
 }
 
 </style>


### PR DESCRIPTION
## Summary
- use theme tokens and reusable container on About page
- standardize overview icons and audience cards
- simplify ecash flow with responsive stepper

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aac0f501a483309a1492cb41ba66c9