### PR TITLE
chore: handle onboarding tour errors

### DIFF
--- a/src/boot/onboardingTour.ts
+++ b/src/boot/onboardingTour.ts
@@ -87,9 +87,14 @@ export default boot(async ({ router }) => {
       firstRunStore.tourStarted = true
       const instance = Symbol('tour')
       activeTour = instance
-      startOnboardingTour(prefix, router, undefined, () => {
-        if (activeTour === instance) reset()
-      })
+      try {
+        startOnboardingTour(prefix, router, undefined, () => {
+          if (activeTour === instance) reset()
+        })
+      } catch (err) {
+        console.error('Failed to start onboarding tour', err)
+        reset()
+      }
     }
 
     const reset = () => {


### PR DESCRIPTION
## Summary
- ensure onboarding tour start failure resets state

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaf871975483309e88cd3d4dc59ffb