### PR TITLE
fix: show navigation menu on wallet page

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -9,7 +9,6 @@ const routes = [
   {
     path: "/wallet",
     component: () => import("layouts/MainLayout.vue"),
-    meta: { hideHeader: true },
     children: [
       { path: "", component: () => import("src/pages/WalletPage.vue") },
     ],


### PR DESCRIPTION
## Summary
- restore the main header on the wallet route so the navigation menu button is visible again

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b020cbea5883308de858f2155b09c7