### PR TITLE
Handle WebSocket CONNECTING state during relay pings

### DIFF
--- a/public/relayHealth.js
+++ b/public/relayHealth.js
@@ -38,9 +38,17 @@ export async function pingRelay(url) {
       const timer = setTimeout(() => {
         if (!settled) {
           settled = true;
-          try {
-            ws.close();
-          } catch {}
+          if (ws.readyState === WebSocket.OPEN) {
+            try {
+              ws.close();
+            } catch {}
+          } else if (ws.readyState === WebSocket.CONNECTING) {
+            ws.onopen = () => {
+              try {
+                ws.close();
+              } catch {}
+            };
+          }
           resolve(false);
         }
       }, 1000);

--- a/src/utils/relayHealth.ts
+++ b/src/utils/relayHealth.ts
@@ -34,9 +34,17 @@ export async function pingRelay(url: string): Promise<boolean> {
       const timer = setTimeout(() => {
         if (!settled) {
           settled = true;
-          try {
-            ws.close();
-          } catch {}
+          if (ws.readyState === WebSocket.OPEN) {
+            try {
+              ws.close();
+            } catch {}
+          } else if (ws.readyState === WebSocket.CONNECTING) {
+            ws.onopen = () => {
+              try {
+                ws.close();
+              } catch {}
+            };
+          }
           resolve(false);
         }
       }, 1000);


### PR DESCRIPTION
## Summary
- avoid closing WebSockets while connecting in relay health checks
- mirror WebSocket timeout handling in compiled relayHealth.js

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b08f1b072083309c585370bff401a4