### PR TITLE
feat: allow hiding header per route

### DIFF
--- a/src/layouts/BlankLayout.vue
+++ b/src/layouts/BlankLayout.vue
@@ -4,8 +4,8 @@
       class="bg-surface-1 text-1"
       :style="navStyleVars"
     >
-    <MainHeader v-if="!route.path.startsWith('/welcome')" />
-    <AppNavDrawer v-if="!route.path.startsWith('/welcome')" />
+    <MainHeader v-if="!route.meta.hideHeader" />
+    <AppNavDrawer v-if="!route.meta.hideHeader" />
     <q-page-container class="text-body1">
       <div class="max-w-7xl mx-auto">
         <router-view />

--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -4,8 +4,8 @@
       class="bg-surface-1 text-1"
       :style="navStyleVars"
     >
-    <MainHeader />
-    <AppNavDrawer />
+    <MainHeader v-if="!route.meta.hideHeader" />
+    <AppNavDrawer v-if="!route.meta.hideHeader" />
     <q-page-container class="text-body1">
       <router-view />
     </q-page-container>
@@ -58,6 +58,7 @@ export default defineComponent({
       publishing,
       showPublishBar,
       navStyleVars,
+      route,
     };
   },
 });

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -4,8 +4,8 @@
     class="bg-surface-1 text-1"
     :style="navStyleVars"
   >
-    <MainHeader />
-    <AppNavDrawer />
+    <MainHeader v-if="!route.meta.hideHeader" />
+    <AppNavDrawer v-if="!route.meta.hideHeader" />
     <q-drawer
       v-if="isMessengerRoute"
       v-model="messenger.drawerOpen"
@@ -86,7 +86,7 @@
 <script>import windowMixin from 'src/mixins/windowMixin'
 import { defineComponent, ref, computed, watch } from "vue";
 
-import { useRouter } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
 import { useQuasar, LocalStorage } from "quasar";
 import MainHeader from "components/MainHeader.vue";
 import AppNavDrawer from "components/AppNavDrawer.vue";
@@ -112,6 +112,7 @@ export default defineComponent({
   setup() {
     const messenger = useMessengerStore();
     const router = useRouter();
+    const route = useRoute();
     const conversationSearch = ref("");
     const newChatDialogRef = ref(null);
     const $q = useQuasar();
@@ -213,6 +214,7 @@ export default defineComponent({
       computedDrawerWidth,
       onResizeStart,
       navStyleVars,
+      route,
     };
   },
   async mounted() {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -9,6 +9,7 @@ const routes = [
   {
     path: "/wallet",
     component: () => import("layouts/MainLayout.vue"),
+    meta: { hideHeader: true },
     children: [
       { path: "", component: () => import("src/pages/WalletPage.vue") },
     ],
@@ -101,11 +102,13 @@ const routes = [
   {
     path: "/restore",
     component: () => import("layouts/FullscreenLayout.vue"),
+    meta: { hideHeader: true },
     children: [{ path: "", component: () => import("src/pages/Restore.vue") }],
   },
   {
     path: "/already-running",
     component: () => import("layouts/BlankLayout.vue"),
+    meta: { hideHeader: true },
     children: [
       { path: "", component: () => import("src/pages/AlreadyRunning.vue") },
     ],
@@ -113,6 +116,7 @@ const routes = [
   {
     path: "/welcome",
     component: () => import("layouts/BlankLayout.vue"),
+    meta: { hideHeader: true },
     children: [
       { path: "", component: () => import("src/pages/WelcomePage.vue") },
     ],


### PR DESCRIPTION
## Summary
- support `meta.hideHeader` in wallet/onboarding routes
- layouts hide header & drawer when route meta flag is set

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0064f84b4833084f6bfaef7b9df77