### PR TITLE
Redirect to wallet after onboarding

### DIFF
--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -107,6 +107,7 @@ async function finishOnboarding() {
   // remember that the welcome flow has been completed on this device
   markWelcomeSeen()
   await nextTick()
+  router.replace('/wallet')
 }
 
 const slides = [


### PR DESCRIPTION
## Summary
- redirect from finished onboarding to wallet route to avoid returning to welcome page

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ab64376b8c8330b7327de0ff24c2de