### PR TITLE
feat: add theme toggle to welcome/onboarding pages

### DIFF
--- a/src/pages/AlreadyRunning.vue
+++ b/src/pages/AlreadyRunning.vue
@@ -5,6 +5,7 @@
       'fullscreen text-center q-pa-md flex flex-center',
     ]"
   >
+    <ThemeToggle class="absolute-top-right q-ma-md" />
     <div>
       <div class="text-h3">{{ $t("AlreadyRunning.title") }}</div>
       <div class="text-h5 q-ma-lg text-grey">
@@ -25,8 +26,10 @@
 
 <script>
 import { defineComponent } from "vue";
+import ThemeToggle from "components/ThemeToggle.vue";
 
 export default defineComponent({
   name: "AlreadyRunning",
+  components: { ThemeToggle },
 });
 </script>

--- a/src/pages/Restore.vue
+++ b/src/pages/Restore.vue
@@ -5,6 +5,7 @@
       'text-center q-pa-md flex flex-center',
     ]"
   >
+    <ThemeToggle class="absolute-top-right q-ma-md" />
     <RestoreView />
   </div>
 </template>
@@ -12,11 +13,13 @@
 <script>
 import { defineComponent } from "vue";
 import RestoreView from "components/RestoreView.vue";
+import ThemeToggle from "components/ThemeToggle.vue";
 
 export default defineComponent({
   name: "ErrorNotFound",
   components: {
     RestoreView,
+    ThemeToggle,
   },
 });
 </script>

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -2,7 +2,7 @@
   <q-page class="q-pa-md flex flex-center">
     <div style="width:100%;max-width:600px">
       <div class="row items-center justify-between q-mb-md">
-        <div></div>
+        <ThemeToggle />
         <q-btn dense flat icon="checklist" @click="showChecklist = true" />
       </div>
       <div class="text-center q-mb-md">
@@ -72,6 +72,7 @@ import { useMnemonicStore } from 'src/stores/mnemonic'
 import { useStorageStore } from 'src/stores/storage'
 import { useNostrStore } from 'src/stores/nostr'
 import { useNdk } from 'src/composables/useNdk'
+import ThemeToggle from 'src/components/ThemeToggle.vue'
 
 const { t } = useI18n()
 const welcome = useWelcomeStore()


### PR DESCRIPTION
## Summary
- add ThemeToggle on welcome page toolbar
- expose ThemeToggle on restore and already-running onboarding screens

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0067bc4688330b304eb7e02f353b1