### PR TITLE
Add Fundstr Nostr profile and update repo links

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -242,6 +242,12 @@ const essentialLinks = [
     link: "https://primal.net/KalonAxiarch",
   },
   {
+    title: t("MainHeader.menu.links.fundstrNostr.title"),
+    caption: t("MainHeader.menu.links.fundstrNostr.caption"),
+    icon: "link",
+    link: "https://primal.net/p/nprofile1qqsdndspt5x07jhp5vrs0s4a7z0spwl4v28su0263vdjmwfmumxdygc6lzn8y",
+  },
+  {
     title: t("MainHeader.menu.links.cashuSpace.title"),
     caption: t("MainHeader.menu.links.cashuSpace.caption"),
     icon: "web",
@@ -251,7 +257,7 @@ const essentialLinks = [
     title: t("MainHeader.menu.links.github.title"),
     caption: t("MainHeader.menu.links.github.caption"),
     icon: "code",
-    link: "https://github.com/cashubtc/Fundstr",
+    link: "https://github.com/ritty65/Fundstr",
   },
   {
     title: t("MainHeader.menu.links.telegram.title"),

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -166,13 +166,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -165,13 +165,17 @@ export const messages = {
           title: "Fundstr's Creator",
           caption: "primal.net/KalonAxiarch",
         },
+        fundstrNostr: {
+          title: "Fundstr Nostr",
+          caption: "primal.net/fundstr",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",
         },
         github: {
           title: "Github",
-          caption: "github.com/cashubtc",
+          caption: "github.com/ritty65/Fundstr",
         },
         telegram: {
           title: "Telegram",

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -207,7 +207,7 @@
         <p class="center">Install the PWA, explore the code, or help fund development.</p>
         <div class="cta-row">
           <button class="btn solid" @click="installPwa">Install PWA</button>
-          <a class="btn outline" href="https://github.com/cashubtc" target="_blank" rel="noopener">View Code</a>
+          <a class="btn outline" href="https://github.com/ritty65/Fundstr" target="_blank" rel="noopener">View Code</a>
           <router-link class="btn outline" to="/creator-hub">Support Fundstr</router-link>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Add Fundstr Nostr profile to navigation links
- Point GitHub link to ritty65/Fundstr repository
- Update About page "View Code" button to new repository

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68af35a047148330a5146750bcc5323f