### PR TITLE
feat: handle missing donation addresses

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,4 @@
 VITE_APP_ENV=production
 VITE_API_BASE=https://api.fundstr.me
+VITE_DONATION_LIGHTNING=lightning_address_here
+VITE_DONATION_BITCOIN=bitcoin_address_here

--- a/.env.staging
+++ b/.env.staging
@@ -1,2 +1,4 @@
 VITE_APP_ENV=staging
 VITE_API_BASE=https://api-staging.fundstr.me
+VITE_DONATION_LIGHTNING=lightning_address_here
+VITE_DONATION_BITCOIN=bitcoin_address_here

--- a/src/components/DonationPrompt.vue
+++ b/src/components/DonationPrompt.vue
@@ -3,55 +3,78 @@
     <q-card class="q-pa-md" style="min-width: 300px">
       <q-card-section class="text-h6">Support Fundstr</q-card-section>
       <q-card-section>
-        <q-tabs v-model="tab" dense class="text-primary">
-          <q-tab name="lightning" label="Lightning" />
-          <q-tab name="bitcoin" label="Bitcoin" />
-        </q-tabs>
-        <q-separator />
-        <q-tab-panels v-model="tab" animated>
-          <q-tab-panel name="lightning" class="q-pt-md">
-            <div class="text-center q-mb-md">
-              <vue-qrcode :value="lightningQRCode" :options="{ width: 200 }" />
-            </div>
-            <q-input :model-value="lightning" readonly dense outlined label="Lightning">
-              <template #append>
-                <q-btn
-                  flat
-                  icon="content_copy"
-                  @click="copy(lightning)"
-                  aria-label="Copy Lightning address"
-                />
-              </template>
-            </q-input>
-          </q-tab-panel>
-          <q-tab-panel name="bitcoin" class="q-pt-md">
-            <div class="text-center q-mb-md">
-              <vue-qrcode :value="bitcoinQRCode" :options="{ width: 200 }" />
-            </div>
-            <q-input :model-value="bitcoin" readonly dense outlined label="Bitcoin">
-              <template #append>
-                <q-btn
-                  flat
-                  icon="content_copy"
-                  @click="copy(bitcoin)"
-                  aria-label="Copy Bitcoin address"
-                />
-              </template>
-            </q-input>
-          </q-tab-panel>
-        </q-tab-panels>
+        <div v-if="noAddress" class="text-2">
+          Donation address not configured.
+        </div>
+        <template v-else>
+          <q-tabs v-model="tab" dense class="text-primary">
+            <q-tab name="lightning" label="Lightning" />
+            <q-tab name="bitcoin" label="Bitcoin" />
+          </q-tabs>
+          <q-separator />
+          <q-tab-panels v-model="tab" animated>
+            <q-tab-panel name="lightning" class="q-pt-md">
+              <div v-if="lightning">
+                <div class="text-center q-mb-md">
+                  <vue-qrcode :value="lightningQRCode" :options="{ width: 200 }" />
+                </div>
+                <q-input
+                  :model-value="lightning"
+                  readonly
+                  dense
+                  outlined
+                  label="Lightning"
+                >
+                  <template #append>
+                    <q-btn
+                      flat
+                      icon="content_copy"
+                      @click="copy(lightning)"
+                      aria-label="Copy Lightning address"
+                    />
+                  </template>
+                </q-input>
+              </div>
+              <div v-else class="text-2">No Lightning address configured.</div>
+            </q-tab-panel>
+            <q-tab-panel name="bitcoin" class="q-pt-md">
+              <div v-if="bitcoin">
+                <div class="text-center q-mb-md">
+                  <vue-qrcode :value="bitcoinQRCode" :options="{ width: 200 }" />
+                </div>
+                <q-input
+                  :model-value="bitcoin"
+                  readonly
+                  dense
+                  outlined
+                  label="Bitcoin"
+                >
+                  <template #append>
+                    <q-btn
+                      flat
+                      icon="content_copy"
+                      @click="copy(bitcoin)"
+                      aria-label="Copy Bitcoin address"
+                    />
+                  </template>
+                </q-input>
+              </div>
+              <div v-else class="text-2">No Bitcoin address configured.</div>
+            </q-tab-panel>
+          </q-tab-panels>
+        </template>
       </q-card-section>
       <q-card-actions align="right">
         <q-btn flat label="Never Ask Again" @click="never" />
         <q-btn flat label="Remind Me Later" @click="later" />
-        <q-btn color="primary" label="Donate Now" @click="donate" />
+        <q-btn color="primary" label="Donate Now" @click="donate" :disable="noAddress" />
       </q-card-actions>
     </q-card>
   </q-dialog>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, defineAsyncComponent } from 'vue'
+import { ref, onMounted, defineAsyncComponent, computed } from 'vue'
 import { copyToClipboard } from 'quasar'
 import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys'
 
@@ -63,6 +86,11 @@ const lightning = ref(import.meta.env.VITE_DONATION_LIGHTNING || '')
 const bitcoin = ref(import.meta.env.VITE_DONATION_BITCOIN || '')
 const lightningQRCode = ref(lightning.value ? `lightning:${lightning.value}` : '')
 const bitcoinQRCode = ref(bitcoin.value ? `bitcoin:${bitcoin.value}` : '')
+const noAddress = computed(() => !lightning.value && !bitcoin.value)
+
+defineOptions({
+  name: 'DonationPrompt'
+})
 
 const LAUNCH_THRESHOLD = 5
 const DAY_THRESHOLD = 7
@@ -116,15 +144,6 @@ async function copy(text: string) {
     await copyToClipboard(text)
   } catch {
     // ignore copy errors
-  }
-}
-</script>
-
-<script lang="ts">
-export default {
-  name: 'DonationPrompt',
-  components: {
-    VueQrcode
   }
 }
 </script>

--- a/test/vitest/__tests__/donationPrompt.spec.ts
+++ b/test/vitest/__tests__/donationPrompt.spec.ts
@@ -17,7 +17,11 @@ const mountComponent = () =>
         QTabPanel: { template: '<div><slot /></div>' },
         QInput: { template: '<input />', props: ['modelValue'] },
         QCardActions: { template: '<div><slot /></div>' },
-        QBtn: { template: '<button><slot /></button>' },
+        QBtn: {
+          props: ['label', 'disable'],
+          template: '<button :disabled="disable">{{ label }}</button>'
+        },
+        QBanner: { template: '<div><slot /></div>' },
         VueQrcode: { template: '<div />' }
       }
     }
@@ -41,5 +45,14 @@ describe('DonationPrompt', () => {
     localStorage.setItem(LOCAL_STORAGE_KEYS.DONATION_LAUNCH_COUNT, '4')
     const wrapper = mountComponent()
     expect(wrapper.vm.visible).toBe(true)
+  })
+
+  it('disables donate button when no address is configured', () => {
+    const wrapper = mountComponent()
+    const donateBtn = wrapper
+      .findAll('button')
+      .find((b) => b.text() === 'Donate Now')
+    expect(donateBtn?.attributes('disabled')).toBeDefined()
+    expect(wrapper.text()).toContain('Donation address not configured')
   })
 })


### PR DESCRIPTION
## Summary
- Disable Donate Now when no donation addresses and show helpful messages
- Provide placeholders for lightning/bitcoin donation env vars
- Test donation prompt disables donate button when address missing

## Testing
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/vitest/__tests__/donationPrompt.spec.ts`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac80f82d388330b448900c35a2d73b