### PR TITLE
Redirect onboarding completion to About page

### DIFF
--- a/src/boot/welcomeGate.ts
+++ b/src/boot/welcomeGate.ts
@@ -19,7 +19,7 @@ export default boot(({ router }) => {
     }
 
     if (seen && isWelcome && !allow) {
-      next('/wallet')
+      next('/about')
       return
     }
 

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -89,7 +89,7 @@ onMounted(() => {
   const allow =
     route.query.allow === '1' && (env === 'development' || env === 'staging')
   if (route.path.startsWith('/welcome') && hasSeenWelcome() && !allow) {
-    router.replace('/wallet')
+    router.replace('/about')
   }
 })
 
@@ -107,7 +107,7 @@ async function finishOnboarding() {
   // remember that the welcome flow has been completed on this device
   markWelcomeSeen()
   await nextTick()
-  router.replace('/wallet')
+  router.replace('/about')
 }
 
 const slides = [

--- a/test/welcomeGate.guard.spec.ts
+++ b/test/welcomeGate.guard.spec.ts
@@ -19,6 +19,7 @@ async function setup({
   const routes = [
     { path: '/', component: {} },
     { path: '/wallet', component: {} },
+    { path: '/about', component: {} },
     { path: '/welcome', component: {} },
     { path: '/restore', component: {} },
   ]
@@ -58,7 +59,7 @@ describe('welcome gate router guard', () => {
   it('redirects away from /welcome after completion', async () => {
     const router = await setup({ seen: true })
     await router.push('/welcome')
-    expect(router.currentRoute.value.fullPath).toBe('/wallet')
+    expect(router.currentRoute.value.fullPath).toBe('/about')
   })
 
   it('allows /welcome with allow flag in dev env', async () => {


### PR DESCRIPTION
## Summary
- Redirect completed welcome flow to the About page
- Update welcome gate to guard against returning to /welcome by routing to /about
- Adjust router guard tests for new About page redirect

## Testing
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/welcomeGate.guard.spec.ts`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d07ff08833093fdc987f96fd5a6