### PR TITLE
Use composable welcome gate and await onboarding persistence

### DIFF
--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter, useRoute } from 'vue-router'
 import { useQuasar } from 'quasar'
@@ -103,11 +103,12 @@ function downloadBackup() {
   storageStore.exportWalletState()
 }
 
-function finishOnboarding() {
+async function finishOnboarding() {
   showChecklist.value = false
   welcome.closeWelcome()
   // remember that the welcome flow has been completed on this device
   markWelcomeSeen()
+  await nextTick()
   firstRunStore.beginFirstRun(router)
 }
 
@@ -143,9 +144,9 @@ function runTask(task: WelcomeTask) {
   showChecklist.value = false
 }
 
-function next() {
+async function next() {
   if (welcome.currentSlide === LAST_WELCOME_SLIDE) {
-    finishOnboarding()
+    await finishOnboarding()
   } else if (welcome.canProceed(welcome.currentSlide)) {
     welcome.currentSlide++
   }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,8 +6,8 @@ import {
   createWebHashHistory,
 } from "vue-router";
 import routes from "./routes";
-import { useWelcomeStore } from "src/stores/welcome";
 import { useRestoreStore } from "src/stores/restore";
+import { hasSeenWelcome } from "src/composables/useWelcomeGate";
 
 /*
  * If not building with SSR mode, you can
@@ -36,11 +36,10 @@ export default route(function (/* { store, ssrContext } */) {
   });
 
   Router.beforeEach((to, from, next) => {
-    const welcome = useWelcomeStore();
     const restore = useRestoreStore();
     if (
       to.path !== '/welcome' &&
-      !welcome.welcomeCompleted &&
+      !hasSeenWelcome() &&
       !restore.restoringState &&
       to.path !== '/restore'
     ) {


### PR DESCRIPTION
## Summary
- check welcome completion via `hasSeenWelcome()` in router
- await onboarding persistence before routing away

## Testing
- `pnpm lint && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aad10943a083308f7dd61d7a5bde28