### PR TITLE
feat(about): expand trust grid to four columns

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -194,9 +194,9 @@
         <h2 class="text-3xl md:text-5xl font-bold mb-12 gradient-text">
           Trust Through Transparency
         </h2>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
           <!-- Card 1 -->
-          <details class="interactive-card p-6 text-left">
+          <details class="interactive-card p-6 text-left h-full">
             <summary class="cursor-pointer">
               <q-icon name="code" size="32px" class="mb-4 text-accent" aria-hidden="true" />
               <span class="block font-semibold text-xl mb-2"
@@ -251,7 +251,7 @@
           </details>
 
           <!-- Card 2 -->
-          <details class="interactive-card p-6 text-left">
+          <details class="interactive-card p-6 text-left h-full">
             <summary class="cursor-pointer">
               <q-icon name="vpn_key" size="32px" class="mb-4 text-accent" aria-hidden="true" />
               <span class="block font-semibold text-xl mb-2"
@@ -298,7 +298,7 @@
           </details>
 
           <!-- Card 3 -->
-          <details class="interactive-card p-6 text-left">
+          <details class="interactive-card p-6 text-left h-full">
             <summary class="cursor-pointer">
               <q-icon name="shield" size="32px" class="mb-4 text-accent" aria-hidden="true" />
               <span class="block font-semibold text-xl mb-2"
@@ -361,7 +361,7 @@
           </details>
 
           <!-- Card 4 -->
-          <details class="interactive-card p-6 text-left">
+          <details class="interactive-card p-6 text-left h-full">
             <summary class="cursor-pointer">
               <q-icon name="account_balance_wallet" size="32px" class="mb-4 text-accent" aria-hidden="true" />
               <span class="block font-semibold text-xl mb-2"


### PR DESCRIPTION
## Summary
- expand `#trust` grid to 4 columns on large screens
- stretch all `details` cards to full height for consistent rows

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: ERR_PNPM_FETCH_403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab676a94888330b5888ca3afb645d1