### PR TITLE
feat: enable Quasar LocalStorage plugin

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -28,6 +28,6 @@ export default configure(() => ({
   },
   framework: {
     config: {},
-    plugins: ['Notify']
+    plugins: ['Notify', 'LocalStorage']
   }
 }))


### PR DESCRIPTION
## Summary
- include Quasar LocalStorage plugin so $q.localStorage is accessible

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: ERR_PNPM_FETCH_403 Forbidden, missing registry auth)*

------
https://chatgpt.com/codex/tasks/task_e_68aaf231dff08330b65b8add9b1a3452