### PR TITLE
refactor: move welcome gate guard to router

### DIFF
--- a/src/boot/welcomeGate.ts
+++ b/src/boot/welcomeGate.ts
@@ -1,39 +1,4 @@
 import { boot } from 'quasar/wrappers'
-import { hasSeenWelcome } from 'src/composables/useWelcomeGate'
-import { useRestoreStore } from 'src/stores/restore'
 
-// router guard to ensure the welcome flow is shown only once per device
-export default boot(({ router }) => {
-  router.beforeEach((to, _from, next) => {
-    const seen = hasSeenWelcome()
-    const isWelcome = to.path.startsWith('/welcome')
-    const isPublicProfile =
-      to.matched.some(r => r.name === 'PublicCreatorProfile') ||
-      to.path.startsWith('/creator/')
-    const isPublicDiscover = to.path === '/find-creators'
-    const restore = useRestoreStore()
-
-    const env = import.meta.env.VITE_APP_ENV
-    const allow =
-      to.query.allow === '1' && (env === 'development' || env === 'staging')
-
-    if (
-      !seen &&
-      !isWelcome &&
-      !restore.restoringState &&
-      to.path !== '/restore' &&
-      !isPublicProfile &&
-      !isPublicDiscover
-    ) {
-      next({ path: '/welcome', query: { first: '1' } })
-      return
-    }
-
-    if (seen && isWelcome && !allow) {
-      next('/about')
-      return
-    }
-
-    next()
-  })
-})
+// Guard is now configured within the router (src/router/index.js)
+export default boot(() => {})

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,8 @@ import {
   createWebHashHistory,
 } from "vue-router";
 import routes from "./routes";
+import { hasSeenWelcome } from "src/composables/useWelcomeGate";
+import { useRestoreStore } from "src/stores/restore";
 
 /*
  * If not building with SSR mode, you can
@@ -31,6 +33,39 @@ export default route(function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> vueRouterMode
     // quasar.conf.js -> build -> publicPath
     history: createHistory(process.env.VUE_ROUTER_BASE),
+  });
+
+  Router.beforeEach((to, _from, next) => {
+    const seen = hasSeenWelcome();
+    const isWelcome = to.path.startsWith("/welcome");
+    const isPublicProfile =
+      to.matched.some((r) => r.name === "PublicCreatorProfile") ||
+      to.path.startsWith("/creator/");
+    const isPublicDiscover = to.path === "/find-creators";
+    const restore = useRestoreStore();
+
+    const env = import.meta.env.VITE_APP_ENV;
+    const allow =
+      to.query.allow === "1" && (env === "development" || env === "staging");
+
+    if (
+      !seen &&
+      !isWelcome &&
+      !restore.restoringState &&
+      to.path !== "/restore" &&
+      !isPublicProfile &&
+      !isPublicDiscover
+    ) {
+      next({ path: "/welcome", query: { first: "1" } });
+      return;
+    }
+
+    if (seen && isWelcome && !allow) {
+      next("/about");
+      return;
+    }
+
+    next();
   });
 
   return Router;

--- a/test/welcomeGate.guard.spec.ts
+++ b/test/welcomeGate.guard.spec.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { createMemoryHistory, createRouter } from 'vue-router'
 
-// utility to initialize router with the welcome gate boot plugin
+// utility to initialize router with the welcome gate guard
 async function setup({
   seen = false,
   restoring = false,
@@ -24,9 +23,13 @@ async function setup({
     { path: '/restore', component: {} },
   ]
 
-  const router = createRouter({ history: createMemoryHistory(), routes })
-  const bootWelcomeGate = (await import('src/boot/welcomeGate')).default
-  await bootWelcomeGate({ router })
+  vi.doMock('src/router/routes', () => ({ default: routes }))
+
+  const oldServer = process.env.SERVER
+  process.env.SERVER = '1'
+  const createAppRouter = (await import('src/router/index.js')).default
+  const router = createAppRouter()
+  process.env.SERVER = oldServer
 
   // start router at root
   await router.push('/')


### PR DESCRIPTION
## Summary
- migrate welcome gate guard into router setup
- stub old welcomeGate boot file
- update tests to use new router guard

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm exec vitest run test/welcomeGate.guard.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ad5dc900908330aa72af72bc7dc4da