### PR TITLE
feat: expose formatCurrency helper in ReceiveTokenDialog

### DIFF
--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -489,6 +489,9 @@ export default defineComponent({
       "pasteToParseDialog",
     ]),
     shortenString,
+    formatCurrency(amount, unit, showBalance = false) {
+      return useUiStore().formatCurrency(amount, unit, showBalance);
+    },
     // TOKEN METHODS
     decodePeanut: function (peanut) {
       try {


### PR DESCRIPTION
## Summary
- add `formatCurrency` method in ReceiveTokenDialog using Ui store

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b14c417e3483309209bc545c7b92c2