### PR TITLE
refactor: unify welcome gate guard

### DIFF
--- a/src/boot/welcomeGate.ts
+++ b/src/boot/welcomeGate.ts
@@ -1,17 +1,19 @@
 import { boot } from 'quasar/wrappers'
 import { hasSeenWelcome } from 'src/composables/useWelcomeGate'
+import { useRestoreStore } from 'src/stores/restore'
 
 // router guard to ensure the welcome flow is shown only once per device
 export default boot(({ router }) => {
   router.beforeEach((to, _from, next) => {
     const seen = hasSeenWelcome()
     const isWelcome = to.path.startsWith('/welcome')
+    const restore = useRestoreStore()
 
     const env = import.meta.env.VITE_APP_ENV
     const allow =
       to.query.allow === '1' && (env === 'development' || env === 'staging')
 
-    if (!seen && !isWelcome) {
+    if (!seen && !isWelcome && !restore.restoringState && to.path !== '/restore') {
       next({ path: '/welcome', query: { first: '1' } })
       return
     }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,8 +6,6 @@ import {
   createWebHashHistory,
 } from "vue-router";
 import routes from "./routes";
-import { useRestoreStore } from "src/stores/restore";
-import { hasSeenWelcome } from "src/composables/useWelcomeGate";
 
 /*
  * If not building with SSR mode, you can
@@ -33,20 +31,6 @@ export default route(function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> vueRouterMode
     // quasar.conf.js -> build -> publicPath
     history: createHistory(process.env.VUE_ROUTER_BASE),
-  });
-
-  Router.beforeEach((to, from, next) => {
-    const restore = useRestoreStore();
-    if (
-      to.path !== '/welcome' &&
-      !hasSeenWelcome() &&
-      !restore.restoringState &&
-      to.path !== '/restore'
-    ) {
-      next('/welcome?first=1');
-      return;
-    }
-    next();
   });
 
   return Router;

--- a/test/welcomeGate.guard.spec.ts
+++ b/test/welcomeGate.guard.spec.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+
+// utility to initialize router with the welcome gate boot plugin
+async function setup({
+  seen = false,
+  restoring = false,
+  env = 'production',
+} = {}) {
+  vi.resetModules()
+  vi.doMock('src/composables/useWelcomeGate', () => ({
+    hasSeenWelcome: () => seen,
+  }))
+  vi.doMock('src/stores/restore', () => ({
+    useRestoreStore: () => ({ restoringState: restoring }),
+  }))
+  vi.stubEnv('VITE_APP_ENV', env)
+
+  const routes = [
+    { path: '/', component: {} },
+    { path: '/wallet', component: {} },
+    { path: '/welcome', component: {} },
+    { path: '/restore', component: {} },
+  ]
+
+  const router = createRouter({ history: createMemoryHistory(), routes })
+  const bootWelcomeGate = (await import('src/boot/welcomeGate')).default
+  await bootWelcomeGate({ router })
+
+  // start router at root
+  await router.push('/')
+  return router
+}
+
+describe('welcome gate router guard', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('redirects to /welcome when onboarding not seen', async () => {
+    const router = await setup()
+    await router.push('/wallet')
+    expect(router.currentRoute.value.fullPath).toBe('/welcome?first=1')
+  })
+
+  it('allows navigation when restoring state', async () => {
+    const router = await setup({ restoring: true })
+    await router.push('/wallet')
+    expect(router.currentRoute.value.fullPath).toBe('/wallet')
+  })
+
+  it('skips redirect for restore page', async () => {
+    const router = await setup()
+    await router.push('/restore')
+    expect(router.currentRoute.value.fullPath).toBe('/restore')
+  })
+
+  it('redirects away from /welcome after completion', async () => {
+    const router = await setup({ seen: true })
+    await router.push('/welcome')
+    expect(router.currentRoute.value.fullPath).toBe('/wallet')
+  })
+
+  it('allows /welcome with allow flag in dev env', async () => {
+    const router = await setup({ seen: true, env: 'development' })
+    await router.push('/welcome?allow=1')
+    expect(router.currentRoute.value.fullPath).toBe('/welcome?allow=1')
+  })
+})
+


### PR DESCRIPTION
## Summary
- consolidate welcome gate router logic into boot file
- remove duplicate guard from router index
- add tests for welcome gate navigation scenarios

## Testing
- `pnpm lint`
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/welcomeGate.guard.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab6542aca08330b9e4cfdae2f76db7