### PR TITLE
feat: add browser-specific onboarding reset

### DIFF
--- a/src/boot/onboardingTour.ts
+++ b/src/boot/onboardingTour.ts
@@ -2,7 +2,11 @@ import { boot } from 'quasar/wrappers'
 import { nextTick, watch } from 'vue'
 import { Notify } from 'quasar'
 import { useNostrStore } from 'src/stores/nostr'
-import { hasCompletedOnboarding, startOnboardingTour } from 'src/composables/useOnboardingTour'
+import {
+  hasCompletedOnboarding,
+  startOnboardingTour,
+  getBrowserId,
+} from 'src/composables/useOnboardingTour'
 import { useFirstRunStore } from 'src/stores/firstRun'
 import { useUiStore } from 'src/stores/ui'
 
@@ -65,7 +69,7 @@ export default boot(async ({ router }) => {
     const tryStart = async () => {
       const path = router.currentRoute.value.path
       if (started || firstRunStore.tourStarted || firstRunStore.suppressModals || !canRunOnRoute(path)) return
-      const prefix = (nostr.pubkey || 'anon').slice(0, 8)
+      const prefix = (nostr.pubkey || getBrowserId()).slice(0, 8)
       if (hasCompletedOnboarding(prefix)) return
       await nextTick()
 

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1537,12 +1537,32 @@
                       >
                     </div>
                   </div>
-                </q-item-section>
-              </q-item>
-              <q-item>
-                <q-item-section>
-                  <div class="row">
-                    <q-btn
+              </q-item-section>
+            </q-item>
+            <q-item>
+              <q-item-section>
+                <div class="row">
+                  <q-btn dense flat outline click @click="resetTour">
+                    {{
+                      $t("Settings.advanced.developer.reset_onboarding.button")
+                    }}
+                  </q-btn>
+                </div>
+                <div class="row">
+                  <q-item-label class="q-px-sm" caption
+                    >{{
+                      $t(
+                        "Settings.advanced.developer.reset_onboarding.description",
+                      )
+                    }}
+                  </q-item-label>
+                </div>
+              </q-item-section>
+            </q-item>
+            <q-item>
+              <q-item-section>
+                <div class="row">
+                  <q-btn
                       dense
                       flat
                       outline
@@ -1806,7 +1826,11 @@ import { usePRStore } from "../stores/payment-request";
 import { useRestoreStore } from "src/stores/restore";
 import { useDexieStore } from "../stores/dexie";
 import { useReceiveTokensStore } from "../stores/receiveTokensStore";
-import { resetOnboarding, startOnboardingTour } from "src/composables/useOnboardingTour";
+import {
+  resetOnboarding,
+  startOnboardingTour,
+  getBrowserId,
+} from "src/composables/useOnboardingTour";
 import { useFirstRunStore } from "src/stores/firstRun";
 import { useStorageStore } from "src/stores/storage";
 import { useI18n } from "vue-i18n";
@@ -2117,7 +2141,7 @@ export default defineComponent({
       await this.generateNPCConnection();
     },
     showTour: async function () {
-      const prefix = (useNostrStore().pubkey || 'anon').slice(0, 8)
+      const prefix = (useNostrStore().pubkey || getBrowserId()).slice(0, 8)
       resetOnboarding(prefix)
       const firstRunStore = useFirstRunStore()
       this.$router.push('/wallet').then(() => {
@@ -2128,6 +2152,10 @@ export default defineComponent({
           })
         }, 300)
       })
+    },
+    resetTour: function () {
+      const prefix = (useNostrStore().pubkey || getBrowserId()).slice(0, 8)
+      resetOnboarding(prefix)
     },
     nukeWallet: async function () {
       // create a backup just in case

--- a/src/composables/useOnboardingTour.ts
+++ b/src/composables/useOnboardingTour.ts
@@ -6,6 +6,15 @@ import { LOCAL_STORAGE_KEYS } from 'src/constants/localStorageKeys'
 import { i18n } from 'src/boot/i18n'
 import type { OnboardingStep } from 'src/types/onboarding'
 
+export function getBrowserId(): string {
+  let id = LocalStorage.getItem<string>(LOCAL_STORAGE_KEYS.FUNDSTR_BROWSER_ID)
+  if (!id) {
+    id = crypto.randomUUID()
+    LocalStorage.set(LOCAL_STORAGE_KEYS.FUNDSTR_BROWSER_ID, id)
+  }
+  return id
+}
+
 function key(prefix: string) {
   return `${LOCAL_STORAGE_KEYS.FUNDSTR_ONBOARDING_DONE}:${prefix}:done`
 }

--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -98,6 +98,7 @@ export const LOCAL_STORAGE_KEYS = {
   CREATORPROFILE_PUBKEY: "creatorProfile.pubkey",
   CREATORPROFILE_RELAYS: "creatorProfile.relays",
   FIRST_RUN_DONE: "fundstr:firstRunDone",
+  FUNDSTR_BROWSER_ID: "fundstr:browserId",
   // bump to `fundstr:onboarding:v4` if the tour changes and users should see it again
   FUNDSTR_ONBOARDING_DONE: "fundstr:onboarding:v3",
 } as const;

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -506,6 +506,10 @@ export const messages = {
           button: "Replay tutorial",
           description: "Restart the onboarding tour from the beginning.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -505,6 +505,10 @@ export const messages = {
           button: "Show onboarding",
           description: "Show the onboarding screen again.",
         },
+        reset_onboarding: {
+          button: "Reset onboarding",
+          description: "Clear onboarding status for this browser.",
+        },
         reset_wallet: {
           button: "Reset wallet data",
           description:

--- a/src/stores/firstRun.ts
+++ b/src/stores/firstRun.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { useLocalStorage } from '@vueuse/core';
 import { LOCAL_STORAGE_KEYS } from 'src/constants/localStorageKeys';
-import { startOnboardingTour } from 'src/composables/useOnboardingTour';
+import { startOnboardingTour, getBrowserId } from 'src/composables/useOnboardingTour';
 import { useNostrStore } from 'src/stores/nostr';
 import type { Router } from 'vue-router';
 
@@ -34,7 +34,7 @@ export const useFirstRunStore = defineStore('firstRun', () => {
     cancelTimeout();
     timer = setTimeout(() => {
       const nostr = useNostrStore();
-      const prefix = (nostr.pubkey || 'anon').slice(0, 8);
+      const prefix = (nostr.pubkey || getBrowserId()).slice(0, 8);
       tourStarted.value = true;
       startOnboardingTour(prefix, undefined, () => {
         tourStarted.value = false;


### PR DESCRIPTION
## Summary
- store a persistent browser identifier to track onboarding
- allow resetting onboarding for the current browser in settings
- update translations for new onboarding option

## Testing
- `corepack pnpm lint`
- `corepack pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaca227ec88330b53a78b56b7fdb46