### PR TITLE
refactor: rely on nostr pubkey in creator hub

### DIFF
--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -51,7 +51,7 @@ export function useCreatorHub() {
   const splitterModel = ref(50);
   const tab = ref<"profile" | "tiers">("profile");
 
-  const loggedIn = computed(() => !!store.loggedInNpub);
+  const loggedIn = computed(() => !!nostr.pubkey);
   const tierList = computed<Tier[]>(() => store.getTierArray());
   const draggableTiers = ref<Tier[]>([]);
   const deleteDialog = ref(false);
@@ -60,7 +60,7 @@ export function useCreatorHub() {
   const currentTier = ref<Partial<Tier>>({});
   const publishing = ref(false);
   const npub = computed(() =>
-    store.loggedInNpub ? nip19.npubEncode(store.loggedInNpub) : "",
+    nostr.pubkey ? nip19.npubEncode(nostr.pubkey) : "",
   );
 
   watch(
@@ -89,9 +89,9 @@ export function useCreatorHub() {
   }
 
   async function initPage() {
-    if (!store.loggedInNpub) return;
+    if (!nostr.pubkey) return;
     await nostr.initSignerIfNotSet();
-    const p = await nostr.getProfile(store.loggedInNpub);
+    const p = await nostr.getProfile(nostr.pubkey);
     if (p) profileStore.setProfile(p);
     if (profileStore.mints.length) {
       profileMints.value = [...profileStore.mints];
@@ -101,7 +101,7 @@ export function useCreatorHub() {
     }
     let existing = null;
     try {
-      existing = await fetchNutzapProfile(store.loggedInNpub);
+      existing = await fetchNutzapProfile(nostr.pubkey);
     } catch (e: any) {
       if (e instanceof RelayConnectionError) {
         notifyError("Unable to connect to Nostr relays");
@@ -123,7 +123,7 @@ export function useCreatorHub() {
       if (!profileStore.mints.length && mintsStore.mints.length > 0)
         profileMints.value = mintsStore.mints.map((m) => m.url);
     }
-    await store.loadTiersFromNostr(store.loggedInNpub);
+    await store.loadTiersFromNostr(nostr.pubkey);
     profileStore.markClean();
   }
 
@@ -225,7 +225,7 @@ export function useCreatorHub() {
   }
 
   onMounted(() => {
-    if (store.loggedInNpub) initPage();
+    if (nostr.pubkey) initPage();
   });
 
   return {

--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -88,7 +88,6 @@ export const LOCAL_STORAGE_KEYS = {
   CASHU_WORKER_INVOICES_LASTPENDINGINVOICECHECK:
     "cashu.worker.invoices.lastPendingInvoiceCheck",
   CASHU_WORKER_INVOICES_QUOTESQUEUE: "cashu.worker.invoices.quotesQueue",
-  CREATORHUB_LOGGEDINNPUB: "creatorHub.loggedInNpub",
   CREATORHUB_TIERORDER: "creatorHub.tierOrder",
   CREATORHUB_TIERS: "creatorHub.tiers",
   CREATORPROFILE_ABOUT: "creatorProfile.about",

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -67,7 +67,6 @@ export async function maybeRepublishNutzapProfile() {
 
 export const useCreatorHubStore = defineStore("creatorHub", {
   state: () => ({
-    loggedInNpub: useLocalStorage<string>("creatorHub.loggedInNpub", ""),
     tiers: useLocalStorage<Record<string, Tier>>("creatorHub.tiers", {}),
     tierOrder: useLocalStorage<string[]>("creatorHub.tierOrder", []),
   }),
@@ -75,15 +74,14 @@ export const useCreatorHubStore = defineStore("creatorHub", {
     async loginWithNip07() {
       const nostr = useNostrStore();
       await nostr.initNip07Signer();
-      this.loggedInNpub = nostr.pubkey;
     },
     async loginWithNsec(nsec: string) {
       const nostr = useNostrStore();
       await nostr.initPrivateKeySigner(nsec);
-      this.loggedInNpub = nostr.pubkey;
     },
     logout() {
-      this.loggedInNpub = "";
+      const nostr = useNostrStore();
+      nostr.setPubkey("");
     },
     async updateProfile(profile: any) {
       const nostr = useNostrStore();
@@ -169,7 +167,7 @@ export const useCreatorHubStore = defineStore("creatorHub", {
     async loadTiersFromNostr(pubkey?: string) {
       const nostr = useNostrStore();
       await nostr.initNdkReadOnly();
-      const author = pubkey || this.loggedInNpub || nostr.pubkey;
+      const author = pubkey || nostr.pubkey;
       if (!author) return;
       const filter: NDKFilter = {
         kinds: [TIER_DEFINITIONS_KIND as unknown as NDKKind],

--- a/test/vitest/__tests__/creatorHub-layout.spec.ts
+++ b/test/vitest/__tests__/creatorHub-layout.spec.ts
@@ -7,7 +7,6 @@ vi.spyOn(quasar, "useQuasar").mockReturnValue({
 });
 
 const creatorHubStoreMock = {
-  loggedInNpub: "pubkey",
   tiers: {},
   tierOrder: [] as string[],
   getTierArray: () => [] as any[],
@@ -28,6 +27,7 @@ vi.mock("../../../src/stores/creatorHub", () => ({
 }));
 
 const nostrStoreMock = {
+  pubkey: "pubkey",
   initSignerIfNotSet: vi.fn(),
   getProfile: vi.fn(async () => null),
   relays: [] as string[],


### PR DESCRIPTION
## Summary
- remove creator hub `loggedInNpub` state and use `useNostrStore().pubkey`
- drop `CREATORHUB_LOGGEDINNPUB` localStorage key
- update creator hub composable and test mocks to derive login status from nostr store

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac8adb47b48330beafb8e34b134221