### PR TITLE
fix: hide spinner on find-creators page once data loads

### DIFF
--- a/public/find-creators.css
+++ b/public/find-creators.css
@@ -891,6 +891,10 @@
   }
 }
 
+.hidden {
+  display: none;
+}
+
 @layer utilities {
   @tailwind utilities;
 }

--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -1005,11 +1005,10 @@
                 JSON.stringify({ timestamp: Date.now(), profiles }),
               );
             }
-          } catch (e) {
-          } finally {
-            featuredCreatorsLoaderElement.style.display = "none";
-          }
+          } catch (e) {}
         }
+
+        featuredCreatorsLoaderElement.style.display = "none";
 
         if (profiles && profiles.length > 0) {
           renderProfiles(profiles, featuredCreatorsGridElement, true);


### PR DESCRIPTION
## Summary
- Hide featured creators loader after retrieving profiles from cache or network
- Add `.hidden` utility in find-creators CSS so status messages can toggle visibility

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b08ac964a083308e13423144eada4e