### PR TITLE
docs: document sharing creator links

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,16 @@ wss://relay.nostr.band/
 wss://relay.snort.social/
 ```
 
+### Sharing Creator Links
+
+You can share direct links to creator profiles by appending an `npub` query parameter to the search page:
+
+```
+/#/find-creators?npub=<npub>
+```
+
+When opened, Fundstr automatically loads the profile for the provided `npub`. If the visitor hasn't logged in or set up a wallet yet, the app will prompt them to authenticate and choose a wallet before they can send support.
+
 ### Verify Nutzap Profile
 
 After publishing your `kind:10019` Nutzap profile, you can confirm that relays


### PR DESCRIPTION
## Summary
- document how to share `/find-creators` links with an `npub` parameter

## Testing
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb47224a48330875909e84ff46267