### PR TITLE
refactor: pass router to onboarding tour

### DIFF
--- a/src/boot/onboardingTour.ts
+++ b/src/boot/onboardingTour.ts
@@ -87,7 +87,7 @@ export default boot(async ({ router }) => {
       firstRunStore.tourStarted = true
       const instance = Symbol('tour')
       activeTour = instance
-      startOnboardingTour(prefix, undefined, () => {
+      startOnboardingTour(prefix, router, undefined, () => {
         if (activeTour === instance) reset()
       })
     }

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -2152,7 +2152,7 @@ export default defineComponent({
       this.$router.push('/wallet').then(() => {
         setTimeout(() => {
           firstRunStore.tourStarted = true
-          startOnboardingTour(prefix, undefined, () => {
+          startOnboardingTour(prefix, this.$router, undefined, () => {
             firstRunStore.tourStarted = false
             firstRunStore.firstRunCompleted = true
           })

--- a/src/composables/useOnboardingTour.ts
+++ b/src/composables/useOnboardingTour.ts
@@ -4,8 +4,8 @@ import { getActivePinia } from 'pinia'
 import OnboardingTour from 'src/components/OnboardingTour.vue'
 import { LOCAL_STORAGE_KEYS } from 'src/constants/localStorageKeys'
 import { i18n } from 'src/boot/i18n'
-import router from 'src/router'
 import type { OnboardingStep } from 'src/types/onboarding'
+import type { Router } from 'vue-router'
 
 export function getBrowserId(): string {
   let id = LocalStorage.getItem<string>(LOCAL_STORAGE_KEYS.FUNDSTR_BROWSER_ID)
@@ -30,6 +30,7 @@ export function resetOnboarding(prefix: string): void {
 
 export function startOnboardingTour(
   prefix: string,
+  passedRouter: Router,
   steps?: OnboardingStep[],
   onFinish?: () => void
 ): void {
@@ -48,6 +49,6 @@ export function startOnboardingTour(
   if (pinia) app.use(pinia)
   app.use(i18n)
   app.use(Quasar, {})
-  app.use(router)
+  app.use(passedRouter)
   app.mount(el)
 }

--- a/src/stores/firstRun.ts
+++ b/src/stores/firstRun.ts
@@ -36,7 +36,7 @@ export const useFirstRunStore = defineStore('firstRun', () => {
       const nostr = useNostrStore();
       const prefix = (nostr.pubkey || getBrowserId()).slice(0, 8);
       tourStarted.value = true;
-      startOnboardingTour(prefix, undefined, () => {
+      startOnboardingTour(prefix, router, undefined, () => {
         tourStarted.value = false;
         firstRunCompleted.value = true;
       });

--- a/test/firstRun.store.spec.ts
+++ b/test/firstRun.store.spec.ts
@@ -13,9 +13,11 @@ describe('firstRun store', () => {
   it('sets completion only on finish', async () => {
     vi.useFakeTimers()
     let finish!: () => void
-    const startSpy = vi.fn((_prefix: string, _steps: any, onFinish?: () => void) => {
-      finish = onFinish!
-    })
+    const startSpy = vi.fn(
+      (_prefix: string, _router: any, _steps: any, onFinish?: () => void) => {
+        finish = onFinish!
+      },
+    )
     vi.doMock('src/composables/useOnboardingTour', () => ({
       startOnboardingTour: startSpy,
       getBrowserId: () => 'browserid',

--- a/test/onboardingBoot.spec.ts
+++ b/test/onboardingBoot.spec.ts
@@ -28,7 +28,12 @@ describe.skip('onboarding boot', () => {
     router.currentRoute.value.path = '/wallet'
     afterEachCbs.forEach(cb => cb())
     await vi.runAllTimersAsync()
-    expect(startSpy).toHaveBeenCalledWith('abcdef12', undefined, expect.any(Function))
+    expect(startSpy).toHaveBeenCalledWith(
+      'abcdef12',
+      router,
+      undefined,
+      expect.any(Function),
+    )
     vi.unmock('src/composables/useOnboardingTour')
     vi.resetModules()
     vi.useRealTimers()

--- a/test/vitest/__tests__/onboardingTour.spec.ts
+++ b/test/vitest/__tests__/onboardingTour.spec.ts
@@ -67,11 +67,17 @@ describe('Onboarding tour', () => {
     target.setAttribute('data-tour', 'nav-dashboard')
     document.body.appendChild(target)
     const bootModule = await import('src/boot/onboardingTour')
-    await bootModule.default({ router: { isReady: () => Promise.resolve() } })
+    const router = { isReady: () => Promise.resolve() }
+    await bootModule.default({ router })
     await nextTick()
     await nextTick()
     vi.runAllTimers()
-    expect(startSpy).toHaveBeenCalledWith(prefix, undefined, expect.any(Function))
+    expect(startSpy).toHaveBeenCalledWith(
+      prefix,
+      router,
+      undefined,
+      expect.any(Function),
+    )
   })
 
   it('skip sets key and prevents subsequent runs', async () => {
@@ -99,7 +105,8 @@ describe('Onboarding tour', () => {
     const onboarding = await import('src/composables/useOnboardingTour')
     const startSpy = vi.spyOn(onboarding, 'startOnboardingTour').mockImplementation(() => {})
     const bootModule = await import('src/boot/onboardingTour')
-    await bootModule.default({ router: { isReady: () => Promise.resolve() } })
+    const router = { isReady: () => Promise.resolve() }
+    await bootModule.default({ router })
     await nextTick()
     await nextTick()
     vi.runAllTimers()
@@ -171,7 +178,12 @@ describe('Onboarding tour', () => {
     await nextTick()
     await vi.runAllTimersAsync()
     await nextTick()
-    expect(startSpy).toHaveBeenCalledWith(prefix, undefined, expect.any(Function))
+    expect(startSpy).toHaveBeenCalledWith(
+      prefix,
+      router,
+      undefined,
+      expect.any(Function),
+    )
     expect(document.body.innerHTML).toContain('OnboardingTour.navDashboard')
   })
 })


### PR DESCRIPTION
## Summary
- Accept Router instance in `startOnboardingTour` and use passed router when mounting
- Pass boot and component routers into the onboarding tour starter
- Update stores, components, and tests for new router argument

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaf6d3e3648330be51cf0dbd851c5c