### PR TITLE
gate subscription to setup-complete users

### DIFF
--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -84,10 +84,13 @@
             </ul>
             <div class="q-mt-md text-right subscribe-container">
               <q-btn
-                label="Subscribe"
+                :label="isGuest ? 'Finish setup' : 'Subscribe'"
                 class="subscribe-btn"
+                :disable="isGuest"
                 @click="openSubscribe(t)"
-              />
+              >
+                <q-tooltip v-if="isGuest">Finish setup to subscribe</q-tooltip>
+              </q-btn>
             </div>
             <PaywalledContent
               :creator-npub="creatorHex"
@@ -189,6 +192,10 @@ export default defineComponent({
 
     const openSubscribe = (tier: any) => {
       selectedTier.value = tier
+      if (isGuest.value || !welcomeStore.welcomeCompleted) {
+        showSetupDialog.value = true
+        return
+      }
       if (!nostr.pubkey && !nostr.signer) {
         showSetupDialog.value = true
         return


### PR DESCRIPTION
## Summary
- disable Subscribe when user hasn't completed onboarding and show tooltip
- open SetupRequiredDialog if user tries to subscribe before completing setup

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68adff8adbb483308670c67a2f96030b