### PR TITLE
refactor: use PWA install composable on About page

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -257,6 +257,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount, watchEffect } from 'vue'
 import { useQuasar } from 'quasar'
+import { usePwaInstall } from 'src/composables/usePwaInstall'
 
 const $q = useQuasar()
 const isDark = ref($q.dark.isActive)
@@ -264,6 +265,8 @@ watchEffect(() => (isDark.value = $q.dark.isActive))
 
 const root = ref<HTMLElement | null>(null)
 let io: IntersectionObserver | null = null
+
+const { deferredPrompt, promptInstall } = usePwaInstall()
 
 onMounted(() => {
   io = new IntersectionObserver((entries) => {
@@ -299,10 +302,8 @@ const filteredFaqs = computed(() => {
 })
 
 function installPwa () {
-  const evt: any = (window as any).deferredPWAInstallPrompt
-  if (evt?.prompt) {
-    evt.prompt()
-    evt.userChoice?.then(() => ((window as any).deferredPWAInstallPrompt = null))
+  if (deferredPrompt.value) {
+    promptInstall()
   } else {
     $q.notify({ message: 'Use your browser menu → “Install app” / “Add to Home Screen”.', color: 'primary', icon: 'download' })
   }


### PR DESCRIPTION
## Summary
- use shared PWA install composable in About page
- drop global deferred install prompt usage

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b02701db388330961d57bb936ae8e4