### PR TITLE
compile relay health utility for find-creators page

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -300,15 +300,15 @@
       <div class="relay-info">Connecting to: <span id="relayList"></span></div>
     </div>
 
-      <script type="module">
-        import { filterHealthyRelays } from "../src/utils/relayHealth.ts";
-        const DEFAULT_RELAYS = [
-          "wss://relay.damus.io",
-          "wss://relay.primal.net",
-          "wss://relay.snort.social",
-          "wss://nos.lol",
-          "wss://relay.nostr.band",
-        ];
+    <script type="module">
+      import { filterHealthyRelays } from "./relayHealth.js";
+      const DEFAULT_RELAYS = [
+        "wss://relay.damus.io",
+        "wss://relay.primal.net",
+        "wss://relay.snort.social",
+        "wss://nos.lol",
+        "wss://relay.nostr.band",
+      ];
       // --- Nostr Tools ---
       if (!window.NostrTools) {
         document.getElementById("statusMessage").textContent =
@@ -333,16 +333,16 @@
       } catch {
         storedRelays = [];
       }
-        let RELAYS = Array.from(new Set([...storedRelays, ...DEFAULT_RELAYS])).filter(
-          (r) => r.startsWith("wss://"),
+      let RELAYS = Array.from(
+        new Set([...storedRelays, ...DEFAULT_RELAYS]),
+      ).filter((r) => r.startsWith("wss://"));
+      RELAYS = await filterHealthyRelays(RELAYS);
+      if (RELAYS.length === 0) {
+        console.error(
+          "[find-creators] no reachable relays:",
+          [...storedRelays, ...DEFAULT_RELAYS].join(", "),
         );
-        RELAYS = await filterHealthyRelays(RELAYS);
-        if (RELAYS.length === 0) {
-          console.error(
-            "[find-creators] no reachable relays:",
-            [...storedRelays, ...DEFAULT_RELAYS].join(", "),
-          );
-        }
+      }
       document.getElementById("relayList").textContent = RELAYS.join(", ");
 
       const pool = new SimplePool({ eoseSubTimeout: 8000 });

--- a/public/relayHealth.js
+++ b/public/relayHealth.js
@@ -1,0 +1,98 @@
+const FREE_RELAYS = [
+  "wss://relay.damus.io",
+  "wss://relay.primal.net",
+  "wss://relayable.org",
+];
+
+// keep track of relays that have already produced a constructor error so we only
+// emit a single console message per relay. This keeps startup logs readable when
+// many relays are unreachable.
+const reportedFailures = new Map();
+let aggregateTimer = null;
+
+function scheduleFailureLog() {
+  if (aggregateTimer) return;
+  aggregateTimer = setTimeout(() => {
+    const entries = Array.from(reportedFailures.entries());
+    reportedFailures.clear();
+    aggregateTimer = null;
+    if (!entries.length) return;
+    const summary = entries
+      .map(([u, c]) => (c > 1 ? `${u} (x${c})` : u))
+      .join(", ");
+    console.error(`WebSocket ping failed for: ${summary}`);
+  }, 0);
+}
+
+export async function pingRelay(url) {
+  return new Promise((resolve) => {
+    let settled = false;
+    let ws;
+    try {
+      ws = new WebSocket(url);
+    } catch (err) {
+      // Catch constructor errors (e.g. invalid URL or security issues) and log
+      // them in an aggregated fashion instead of flooding the console.
+      reportedFailures.set(url, (reportedFailures.get(url) ?? 0) + 1);
+      scheduleFailureLog();
+      resolve(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        try {
+          ws.close();
+        } catch {}
+        resolve(false);
+      }
+    }, 1000);
+    ws.onopen = () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        ws.close();
+        resolve(true);
+      }
+    };
+    ws.onerror = () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        // aggregate error rather than letting each failed relay spam the console
+        reportedFailures.set(url, (reportedFailures.get(url) ?? 0) + 1);
+        scheduleFailureLog();
+        resolve(false);
+      }
+    };
+    ws.onmessage = (ev) => {
+      if (
+        !settled &&
+        typeof ev.data === "string" &&
+        ev.data.startsWith("restricted:")
+      ) {
+        settled = true;
+        clearTimeout(timer);
+        ws.close();
+        resolve(false);
+      }
+    };
+  });
+}
+
+export async function filterHealthyRelays(relays) {
+  const healthy = [];
+  // Process relays in small batches to avoid exhausting browser resources
+  const batchSize = 10;
+
+  for (let i = 0; i < relays.length; i += batchSize) {
+    const batch = relays.slice(i, i + batchSize);
+    const results = await Promise.all(
+      batch.map(async (u) => ((await pingRelay(u)) ? u : null)),
+    );
+    const batchHealthy = results.filter((u) => !!u);
+    healthy.push(...batchHealthy);
+  }
+
+  return healthy.length >= 2 ? healthy : FREE_RELAYS;
+}


### PR DESCRIPTION
## Summary
- bundle relayHealth helper into `public/relayHealth.js`
- load `relayHealth.js` in find-creators page instead of TypeScript source

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b02eaac0708330a5bdea315281658d