### PR TITLE
fix: ensure find creators headings visible in dark mode

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -231,6 +231,10 @@
         padding-bottom: 0.5rem;
         border-bottom: 2px solid #e2e8f0;
       }
+      body.dark .section-title {
+        color: #e2e8f0;
+        border-bottom-color: #4a5568;
+      }
       body.dark {
         background-color: #1a202c;
         color: #e2e8f0;


### PR DESCRIPTION
## Summary
- ensure headings on `/find-creators` are readable in dark mode by setting appropriate text and border colors

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b08bc8bff88330a78760e95122edfa