### PR TITLE
Fix onboarding tour missing router setup

### DIFF
--- a/src/composables/useOnboardingTour.ts
+++ b/src/composables/useOnboardingTour.ts
@@ -4,6 +4,7 @@ import { getActivePinia } from 'pinia'
 import OnboardingTour from 'src/components/OnboardingTour.vue'
 import { LOCAL_STORAGE_KEYS } from 'src/constants/localStorageKeys'
 import { i18n } from 'src/boot/i18n'
+import router from 'src/router'
 import type { OnboardingStep } from 'src/types/onboarding'
 
 export function getBrowserId(): string {
@@ -47,5 +48,6 @@ export function startOnboardingTour(
   if (pinia) app.use(pinia)
   app.use(i18n)
   app.use(Quasar, {})
+  app.use(router)
   app.mount(el)
 }


### PR DESCRIPTION
## Summary
- install the main router when spawning the onboarding tour app

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaeee1dbc883309ac79df94d93b71d