### PR TITLE
Guard onboarding completion flag and retry on failure

### DIFF
--- a/test/onboardingTour.component.spec.ts
+++ b/test/onboardingTour.component.spec.ts
@@ -26,6 +26,8 @@ describe('OnboardingTour component', () => {
       props: { pubkeyPrefix: 'test2', onFinish: () => {} },
       global: { plugins: [[Quasar, {}], i18n] },
     })
+    ;(wrapper.vm as any).steps = [{}]
+    ;(wrapper.vm as any).index = 1
     ;(wrapper.vm as any).shownAtLeastOneStep = true
     ;(wrapper.vm as any).finish()
     expect(LocalStorage.getItem('fundstr:onboarding:v3:test2:done')).toBe('1')


### PR DESCRIPTION
## Summary
- Mark onboarding as done only after final step or skip action, with retrying error handler
- Invoke finish with a skip flag when tour is skipped
- Adjust onboarding tour tests to match new completion logic

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68aad6fa363483308df07d871ddf0933