### PR TITLE
refactor: use theme tokens for creator hub

### DIFF
--- a/src/css/creator-hub.scss
+++ b/src/css/creator-hub.scss
@@ -2,6 +2,7 @@
   padding: 24px;
   background-color: var(--surface-2);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  border: var(--surface-contrast-border);
   border-radius: 8px;
 }
 
@@ -23,7 +24,7 @@
 
 /* Subtle border helpers */
 .border-subtle {
-  border: var(--border-subtle);
+  border: var(--surface-contrast-border);
 }
 
 /* Rounded card helpers */
@@ -36,13 +37,13 @@
 
 /* Chip variants */
 .chip-outline {
-  border: var(--border-subtle);
+  border: var(--surface-contrast-border);
   background-color: transparent;
-  color: var(--q-color-grey-8);
+  color: var(--text-2);
 }
 .chip-solid {
-  background-color: var(--q-color-grey-8);
-  color: #fff;
+  background-color: var(--chip-bg);
+  color: var(--chip-text);
   border: none;
 }
 .chip-filled {


### PR DESCRIPTION
## Summary
- replace grey text and chip styles with theme tokens
- add surface contrast borders for cards and chip outlines
- ensure chip colors meet WCAG AA contrast in light and dark modes

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aca792d73883308297a12e45bc7b50