### PR TITLE
fix: show subscribe label for guests

### DIFF
--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -84,7 +84,7 @@
             </ul>
             <div class="q-mt-md text-right subscribe-container">
               <q-btn
-                :label="isGuest ? 'Finish setup' : 'Subscribe'"
+                label="Subscribe"
                 class="subscribe-btn"
                 :disable="isGuest"
                 @click="openSubscribe(t)"


### PR DESCRIPTION
## Summary
- show "Subscribe" label on subscription tier button even for guests
- keep tooltip prompting guests to finish setup

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae037829a88330a622157c6fe7ba39