### PR TITLE
Inline default relays for find-creators page

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -268,16 +268,14 @@
       <div class="relay-info">Connecting to: <span id="relayList"></span></div>
     </div>
 
-    <script type="module">
-      import { DEFAULT_RELAYS } from "/src/config/relays";
-
-      const FALLBACK_RELAYS = [
-        "wss://relay.damus.io",
-        "wss://relay.primal.net",
-        "wss://relay.snort.social",
-        "wss://nostr.wine",
-        "wss://nos.lol",
-      ];
+      <script type="module">
+        const DEFAULT_RELAYS = [
+          "wss://relay.damus.io",
+          "wss://relay.primal.net",
+          "wss://relay.snort.social",
+          "wss://nostr-pub.wellorder.net",
+          "wss://relay.nostr.band",
+        ];
       // --- Nostr Tools ---
       if (!window.NostrTools) {
         document.getElementById("statusMessage").textContent =
@@ -296,7 +294,7 @@
       } catch {
         storedRelays = [];
       }
-      const RELAYS = Array.from(new Set([...storedRelays, ...FALLBACK_RELAYS]));
+        const RELAYS = Array.from(new Set([...storedRelays, ...DEFAULT_RELAYS]));
       document.getElementById("relayList").textContent = RELAYS.join(", ");
 
       const pool = new SimplePool({ eoseSubTimeout: 8000 });


### PR DESCRIPTION
## Summary
- inline default relay endpoints in find-creators HTML page
- remove unused module import to avoid module-script MIME errors

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run build`
- `node --input-type=module - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68aca2028d6c8330a8e777da269933ef