### PR TITLE
fix: remove h-full from trust cards

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -209,7 +209,7 @@
           </h2>
 
           <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-8">
-            <details class="interactive-card p-6 text-left h-full rounded-2xl">
+            <details class="interactive-card p-6 text-left rounded-2xl">
               <summary class="cursor-pointer">
                 <span class="mb-4 text-4xl block">💻</span>
                 <span class="block font-bold text-xl mb-2">Open Source &amp; Verifiable</span>
@@ -228,7 +228,7 @@
               </div>
             </details>
 
-            <details class="interactive-card p-6 text-left h-full rounded-2xl">
+            <details class="interactive-card p-6 text-left rounded-2xl">
               <summary class="cursor-pointer">
                 <span class="mb-4 text-4xl block">🔑</span>
                 <span class="block font-bold text-xl mb-2">You Hold the Keys</span>
@@ -246,7 +246,7 @@
               </div>
             </details>
 
-            <details class="interactive-card p-6 text-left h-full rounded-2xl">
+            <details class="interactive-card p-6 text-left rounded-2xl">
               <summary class="cursor-pointer">
                 <span class="mb-4 text-4xl block">🛡️</span>
                 <span class="block font-bold text-xl mb-2">Unbreakable Privacy</span>
@@ -264,7 +264,7 @@
               </div>
             </details>
 
-            <details class="interactive-card p-6 text-left h-full rounded-2xl">
+            <details class="interactive-card p-6 text-left rounded-2xl">
               <summary class="cursor-pointer">
                 <span class="mb-4 text-4xl block">👛</span>
                 <span class="block font-bold text-xl mb-2">Mint Diversification</span>


### PR DESCRIPTION
## Summary
- avoid overlapping about page cards by removing h-full from Trust Through Transparency details

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b00adb4d388330b8b99225eb4f1486