### PR TITLE
fix(profile): remove unsupported supporter pubkey binding

### DIFF
--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -21,7 +21,6 @@
     <SubscribeDialog
       v-model="showSubscribeDialog"
       :tier="selectedTier"
-      :supporter-pubkey="nostr.pubkey"
       :creator-pubkey="creatorHex"
       @confirm="confirmSubscribe"
     />


### PR DESCRIPTION
## Summary
- fix profile render crash by dropping unused supporter pubkey binding on public profile page

## Testing
- `pnpm lint` *(fails: Error when performing request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.7.tgz)*
- `pnpm test` *(fails: Error when performing request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.7.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6d78f6608330bb3b705d739595d6