### PR TITLE
feat: add PWA install prompt to welcome flow

### DIFF
--- a/src/composables/usePwaInstall.ts
+++ b/src/composables/usePwaInstall.ts
@@ -1,0 +1,31 @@
+import { ref } from "vue";
+
+// Minimal interface for the beforeinstallprompt event
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed"; platform: string }>;
+}
+
+// shared ref so multiple composable instances reuse the same prompt
+const deferredPrompt = ref<BeforeInstallPromptEvent | null>(null);
+let initialized = false;
+
+export function usePwaInstall() {
+  if (!initialized && typeof window !== "undefined") {
+    window.addEventListener("beforeinstallprompt", (e: Event) => {
+      e.preventDefault();
+      deferredPrompt.value = e as BeforeInstallPromptEvent;
+    });
+    initialized = true;
+  }
+
+  const promptInstall = async () => {
+    if (!deferredPrompt.value) return;
+    const prompt = deferredPrompt.value;
+    deferredPrompt.value = null;
+    await prompt.prompt();
+  };
+
+  return { deferredPrompt, promptInstall };
+}
+

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -73,6 +73,7 @@ import { useStorageStore } from 'src/stores/storage'
 import { useNostrStore } from 'src/stores/nostr'
 import { useNdk } from 'src/composables/useNdk'
 import ThemeToggle from 'src/components/ThemeToggle.vue'
+import { usePwaInstall } from 'src/composables/usePwaInstall'
 
 const { t } = useI18n()
 const welcome = useWelcomeStore()
@@ -84,6 +85,7 @@ const storageStore = useStorageStore()
 const nostr = useNostrStore()
 const showSeedDialog = ref(false)
 const showChecklist = ref(false)
+const { deferredPrompt } = usePwaInstall()
 
 onMounted(() => {
   const env = import.meta.env.VITE_APP_ENV
@@ -114,7 +116,7 @@ async function finishOnboarding() {
 const slides = [
   { component: WelcomeSlideFeatures },
   { component: WelcomeSlideNostr },
-  { component: WelcomeSlidePwa },
+  { component: WelcomeSlidePwa, props: { deferredPrompt } },
   {
     component: WelcomeSlideBackup,
     props: { onRevealSeed: revealSeed, onDownloadBackup: downloadBackup },

--- a/src/pages/welcome/WelcomeSlidePwa.vue
+++ b/src/pages/welcome/WelcomeSlidePwa.vue
@@ -26,13 +26,14 @@
 </template>
 
 <script setup lang="ts">
+import { usePwaInstall } from "src/composables/usePwaInstall";
+
 const props = defineProps<{ deferredPrompt?: any }>();
+const { promptInstall } = usePwaInstall();
 const id = "welcome-pwa-title";
 
 function install() {
-  if (props.deferredPrompt) {
-    props.deferredPrompt.prompt();
-  }
+  promptInstall();
 }
 
 function skip() {


### PR DESCRIPTION
## Summary
- add `usePwaInstall` composable listening for `beforeinstallprompt`
- pass deferred prompt into welcome slide and trigger install helper

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b025c40de483308a6c2a35eeaf4f97