### PR TITLE
Filter relays before creating pools

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -268,11 +268,12 @@
     </div>
 
       <script type="module">
+        import { filterHealthyRelays } from "../src/utils/relayHealth.ts";
         const DEFAULT_RELAYS = [
           "wss://relay.damus.io",
           "wss://relay.primal.net",
           "wss://relay.snort.social",
-          "wss://nostr-pub.wellorder.net",
+          "wss://nos.lol",
           "wss://relay.nostr.band",
         ];
       // --- Nostr Tools ---
@@ -293,7 +294,16 @@
       } catch {
         storedRelays = [];
       }
-        const RELAYS = Array.from(new Set([...storedRelays, ...DEFAULT_RELAYS]));
+        let RELAYS = Array.from(new Set([...storedRelays, ...DEFAULT_RELAYS])).filter(
+          (r) => r.startsWith("wss://"),
+        );
+        RELAYS = await filterHealthyRelays(RELAYS);
+        if (RELAYS.length === 0) {
+          console.error(
+            "[find-creators] no reachable relays:",
+            [...storedRelays, ...DEFAULT_RELAYS].join(", "),
+          );
+        }
       document.getElementById("relayList").textContent = RELAYS.join(", ");
 
       const pool = new SimplePool({ eoseSubTimeout: 8000 });

--- a/test/vitest/__tests__/nostr.spec.ts
+++ b/test/vitest/__tests__/nostr.spec.ts
@@ -47,12 +47,20 @@ vi.mock("../../../src/js/notify", () => ({
   notifyError,
 }));
 
+let filterHealthyRelaysFn: any;
+vi.mock("../../../src/utils/relayHealth", () => ({
+  filterHealthyRelays: (...args: any[]) => filterHealthyRelaysFn(...args),
+}));
+
 beforeEach(() => {
   encryptMock.mockClear();
   localStorage.clear();
   notifySuccess.mockClear();
   notifyError.mockClear();
   vi.useFakeTimers();
+  filterHealthyRelaysFn = vi.fn(async (r: string[]) =>
+    r.length ? r : ["wss://relay.test"],
+  );
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary
- filter relay URLs and call `filterHealthyRelays` before each `SimplePool`
- restrict relays to `wss://` endpoints and log a single error when none reachable
- update find-creators page to only use responsive Nostr relays

## Testing
- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68aca557c8548330bba4cd5fc444d1aa