### PR TITLE
feat: add profile share links

### DIFF
--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -43,6 +43,14 @@
             >Logout</q-btn
           >
         </div>
+        <div class="q-mb-md">
+          <div class="text-subtitle1 q-mb-sm">Share your profile</div>
+          <q-input :model-value="profileUrl" readonly dense>
+            <template #append>
+              <q-btn flat icon="content_copy" @click="copy(profileUrl)" />
+            </template>
+          </q-input>
+        </div>
         <q-splitter v-if="!isMobile" v-model="splitterModel">
           <template #before>
             <q-card class="section-card">
@@ -131,7 +139,9 @@
 <script setup lang="ts">
 import Draggable from "vuedraggable";
 
+import { computed } from "vue";
 import { useCreatorHub } from "src/composables/useCreatorHub";
+import { useClipboard } from "src/composables/useClipboard";
 import CreatorProfileForm from "components/CreatorProfileForm.vue";
 import TierItem from "components/TierItem.vue";
 import AddTierDialog from "components/AddTierDialog.vue";
@@ -161,6 +171,11 @@ const {
   refreshTiers,
   performDelete,
 } = useCreatorHub();
+
+const { copy } = useClipboard();
+const profileUrl = computed(
+  () => `${window.location.origin}/#/creator/${npub.value}`,
+);
 </script>
 
 <style lang="scss" src="../css/creator-hub.scss" scoped></style>

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -12,8 +12,9 @@
             $t("CreatorHub.profile.back")
           }}</q-btn>
         </div>
-        <div class="text-h5 q-mb-md">
-          {{ profile.display_name || creatorNpub }}
+        <div class="text-h5 q-mb-md row items-center q-gutter-x-sm">
+          <div>{{ profile.display_name || creatorNpub }}</div>
+          <q-btn flat dense icon="content_copy" @click="copy(profileUrl)" />
         </div>
         <div v-if="profile.picture" class="q-mb-md">
           <img :src="profile.picture" style="max-width: 150px" />
@@ -119,6 +120,7 @@ import { useI18n } from "vue-i18n";
 import PaywalledContent from "components/PaywalledContent.vue";
 import MediaPreview from "components/MediaPreview.vue";
 import { isTrustedUrl } from "src/utils/sanitize-url";
+import { useClipboard } from "src/composables/useClipboard";
 
 export default defineComponent({
   name: "PublicCreatorProfilePage",
@@ -141,6 +143,7 @@ export default defineComponent({
     const priceStore = usePriceStore();
     const uiStore = useUiStore();
     const { t } = useI18n();
+    const { copy } = useClipboard();
     const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
     const profile = ref<any>({});
     const tiers = computed(() => creators.tiersMap[creatorHex] || []);
@@ -229,6 +232,10 @@ export default defineComponent({
       return t.price_sats ?? t.price ?? 0;
     }
 
+    const profileUrl = computed(
+      () => `${window.location.origin}/#/creator/${creatorNpub}`,
+    );
+
     return {
       creatorNpub,
       creatorHex,
@@ -247,6 +254,8 @@ export default defineComponent({
       getPrice,
       openSubscribe,
       confirmSubscribe,
+      copy,
+      profileUrl,
     };
   },
 });


### PR DESCRIPTION
## Summary
- let creators copy a shareable profile link from the Creator Hub
- add copy button in public profile header for easy sharing

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac18eee4e48330a4753bdee63e991a