### PR TITLE
Redirect find-creators npub links to creator route

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -328,27 +328,8 @@ onMounted(async () => {
   }
 
   const npub = route.query.npub;
-  if (npub && typeof npub === "string") {
-    const sendViewProfile = () => {
-      try {
-        const decoded = nip19.decode(npub);
-        const hex = typeof decoded.data === "string" ? decoded.data : "";
-        if (hex) {
-          window.postMessage({ type: "viewProfile", pubkey: hex }, "*");
-        }
-      } catch {
-        /* ignore decode errors */
-      }
-    };
-
-    if (iframeEl.value) {
-      const iframe = iframeEl.value;
-      if (iframe.contentWindow?.document.readyState === "complete") {
-        sendViewProfile();
-      } else {
-        iframe.addEventListener("load", sendViewProfile, { once: true });
-      }
-    }
+  if (typeof npub === "string" && npub) {
+    router.push(`/creator/${npub}`);
   }
 });
 

--- a/test/findCreators.redirect.spec.ts
+++ b/test/findCreators.redirect.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createRouter, createMemoryHistory } from "vue-router";
+import { createPinia, setActivePinia } from "pinia";
+import FindCreators from "src/pages/FindCreators.vue";
+
+vi.mock("components/DonateDialog.vue", () => ({ default: { name: "DonateDialog", template: "<div></div>" } }));
+vi.mock("components/SubscribeDialog.vue", () => ({ default: { name: "SubscribeDialog", template: "<div></div>" } }));
+vi.mock("components/SendTokenDialog.vue", () => ({ default: { name: "SendTokenDialog", template: "<div></div>" } }));
+vi.mock("components/MediaPreview.vue", () => ({ default: { name: "MediaPreview", template: "<div></div>" } }));
+vi.mock("stores/sendTokensStore", () => ({ useSendTokensStore: () => ({ clearSendData: vi.fn(), sendData: {}, showSendTokens: false }) }));
+vi.mock("stores/donationPresets", () => ({ useDonationPresetsStore: () => ({ createDonationPreset: vi.fn() }) }));
+vi.mock("stores/creators", () => ({ useCreatorsStore: () => ({ tiersMap: {}, tierFetchError: false, fetchTierDefinitions: vi.fn() }) }));
+vi.mock("stores/nostr", () => ({
+  useNostrStore: () => ({ pubkey: "", initNdkReadOnly: vi.fn().mockResolvedValue(undefined), resolvePubkey: (k: string) => k }),
+  fetchNutzapProfile: vi.fn(),
+  RelayConnectionError: class RelayConnectionError extends Error {},
+}));
+vi.mock("stores/messenger", () => ({ useMessengerStore: () => ({ started: false, startChat: vi.fn(), ensureChatSubscription: vi.fn() }) }));
+vi.mock("src/js/notify", () => ({ notifyWarning: vi.fn() }));
+vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (k: string) => k }) }));
+
+describe("FindCreators redirection", () => {
+  it("redirects to creator route when npub query is present", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: "/find-creators", component: FindCreators },
+        { path: "/creator/:npub", component: { template: "<div />" } },
+      ],
+    });
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    router.push("/find-creators?npub=testnpub");
+    await router.isReady();
+    mount(FindCreators, {
+      global: {
+        plugins: [router, pinia],
+        stubs: [
+          "QDialog",
+          "QCard",
+          "QCardSection",
+          "QCardActions",
+          "QBtn",
+          "QSeparator",
+        ],
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(router.currentRoute.value.path).toBe("/creator/testnpub");
+  });
+});
+


### PR DESCRIPTION
## Summary
- Redirect links like `/find-creators?npub=…` to `/creator/:npub`
- Cover redirection with a unit test

## Testing
- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm exec vitest run test/findCreators.redirect.spec.ts`
- `corepack pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68ac17183a048330856659c6323a2f11