### PR TITLE
feat: sync theme with creators iframe

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -934,6 +934,10 @@
       }
 
       document.addEventListener("DOMContentLoaded", async () => {
+        document.body.classList.toggle(
+          "dark",
+          window.matchMedia("(prefers-color-scheme: dark)").matches,
+        );
         const featuredPubkeysHex = FEATURED_NPUBS.map((npub) => {
           try {
             return nip19.decode(npub).data;

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -153,6 +153,7 @@ import {
 import { nip19 } from "nostr-tools";
 
 const iframeEl = ref<HTMLIFrameElement | null>(null);
+const iframeLoaded = ref(false);
 const showDonateDialog = ref(false);
 const selectedPubkey = ref("");
 const showTierDialog = ref(false);
@@ -188,6 +189,18 @@ function sendTheme() {
     "*",
   );
 }
+
+function onIframeLoad() {
+  iframeLoaded.value = true;
+  sendTheme();
+}
+
+watch(
+  () => $q.dark.isActive,
+  () => {
+    if (iframeLoaded.value) sendTheme();
+  },
+);
 
 function getPrice(t: any): number {
   return t.price_sats ?? t.price ?? 0;
@@ -337,8 +350,7 @@ function handleDonate({
 
 onMounted(async () => {
   window.addEventListener("message", onMessage);
-  iframeEl.value?.addEventListener("load", sendTheme);
-  sendTheme();
+  iframeEl.value?.addEventListener("load", onIframeLoad);
   try {
     await nostr.initNdkReadOnly();
   } catch (e: any) {
@@ -370,7 +382,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   window.removeEventListener("message", onMessage);
-  iframeEl.value?.removeEventListener("load", sendTheme);
+  iframeEl.value?.removeEventListener("load", onIframeLoad);
   if (tierTimeout) clearTimeout(tierTimeout);
   nutzapProfile.value = null;
   loadingProfile.value = false;


### PR DESCRIPTION
## Summary
- wait for iframe load before sending theme
- watch Quasar dark mode and post to iframe
- initialize creators page theme from prefers-color-scheme

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b02d6aa14c8330ab84fd08896a3b25