### PR TITLE
refactor: use notifySuccess helper in MainHeader

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -131,6 +131,7 @@ import { useRoute } from "vue-router";
 import { useUiStore } from "src/stores/ui";
 import { useMessengerStore } from "src/stores/messenger";
 import { useQuasar } from "quasar";
+import { notifySuccess } from "src/js/notify";
 
 export default defineComponent({
   name: "MainHeader",
@@ -179,7 +180,7 @@ export default defineComponent({
       console.log("toggleDarkMode", $q.dark.isActive);
       $q.dark.toggle();
       $q.localStorage.set("cashu.darkMode", $q.dark.isActive);
-      vm?.notifySuccess(
+      notifySuccess(
         $q.dark.isActive ? "Dark mode enabled" : "Dark mode disabled",
       );
     };


### PR DESCRIPTION
## Summary
- import `notifySuccess` helper
- call `notifySuccess` directly when toggling dark mode

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b02fdae6948330890f7d5c596ae641