### PR TITLE
feat: add guest mode indicators

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,16 +1,18 @@
 <template>
   <router-view />
   <DonationPrompt />
+  <GuestConsentBar />
 </template>
 
 <script>
 import { defineComponent } from "vue";
 import { useUiStore } from "src/stores/ui";
 import DonationPrompt from "components/DonationPrompt.vue";
+import GuestConsentBar from "components/GuestConsentBar.vue";
 
   export default defineComponent({
   name: "App",
-  components: { DonationPrompt },
+  components: { DonationPrompt, GuestConsentBar },
   setup() {
     const ui = useUiStore();
     ui.initNetworkWatcher();

--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -35,7 +35,15 @@
       <q-item-label header>{{
         $t("MainHeader.menu.settings.title")
       }}</q-item-label>
-      <q-item clickable @click="gotoDashboard">
+      <q-item v-if="isGuest" clickable @click="gotoWelcome">
+        <q-item-section avatar>
+          <q-icon name="login" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>Finish setup</q-item-label>
+        </q-item-section>
+      </q-item>
+      <q-item v-if="!isGuest" clickable @click="gotoDashboard">
         <q-item-section avatar>
           <q-icon name="dashboard" />
         </q-item-section>
@@ -43,7 +51,7 @@
           <q-item-label>{{ $t("MainHeader.menu.dashboard.title") }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable @click="gotoWallet">
+      <q-item v-if="!isGuest" clickable @click="gotoWallet">
         <q-item-section avatar>
           <q-icon name="account_balance_wallet" />
         </q-item-section>
@@ -51,7 +59,7 @@
           <q-item-label>{{ $t("MainHeader.menu.wallet.title") }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable @click="gotoSettings">
+      <q-item v-if="!isGuest" clickable @click="gotoSettings">
         <q-item-section avatar>
           <q-icon name="settings" />
         </q-item-section>
@@ -77,7 +85,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable @click="gotoCreatorHub">
+      <q-item v-if="!isGuest" clickable @click="gotoCreatorHub">
         <q-item-section avatar>
           <CreatorHubIcon class="themed-icon q-icon" />
         </q-item-section>
@@ -90,7 +98,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable @click="gotoMyProfile">
+      <q-item v-if="!isGuest" clickable @click="gotoMyProfile">
         <q-item-section avatar>
           <q-icon name="person" />
         </q-item-section>
@@ -103,7 +111,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable @click="gotoBuckets">
+      <q-item v-if="!isGuest" clickable @click="gotoBuckets">
         <q-item-section avatar>
           <q-icon name="inventory_2" />
         </q-item-section>
@@ -116,7 +124,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable @click="gotoSubscriptions">
+      <q-item v-if="!isGuest" clickable @click="gotoSubscriptions">
         <q-item-section avatar>
           <q-icon name="auto_awesome_motion" />
         </q-item-section>
@@ -129,7 +137,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable @click="gotoChats">
+      <q-item v-if="!isGuest" clickable @click="gotoChats">
         <q-item-section avatar>
           <q-icon name="chat" />
         </q-item-section>
@@ -137,7 +145,7 @@
           <q-item-label>Chats</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item v-if="needsNostrLogin" clickable @click="gotoNostrLogin">
+      <q-item v-if="!isGuest && needsNostrLogin" clickable @click="gotoNostrLogin">
         <q-item-section avatar>
           <q-icon name="vpn_key" />
         </q-item-section>
@@ -195,6 +203,7 @@ import { computed } from "vue";
 import { useRouter } from "vue-router";
 import { useUiStore } from "src/stores/ui";
 import { useNostrStore } from "src/stores/nostr";
+import { useWelcomeStore } from "src/stores/welcome";
 import { useI18n } from "vue-i18n";
 import { useQuasar } from "quasar";
 import EssentialLink from "components/EssentialLink.vue";
@@ -205,6 +214,7 @@ import CreatorHubIcon from "src/components/icons/CreatorHubIcon.vue";
 const ui = useUiStore();
 const router = useRouter();
 const nostrStore = useNostrStore();
+const welcomeStore = useWelcomeStore();
 const { t } = useI18n();
 const $q = useQuasar();
 
@@ -224,8 +234,10 @@ const gotoChats = () => goto("/nostr-messenger");
 const gotoNostrLogin = () => goto("/nostr-login");
 const gotoTerms = () => goto("/terms");
 const gotoAbout = () => goto("/about");
+const gotoWelcome = () => goto("/welcome");
 
 const needsNostrLogin = computed(() => !nostrStore.privateKeySignerPrivateKey);
+const isGuest = computed(() => !welcomeStore.welcomeCompleted);
 
 const drawerContentClass = computed(() =>
   $q.screen.lt.md ? "main-nav-safe" : "q-pt-sm"

--- a/src/components/GuestConsentBar.vue
+++ b/src/components/GuestConsentBar.vue
@@ -1,0 +1,26 @@
+<template>
+  <q-banner v-if="!consentGiven" class="guest-consent-bar">
+    By browsing, you agree to our
+    <router-link to="/terms">Terms</router-link>
+    and privacy policy.
+    <template #action>
+      <q-btn flat color="primary" label="Accept" @click="consentGiven = true" />
+    </template>
+  </q-banner>
+</template>
+
+<script setup lang="ts">
+import { useLocalStorage } from '@vueuse/core';
+
+const consentGiven = useLocalStorage<boolean>('guest.consent', false);
+</script>
+
+<style scoped>
+.guest-consent-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+}
+</style>

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -10,6 +10,12 @@
         $t("CreatorHub.profile.back")
       }}</q-btn>
     </div>
+    <q-banner v-if="isGuest" class="q-mb-md">
+      You're browsing as a guest. Finish setup to subscribe.
+      <template #action>
+        <q-btn flat color="primary" label="Finish setup" @click="gotoWelcome" />
+      </template>
+    </q-banner>
     <div class="text-h5 q-mb-md row items-center q-gutter-x-sm">
       <div>{{ profile.display_name || creatorNpub }}</div>
       <q-btn flat dense icon="content_copy" @click="copy(profileUrl)" />
@@ -120,6 +126,7 @@ import PaywalledContent from "components/PaywalledContent.vue";
 import MediaPreview from "components/MediaPreview.vue";
 import { isTrustedUrl } from "src/utils/sanitize-url";
 import { useClipboard } from "src/composables/useClipboard";
+import { useWelcomeStore } from "stores/welcome";
 
 export default defineComponent({
   name: "PublicCreatorProfilePage",
@@ -141,6 +148,7 @@ export default defineComponent({
     const nostr = useNostrStore();
     const priceStore = usePriceStore();
     const uiStore = useUiStore();
+    const welcomeStore = useWelcomeStore();
     const { t } = useI18n();
     const { copy } = useClipboard();
     const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
@@ -154,6 +162,7 @@ export default defineComponent({
     const following = ref<number | null>(null);
     const loadingTiers = ref(true);
     const tierFetchError = computed(() => creators.tierFetchError);
+    const isGuest = computed(() => !welcomeStore.welcomeCompleted);
 
     const fetchTiers = async () => {
       loadingTiers.value = true;
@@ -192,6 +201,10 @@ export default defineComponent({
         return
       }
       showSubscribeDialog.value = true
+    }
+
+    const gotoWelcome = () => {
+      router.push({ path: '/welcome', query: { redirect: route.fullPath } })
     }
 
     onMounted(async () => {
@@ -278,6 +291,8 @@ export default defineComponent({
       retryFetchTiers,
       copy,
       profileUrl,
+      isGuest,
+      gotoWelcome,
     };
   },
 });


### PR DESCRIPTION
## Summary
- hide restricted navigation links when browsing as guest
- add guest-mode banner on public profile with onboarding link
- show site-wide guest consent bar

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68adf039c82483309b894ca5ae5fab44