### PR TITLE
fix: show tier subscribe button on touch devices

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -377,10 +377,16 @@ onBeforeUnmount(() => {
 }
 
 .tier-card .subscribe-btn {
-  display: none;
+  display: inline-flex;
 }
 
-.tier-card:hover .subscribe-btn {
-  display: inline-flex;
+@media (hover: hover) {
+  .tier-card .subscribe-btn {
+    display: none;
+  }
+
+  .tier-card:hover .subscribe-btn {
+    display: inline-flex;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- always display subscribe button within tier cards
- hide subscribe button unless hovered on devices with hover capability

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad5f8e9d588330b8c8bd1719f50149