### PR TITLE
feat: add donation prompt and link

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,16 @@
 <template>
   <router-view />
+  <DonationPrompt />
 </template>
 
 <script>
 import { defineComponent } from "vue";
 import { useUiStore } from "src/stores/ui";
+import DonationPrompt from "components/DonationPrompt.vue";
 
-export default defineComponent({
+  export default defineComponent({
   name: "App",
+  components: { DonationPrompt },
   setup() {
     const ui = useUiStore();
     ui.initNetworkWatcher();

--- a/src/components/DonationPrompt.vue
+++ b/src/components/DonationPrompt.vue
@@ -1,0 +1,101 @@
+<template>
+  <q-dialog v-model="visible" persistent>
+    <q-card class="q-pa-md" style="min-width: 300px">
+      <q-card-section class="text-h6">Support Fundstr</q-card-section>
+      <q-card-section>
+        <q-tabs v-model="tab" dense class="text-primary">
+          <q-tab name="lightning" label="Lightning" />
+          <q-tab name="bitcoin" label="Bitcoin" />
+        </q-tabs>
+        <q-separator />
+        <q-tab-panels v-model="tab" animated>
+          <q-tab-panel name="lightning" class="q-pt-md">
+            <div class="text-center q-mb-md">
+              <vue-qrcode :value="lightningQRCode" :options="{ width: 200 }" />
+            </div>
+            <q-input v-model="lightning" readonly dense outlined label="Lightning" />
+          </q-tab-panel>
+          <q-tab-panel name="bitcoin" class="q-pt-md">
+            <div class="text-center q-mb-md">
+              <vue-qrcode :value="bitcoinQRCode" :options="{ width: 200 }" />
+            </div>
+            <q-input v-model="bitcoin" readonly dense outlined label="Bitcoin" />
+          </q-tab-panel>
+        </q-tab-panels>
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat label="Never Ask Again" @click="never" />
+        <q-btn flat label="Remind Me Later" @click="later" />
+        <q-btn color="primary" label="Donate Now" @click="donate" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys'
+
+const visible = ref(false)
+const tab = ref('lightning')
+const lightning = ref(import.meta.env.VITE_DONATION_LIGHTNING || '')
+const bitcoin = ref(import.meta.env.VITE_DONATION_BITCOIN || '')
+const lightningQRCode = ref(lightning.value ? `lightning:${lightning.value}` : '')
+const bitcoinQRCode = ref(bitcoin.value ? `bitcoin:${bitcoin.value}` : '')
+
+const LAUNCH_THRESHOLD = 5
+const DAY_THRESHOLD = 7
+
+const getLaunchCount = () => parseInt(localStorage.getItem(LOCAL_STORAGE_KEYS.DONATION_LAUNCH_COUNT) || '0')
+const setLaunchCount = (v: number) => localStorage.setItem(LOCAL_STORAGE_KEYS.DONATION_LAUNCH_COUNT, v.toString())
+
+onMounted(() => {
+  const optOut = localStorage.getItem(LOCAL_STORAGE_KEYS.DONATION_OPT_OUT) === 'true'
+  if (optOut) return
+
+  const launchCount = getLaunchCount() + 1
+  setLaunchCount(launchCount)
+
+  const lastPrompt = parseInt(localStorage.getItem(LOCAL_STORAGE_KEYS.DONATION_LAST_PROMPT) || '0')
+  const daysSince = (Date.now() - lastPrompt) / (1000 * 60 * 60 * 24)
+
+  if (launchCount >= LAUNCH_THRESHOLD || daysSince >= DAY_THRESHOLD) {
+    visible.value = true
+  }
+})
+
+const donate = () => {
+  if (tab.value === 'lightning' && lightning.value) {
+    window.open(`lightning:${lightning.value}`, '_blank')
+  } else if (tab.value === 'bitcoin' && bitcoin.value) {
+    window.open(`bitcoin:${bitcoin.value}`, '_blank')
+  }
+  localStorage.setItem(LOCAL_STORAGE_KEYS.DONATION_LAST_PROMPT, Date.now().toString())
+  setLaunchCount(0)
+  visible.value = false
+}
+
+const later = () => {
+  localStorage.setItem(LOCAL_STORAGE_KEYS.DONATION_LAST_PROMPT, Date.now().toString())
+  setLaunchCount(0)
+  visible.value = false
+}
+
+const never = () => {
+  localStorage.setItem(LOCAL_STORAGE_KEYS.DONATION_OPT_OUT, 'true')
+  setLaunchCount(0)
+  visible.value = false
+}
+</script>
+
+<script lang="ts">
+export default {
+  name: 'DonationPrompt',
+  components: {
+    VueQrcode: () => import('@chenfengyuan/vue-qrcode')
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -99,4 +99,7 @@ export const LOCAL_STORAGE_KEYS = {
   CREATORPROFILE_RELAYS: "creatorProfile.relays",
   FIRST_RUN_DONE: "fundstr:firstRunDone",
   FUNDSTR_BROWSER_ID: "fundstr:browserId",
+  DONATION_OPT_OUT: "fundstr:donationOptOut",
+  DONATION_LAST_PROMPT: "fundstr:lastDonationPromptTime",
+  DONATION_LAUNCH_COUNT: "fundstr:donationLaunchCount",
 } as const;

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -681,7 +681,8 @@
               label="Install PWA"
             />
             <q-btn
-              href="#"
+              :href="donationLink"
+              target="_blank"
               color="accent"
               outline
               rounded
@@ -798,6 +799,8 @@ const siteOverviewCards: SiteOverviewCard[] = [
     icon: "vpn_key",
   },
 ];
+
+const donationLink = `lightning:${import.meta.env.VITE_DONATION_LIGHTNING || ''}`;
 
 // navigation items for the navigation map
 const navigationItems = useNavigationItems();


### PR DESCRIPTION
## Summary
- add donation modal with Lightning/Bitcoin QR options
- track donation opt-out and last prompt in local storage
- add donation link to About page

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac016ab20c8330a0bcd83829ff89b1