### PR TITLE
feat: add relay fallbacks and async find creators

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -326,23 +326,37 @@
           window.matchMedia("(prefers-color-scheme: dark)").matches,
       );
 
-      let RELAYS = [];
-      try {
-        RELAYS = await filterHealthyRelays(DEFAULT_RELAYS);
-      } catch {
-        console.error(
-          "[find-creators] no reachable relays:",
-          DEFAULT_RELAYS.join(", "),
-        );
-        statusMessageElement.textContent =
-          "Network error: could not reach relays.";
-        statusMessageElement.classList.remove("hidden");
-      }
+      let RELAYS = [...DEFAULT_RELAYS];
       document.getElementById("relayList").textContent = RELAYS.join(", ");
 
       const pool = new SimplePool({ eoseSubTimeout: 8000 });
       let currentSearchAbortController = null;
       let lastSearchQuery = "";
+
+      let relayFailureCount = 0;
+      async function refreshRelays() {
+        try {
+          const healthy = await filterHealthyRelays(DEFAULT_RELAYS);
+          RELAYS = healthy;
+          relayFailureCount = 0;
+          document.getElementById("relayList").textContent = RELAYS.join(", ");
+          statusMessageElement.classList.add("hidden");
+        } catch {
+          relayFailureCount++;
+          if (relayFailureCount >= 3) {
+            console.error(
+              "[find-creators] no reachable relays:",
+              DEFAULT_RELAYS.join(", "),
+            );
+            statusMessageElement.textContent =
+              "Network error: could not reach relays.";
+            statusMessageElement.classList.remove("hidden");
+            clearInterval(relayInterval);
+          }
+        }
+      }
+      const relayInterval = setInterval(refreshRelays, 30000);
+      refreshRelays();
 
       const FEATURED_NPUBS = [
         "npub1aljmhjp5tqrw3m60ra7t3u8uqq223d6rdg9q0h76a8djd9m4hmvsmlj82m",
@@ -947,11 +961,13 @@
         document.body.removeChild(textArea);
       }
 
-      document.addEventListener("DOMContentLoaded", async () => {
+      async function init() {
         document.body.classList.toggle(
           "dark",
           window.matchMedia("(prefers-color-scheme: dark)").matches,
         );
+        featuredStatusMessageElement.textContent = "Loading featured creators...";
+        featuredStatusMessageElement.classList.remove("hidden");
         const featuredPubkeysHex = FEATURED_NPUBS.map((npub) => {
           try {
             return nip19.decode(npub).data;
@@ -997,6 +1013,7 @@
 
         if (profiles && profiles.length > 0) {
           renderProfiles(profiles, featuredCreatorsGridElement, true);
+          featuredStatusMessageElement.classList.add("hidden");
         } else {
           featuredStatusMessageElement.textContent =
             "Could not load featured creators.";
@@ -1023,34 +1040,50 @@
             }
           })();
         }
-      });
 
-      window.addEventListener("message", (ev) => {
-        if (ev.data?.type === "prefillSearch" && ev.data.npub) {
-          searchInputElement.value = ev.data.npub;
-          handleSearch(ev.data.npub);
-        } else if (ev.data?.type === "set-theme") {
-          document.body.classList.toggle("dark", !!ev.data.dark);
+        window.addEventListener("message", (ev) => {
+          if (ev.data?.type === "prefillSearch" && ev.data.npub) {
+            searchInputElement.value = ev.data.npub;
+            handleSearch(ev.data.npub);
+          } else if (ev.data?.type === "set-theme") {
+            document.body.classList.toggle("dark", !!ev.data.dark);
+          }
+        });
+
+        const debouncedSearchHandler = debounce(handleSearch, 500);
+        searchInputElement.addEventListener("input", (event) => {
+          debouncedSearchHandler(event.target.value);
+        });
+
+        retryButtonElement.addEventListener("click", () => {
+          if (lastSearchQuery) {
+            handleSearch(lastSearchQuery);
+          }
+        });
+
+        window.addEventListener("beforeunload", () => {
+          if (currentSearchAbortController) {
+            currentSearchAbortController.abort();
+          }
+          pool.close([...RELAYS]);
+        });
+      }
+
+      const stylesheet = document.querySelector(
+        'link[rel="stylesheet"][href="find-creators.css"]',
+      );
+      function waitForStyles(cb) {
+        if (!stylesheet || stylesheet.sheet) {
+          cb();
+        } else {
+          stylesheet.addEventListener("load", cb, { once: true });
         }
-      });
-
-      const debouncedSearchHandler = debounce(handleSearch, 500);
-      searchInputElement.addEventListener("input", (event) => {
-        debouncedSearchHandler(event.target.value);
-      });
-
-      retryButtonElement.addEventListener("click", () => {
-        if (lastSearchQuery) {
-          handleSearch(lastSearchQuery);
-        }
-      });
-
-      window.addEventListener("beforeunload", () => {
-        if (currentSearchAbortController) {
-          currentSearchAbortController.abort();
-        }
-        pool.close([...RELAYS]);
-      });
+      }
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", () => waitForStyles(init));
+      } else {
+        waitForStyles(init);
+      }
     </script>
   </body>
 </html>

--- a/public/relayHealth.js
+++ b/public/relayHealth.js
@@ -25,7 +25,7 @@ function scheduleFailureLog() {
 }
 
 export async function pingRelay(url) {
-  const attempt = () =>
+  const attemptOnce = () =>
     new Promise((resolve) => {
       let settled = false;
       let ws;
@@ -73,9 +73,14 @@ export async function pingRelay(url) {
       };
     });
 
-  const maxAttempts = 3;
+  const maxAttempts = 6;
+  let delay = 1000;
   for (let i = 0; i < maxAttempts; i++) {
-    if (await attempt()) return true;
+    if (await attemptOnce()) return true;
+    if (i < maxAttempts - 1) {
+      await new Promise((r) => setTimeout(r, delay));
+      delay = Math.min(delay * 2, 32000);
+    }
   }
 
   reportedFailures.set(url, (reportedFailures.get(url) ?? 0) + maxAttempts);


### PR DESCRIPTION
## Summary
- add exponential backoff and retries for relay health checks
- refresh relays on interval and warn when all are unreachable
- load find-creators UI after CSS and show placeholders while async data loads

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b040d591b48330b388596f81b763bc