### PR TITLE
fix donation prompt initial display

### DIFF
--- a/src/components/DonationPrompt.vue
+++ b/src/components/DonationPrompt.vue
@@ -56,7 +56,10 @@ onMounted(() => {
   const launchCount = getLaunchCount() + 1
   setLaunchCount(launchCount)
 
-  const lastPrompt = parseInt(localStorage.getItem(LOCAL_STORAGE_KEYS.DONATION_LAST_PROMPT) || '0')
+  const lastPrompt = parseInt(
+    localStorage.getItem(LOCAL_STORAGE_KEYS.DONATION_LAST_PROMPT) ||
+      Date.now().toString()
+  )
   const daysSince = (Date.now() - lastPrompt) / (1000 * 60 * 60 * 24)
 
   if (launchCount >= LAUNCH_THRESHOLD || daysSince >= DAY_THRESHOLD) {

--- a/test/vitest/__tests__/donationPrompt.spec.ts
+++ b/test/vitest/__tests__/donationPrompt.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import DonationPrompt from '../../../src/components/DonationPrompt.vue'
+import { LOCAL_STORAGE_KEYS } from '../../../src/constants/localStorageKeys'
+
+const mountComponent = () =>
+  mount(DonationPrompt, {
+    global: {
+      stubs: {
+        QDialog: { template: '<div><slot /></div>' },
+        QCard: { template: '<div><slot /></div>' },
+        QCardSection: { template: '<div><slot /></div>' },
+        QTabs: { template: '<div><slot /></div>' },
+        QTab: { template: '<div><slot /></div>' },
+        QSeparator: { template: '<div></div>' },
+        QTabPanels: { template: '<div><slot /></div>' },
+        QTabPanel: { template: '<div><slot /></div>' },
+        QInput: { template: '<input />', props: ['modelValue'] },
+        QCardActions: { template: '<div><slot /></div>' },
+        QBtn: { template: '<button><slot /></button>' },
+        VueQrcode: { template: '<div />' }
+      }
+    }
+  })
+
+describe('DonationPrompt', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('is hidden for first-time users', () => {
+    const wrapper = mountComponent()
+    expect(wrapper.vm.visible).toBe(false)
+  })
+
+  it('shows when thresholds are met', () => {
+    localStorage.setItem(
+      LOCAL_STORAGE_KEYS.DONATION_LAST_PROMPT,
+      (Date.now() - 8 * 24 * 60 * 60 * 1000).toString()
+    )
+    localStorage.setItem(LOCAL_STORAGE_KEYS.DONATION_LAUNCH_COUNT, '4')
+    const wrapper = mountComponent()
+    expect(wrapper.vm.visible).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- avoid showing donation prompt on first launch by defaulting last prompt timestamp to current time
- add unit test for donation prompt thresholds

## Testing
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/vitest/__tests__/donationPrompt.spec.ts`
- `pnpm run build`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac7bfcded88330b17c66fad86162cf