### PR TITLE
feat: highlight no fees on about page

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -48,8 +48,8 @@
               <span>No gatekeepers</span>
             </div>
             <div class="feature">
-              <q-icon name="sell" class="feature-icon" />
-              <span>Low fees</span>
+              <q-icon name="money_off" class="feature-icon" />
+              <span>No fees</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace low fees feature with no fees and update icon

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b017da58848330a3a9b985c1f81b50