### PR TITLE
refactor: use surface tokens in CreatorHub and test ThemeToggle

### DIFF
--- a/src/css/creator-hub.scss
+++ b/src/css/creator-hub.scss
@@ -1,6 +1,6 @@
 .section-card {
   padding: 24px;
-  background-color: var(--q-color-grey-9);
+  background-color: var(--surface-2);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   border-radius: 8px;
 }

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -1,7 +1,7 @@
 <template>
-  <q-page class="bg-grey-10 flex justify-center">
+  <q-page class="bg-surface-1 flex justify-center">
     <q-card
-      class="q-pa-lg q-mt-md q-mb-md bg-grey-9 shadow-4"
+      class="q-pa-lg q-mt-md q-mb-md bg-surface-2 shadow-4"
       style="max-width: 1200px; width: 100%"
     >
       <div class="row items-center justify-between q-mb-lg">

--- a/test/vitest/__tests__/theme-toggle.spec.ts
+++ b/test/vitest/__tests__/theme-toggle.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+const dark = {
+  isActive: false,
+  toggle: vi.fn(function () {
+    this.isActive = !this.isActive;
+  }),
+};
+
+const $q = {
+  dark,
+  localStorage: { set: vi.fn() },
+};
+
+vi.mock("quasar", () => ({
+  useQuasar: () => $q,
+  QBtn: { template: '<button @click="$emit(\'click\')"><slot/></button>' },
+}));
+
+import ThemeToggle from "../../../src/components/ThemeToggle.vue";
+
+describe("ThemeToggle", () => {
+  it("toggles dark mode", async () => {
+    const wrapper = mount(ThemeToggle);
+
+    const initialCalls = dark.toggle.mock.calls.length;
+    await wrapper.find("button").trigger("click");
+    expect(dark.toggle.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+});
+


### PR DESCRIPTION
## Summary
- replace gray background classes with surface utility tokens
- update creator hub styles to pull from `--surface-2`
- add unit test verifying ThemeToggle triggers dark mode toggle

## Testing
- `pnpm test`
- `pnpm exec vitest run test/vitest/__tests__/theme-toggle.spec.ts`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca04d19708330bc9b913836454023