### PR TITLE
fix: stop auto opening add mint dialog

### DIFF
--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -28,7 +28,6 @@ import { useI18n } from "vue-i18n";
 import { maybeRepublishNutzapProfile } from "./creatorHub";
 import { useCreatorProfileStore } from "./creatorProfile";
 import { i18n } from "src/boot/i18n";
-import { useFirstRunStore } from "./firstRun";
 
 export type Mint = {
   url: string;
@@ -149,13 +148,9 @@ export const useMintsStore = defineStore("mints", {
       }
     };
 
-    const firstRunStore = useFirstRunStore();
     if (!isValidUrl(activeMintUrl.value)) {
       activeMintUrl.value = "";
       uiStoreGlobal.setTab("mints");
-      if (!firstRunStore.suppressModals) {
-        showAddMintDialog.value = true;
-      }
     }
 
     return {


### PR DESCRIPTION
## Summary
- avoid showing Add Mint dialog automatically when no active mint is set

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac79c621bc83308af85addb8d33f91