### PR TITLE
feat: retry relay pings and surface relay failures

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -310,11 +310,13 @@
         "wss://nos.lol",
         "wss://relay.nostr.band",
       ];
+      const statusMessageElement = document.getElementById("statusMessage");
+      const retryButtonElement = document.getElementById("retryButton");
       // --- Nostr Tools ---
       if (!window.NostrTools) {
-        document.getElementById("statusMessage").textContent =
+        statusMessageElement.textContent =
           "Error: nostr-tools library not loaded.";
-        document.getElementById("statusMessage").classList.remove("hidden");
+        statusMessageElement.classList.remove("hidden");
       }
       const { SimplePool, nip19, utils } = window.NostrTools;
 
@@ -324,12 +326,17 @@
           window.matchMedia("(prefers-color-scheme: dark)").matches,
       );
 
-      const RELAYS = await filterHealthyRelays(DEFAULT_RELAYS);
-      if (RELAYS.length === 0) {
+      let RELAYS = [];
+      try {
+        RELAYS = await filterHealthyRelays(DEFAULT_RELAYS);
+      } catch {
         console.error(
           "[find-creators] no reachable relays:",
           DEFAULT_RELAYS.join(", "),
         );
+        statusMessageElement.textContent =
+          "Network error: could not reach relays.";
+        statusMessageElement.classList.remove("hidden");
       }
       document.getElementById("relayList").textContent = RELAYS.join(", ");
 
@@ -352,8 +359,6 @@
 
       const searchInputElement = document.getElementById("searchInput");
       const resultsListElement = document.getElementById("resultsList");
-      const statusMessageElement = document.getElementById("statusMessage");
-      const retryButtonElement = document.getElementById("retryButton");
       const loaderElement = document.getElementById("loader");
       const featuredCreatorsGridElement = document.getElementById(
         "featuredCreatorsGrid",

--- a/public/relayHealth.js
+++ b/public/relayHealth.js
@@ -25,59 +25,62 @@ function scheduleFailureLog() {
 }
 
 export async function pingRelay(url) {
-  return new Promise((resolve) => {
-    let settled = false;
-    let ws;
-    try {
-      ws = new WebSocket(url);
-    } catch (err) {
-      // Catch constructor errors (e.g. invalid URL or security issues) and log
-      // them in an aggregated fashion instead of flooding the console.
-      reportedFailures.set(url, (reportedFailures.get(url) ?? 0) + 1);
-      scheduleFailureLog();
-      resolve(false);
-      return;
-    }
-    const timer = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        try {
+  const attempt = () =>
+    new Promise((resolve) => {
+      let settled = false;
+      let ws;
+      try {
+        ws = new WebSocket(url);
+      } catch {
+        resolve(false);
+        return;
+      }
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          try {
+            ws.close();
+          } catch {}
+          resolve(false);
+        }
+      }, 1000);
+      ws.onopen = () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
           ws.close();
-        } catch {}
-        resolve(false);
-      }
-    }, 1000);
-    ws.onopen = () => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timer);
-        ws.close();
-        resolve(true);
-      }
-    };
-    ws.onerror = () => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timer);
-        // aggregate error rather than letting each failed relay spam the console
-        reportedFailures.set(url, (reportedFailures.get(url) ?? 0) + 1);
-        scheduleFailureLog();
-        resolve(false);
-      }
-    };
-    ws.onmessage = (ev) => {
-      if (
-        !settled &&
-        typeof ev.data === "string" &&
-        ev.data.startsWith("restricted:")
-      ) {
-        settled = true;
-        clearTimeout(timer);
-        ws.close();
-        resolve(false);
-      }
-    };
-  });
+          resolve(true);
+        }
+      };
+      ws.onerror = () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve(false);
+        }
+      };
+      ws.onmessage = (ev) => {
+        if (
+          !settled &&
+          typeof ev.data === "string" &&
+          ev.data.startsWith("restricted:")
+        ) {
+          settled = true;
+          clearTimeout(timer);
+          ws.close();
+          resolve(false);
+        }
+      };
+    });
+
+  const maxAttempts = 3;
+  for (let i = 0; i < maxAttempts; i++) {
+    if (await attempt()) return true;
+  }
+
+  reportedFailures.set(url, (reportedFailures.get(url) ?? 0) + maxAttempts);
+  scheduleFailureLog();
+  return false;
 }
 
 export async function filterHealthyRelays(relays) {
@@ -92,6 +95,10 @@ export async function filterHealthyRelays(relays) {
     );
     const batchHealthy = results.filter((u) => !!u);
     healthy.push(...batchHealthy);
+  }
+
+  if (healthy.length === 0) {
+    throw new Error("no reachable relays");
   }
 
   return healthy.length >= 2 ? healthy : FREE_RELAYS;

--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -82,7 +82,12 @@ async function createReadOnlyNdk(): Promise<NDK> {
     ? settings.defaultNostrRelays
     : [];
   const relays = userRelays.length ? userRelays : DEFAULT_RELAYS;
-  const healthy = await filterHealthyRelays(relays);
+  let healthy: string[] = [];
+  try {
+    healthy = await filterHealthyRelays(relays);
+  } catch {
+    healthy = [];
+  }
   const relayUrls = healthy.length ? healthy : FREE_RELAYS;
   const ndk = new NDK({ explicitRelayUrls: relayUrls });
   attachRelayErrorHandlers(ndk);
@@ -132,7 +137,12 @@ export async function createNdk(): Promise<NDK> {
     ? settings.defaultNostrRelays
     : [];
   const relays = userRelays.length ? userRelays : DEFAULT_RELAYS;
-  const healthy = await filterHealthyRelays(relays);
+  let healthy: string[] = [];
+  try {
+    healthy = await filterHealthyRelays(relays);
+  } catch {
+    healthy = [];
+  }
   const relayUrls = healthy.length ? healthy : FREE_RELAYS;
   const ndk = new NDK({ signer: signer as any, explicitRelayUrls: relayUrls });
   attachRelayErrorHandlers(ndk);

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -211,7 +211,12 @@ export const useCreatorsStore = defineStore("creators", {
       );
 
       // Filter out unreachable relays before subscribing
-      const healthyRelays = await filterHealthyRelays(relayUrls);
+      let healthyRelays: string[] = [];
+      try {
+        healthyRelays = await filterHealthyRelays(relayUrls);
+      } catch {
+        healthyRelays = [];
+      }
 
       let received = false;
       const fetchFromIndexer = async () => {

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1200,7 +1200,12 @@ export const useNostrStore = defineStore("nostr", {
       const relayUrls = (relays ?? this.relays).filter((r) =>
         r.startsWith("wss://"),
       );
-      const healthyRelays = await filterHealthyRelays(relayUrls);
+      let healthyRelays: string[] = [];
+      try {
+        healthyRelays = await filterHealthyRelays(relayUrls);
+      } catch {
+        healthyRelays = [];
+      }
       if (healthyRelays.length === 0) {
         console.error("[nostr] NIP-04 publish failed: all relays unreachable");
         notifyError("Could not publish NIP-04 event");
@@ -1373,7 +1378,12 @@ export const useNostrStore = defineStore("nostr", {
       const relayUrls = (relays ?? this.relays).filter((r) =>
         r.startsWith("wss://"),
       );
-      const healthyRelays = await filterHealthyRelays(relayUrls);
+      let healthyRelays: string[] = [];
+      try {
+        healthyRelays = await filterHealthyRelays(relayUrls);
+      } catch {
+        healthyRelays = [];
+      }
       if (healthyRelays.length === 0) {
         console.error("[nostr] NIP-17 publish failed: all relays unreachable");
         notifyError("Could not publish NIP-17 event");
@@ -1720,7 +1730,12 @@ export async function publishEvent(event: NostrEvent): Promise<void> {
   const relayUrls = useSettingsStore().defaultNostrRelays.filter((r) =>
     r.startsWith("wss://"),
   );
-  const healthyRelays = await filterHealthyRelays(relayUrls);
+  let healthyRelays: string[] = [];
+  try {
+    healthyRelays = await filterHealthyRelays(relayUrls);
+  } catch {
+    healthyRelays = [];
+  }
   if (healthyRelays.length === 0) {
     console.error("[nostr] publish failed: all relays unreachable");
     return;
@@ -1748,7 +1763,12 @@ export async function subscribeToNostr(
   }
 
   // Ensure at least one relay is reachable before subscribing
-  const healthy = await filterHealthyRelays(relayUrls);
+  let healthy: string[] = [];
+  try {
+    healthy = await filterHealthyRelays(relayUrls);
+  } catch {
+    healthy = [];
+  }
   if (healthy.length === 0) {
     console.error("[nostr] subscription failed: all relays unreachable");
     return false;


### PR DESCRIPTION
## Summary
- retry relay pings up to three times before logging aggregated failures
- throw when no relays are reachable
- show a single network failure message on find-creators page

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b03bc87ab88330b4a398227eb14037