### PR TITLE
Handle single mint URL in creator profile

### DIFF
--- a/src/components/CreatorProfileForm.vue
+++ b/src/components/CreatorProfileForm.vue
@@ -70,16 +70,13 @@
     </div>
     <q-select
       v-model="profileMintsLocal"
-      multiple
       use-input
-      use-chips
       hide-dropdown-icon
-      new-value-mode="add-unique"
       :options="mintOptions"
       dense
       outlined
       persistent-hint
-      :rules="[urlListRule]"
+      :rules="[urlRule]"
       :hint="$t('creatorHub.urlListHint')"
       :label="$t('creatorHub.trustedMints')"
     />
@@ -180,7 +177,7 @@ const profilePubLocal = computed({
 });
 const profileMintsLocal = computed({
   get: () => profileMints.value,
-  set: (val: string[]) => (profileMints.value = val),
+  set: (val: string) => (profileMints.value = val),
 });
 const profileRelaysLocal = computed({
   get: () => profileRelays.value,

--- a/src/components/ProfilePanel.vue
+++ b/src/components/ProfilePanel.vue
@@ -50,7 +50,7 @@ async function publishProfile() {
         about: about.value,
       },
       p2pkPub: profilePub.value || "",
-      mints: profileMints.value,
+      mints: profileMints.value ? [profileMints.value] : [],
       relays: profileRelays.value,
     });
     notifySuccess("Profile updated");

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -2066,7 +2066,7 @@ export default defineComponent({
             about: profileStore.about,
           },
           p2pkPub: this.firstKey.publicKey,
-          mints: profileStore.mints,
+          mints: profileStore.mints ? [profileStore.mints] : [],
           relays: profileStore.relays,
         });
         notifySuccess("Profile published");

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -226,8 +226,8 @@ export default defineComponent({
         profileStore.setProfile(p);
         profileStore.markClean();
       }
-      if (profileStore.mints.length) {
-        profileMints.value = [...profileStore.mints];
+      if (profileStore.mints) {
+        profileMints.value = profileStore.mints;
       }
       if (profileStore.relays.length) {
         profileRelays.value = [...profileStore.relays];
@@ -257,7 +257,7 @@ export default defineComponent({
         await publishDiscoveryProfile({
           profile: profileData.value,
           p2pkPub: profilePub.value,
-          mints: profileMints.value,
+          mints: profileMints.value ? [profileMints.value] : [],
           relays: profileRelays.value,
         });
         notifySuccess("Profile updated");

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -46,20 +46,21 @@ export async function maybeRepublishNutzapProfile() {
     throw e;
   }
   const profileStore = useCreatorProfileStore();
-  const desiredMints = profileStore.mints.sort().join(",");
+  const desiredMint = profileStore.mints;
   const desiredP2PK = useP2PKStore().firstKey?.publicKey;
 
   if (!desiredP2PK) return;
 
+  const currentMint = current?.trustedMints?.[0] || "";
   const hasDiff =
     !current ||
     current.p2pkPubkey !== desiredP2PK ||
-    current.trustedMints.sort().join(",") !== desiredMints;
+    currentMint !== desiredMint;
 
   if (hasDiff) {
     await publishNutzapProfile({
       p2pkPub: desiredP2PK,
-      mints: [...profileStore.mints],
+      mints: desiredMint ? [desiredMint] : [],
       relays: [...profileStore.relays],
     });
   }
@@ -88,7 +89,7 @@ export const useCreatorHubStore = defineStore("creatorHub", {
         picture: "",
         about: "",
         pubkey: "",
-        mints: [],
+        mints: "",
         relays: [],
       });
       profileStore.markClean();

--- a/src/stores/creatorProfile.ts
+++ b/src/stores/creatorProfile.ts
@@ -6,7 +6,7 @@ export interface CreatorProfile {
   picture: string;
   about: string;
   pubkey: string;
-  mints: string[];
+  mints: string;
   relays: string[];
 }
 
@@ -27,7 +27,7 @@ export const useCreatorProfileStore = defineStore("creatorProfile", {
     picture: useLocalStorage<string>("creatorProfile.picture", ""),
     about: useLocalStorage<string>("creatorProfile.about", ""),
     pubkey: useLocalStorage<string>("creatorProfile.pubkey", ""),
-    mints: useLocalStorage<string[]>("creatorProfile.mints", []),
+    mints: useLocalStorage<string>("creatorProfile.mints", ""),
     relays: useLocalStorage<string[]>("creatorProfile.relays", []),
     _clean: "",
   }),
@@ -50,7 +50,7 @@ export const useCreatorProfileStore = defineStore("creatorProfile", {
       if (data.picture !== undefined) this.picture = data.picture;
       if (data.about !== undefined) this.about = data.about;
       if (data.pubkey !== undefined) this.pubkey = data.pubkey;
-      if (data.mints !== undefined) this.mints = [...data.mints];
+      if (data.mints !== undefined) this.mints = data.mints;
       if (data.relays !== undefined) this.relays = [...data.relays];
     },
     markClean() {

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -358,8 +358,8 @@ export const useMintsStore = defineStore("mints", {
           await notifySuccess(this.t("wallet.mint.notifications.added"));
         }
         const profileStore = useCreatorProfileStore();
-        if (!profileStore.mints.includes(url)) {
-          profileStore.mints.push(url);
+        if (!profileStore.mints) {
+          profileStore.mints = url;
         }
         await maybeRepublishNutzapProfile();
         return mintToAdd;
@@ -563,7 +563,9 @@ export const useMintsStore = defineStore("mints", {
         await this.activateMint(this.mints[0], false);
       }
       const profileStore = useCreatorProfileStore();
-      profileStore.mints = profileStore.mints.filter((m) => m !== url);
+      if (profileStore.mints === url) {
+        profileStore.mints = "";
+      }
       notifySuccess(this.t("wallet.mint.notifications.removed"));
     },
     assertMintError: function (response: { error?: any }, verbose = true) {

--- a/test/vitest/__tests__/creatorHub-layout.spec.ts
+++ b/test/vitest/__tests__/creatorHub-layout.spec.ts
@@ -58,7 +58,7 @@ const profileStoreMock = {
   picture: "",
   about: "",
   pubkey: "",
-  mints: [] as string[],
+  mints: "",
   relays: [] as string[],
   setProfile: vi.fn(),
   markClean: vi.fn(),

--- a/test/vitest/__tests__/creatorHub.spec.ts
+++ b/test/vitest/__tests__/creatorHub.spec.ts
@@ -5,6 +5,7 @@ import {
 } from "../../../src/stores/creatorHub";
 import { useP2PKStore } from "../../../src/stores/p2pk";
 import { useMintsStore } from "../../../src/stores/mints";
+import { useCreatorProfileStore } from "../../../src/stores/creatorProfile";
 
 const notifySuccess = vi.fn();
 const notifyError = vi.fn();
@@ -165,10 +166,12 @@ describe("maybeRepublishNutzapProfile", () => {
     ];
     const mints = useMintsStore();
     mints.mints = [{ url: "mint1" }, { url: "mint2" }] as any;
+    const profileStore = useCreatorProfileStore();
+    profileStore.mints = "mint1";
 
     fetchNutzapProfileMock = vi.fn(async () => ({
       p2pkPubkey: "other",
-      trustedMints: ["mint1"],
+      trustedMints: ["mint2"],
       relays: [],
       hexPub: "pub",
     }));
@@ -177,7 +180,7 @@ describe("maybeRepublishNutzapProfile", () => {
 
     expect(publishNutzapProfileMock).toHaveBeenCalledWith({
       p2pkPub: "pk",
-      mints: ["mint1", "mint2"],
+      mints: ["mint1"],
       relays: nostrStoreMock.relays,
     });
   });

--- a/test/vitest/__tests__/creatorProfileStore.spec.ts
+++ b/test/vitest/__tests__/creatorProfileStore.spec.ts
@@ -13,7 +13,7 @@ describe("CreatorProfileStore isDirty", () => {
       picture: "pic",
       about: "about",
       pubkey: "pub",
-      mints: ["m1"],
+      mints: "m1",
       relays: ["r1"],
     });
     store.markClean();
@@ -35,7 +35,7 @@ describe("CreatorProfileStore isDirty", () => {
     expect(store.isDirty).toBe(true);
     store.markClean();
 
-    store.mints = ["m1", "m2"];
+    store.mints = "m2";
     expect(store.isDirty).toBe(true);
     store.markClean();
 


### PR DESCRIPTION
## Summary
- simplify mint selection to a single URL
- store creator profile mint as a string and update related logic
- adjust publishing and scanning to work with single mint value

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68acb43a513c83308565de1455618613