### PR TITLE
Sanitize token input and notify on decode errors

### DIFF
--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -51,9 +51,11 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
       return enqueueRedemption(fn);
     },
     decodeToken: function (encodedToken: string) {
-      encodedToken = encodedToken.trim();
+      // strip all whitespace/newlines before validation
+      encodedToken = encodedToken.replace(/\s+/g, "");
       if (!isValidTokenString(encodedToken)) {
         console.error("Invalid token string");
+        notifyError("Invalid token string");
         return undefined;
       }
       let decodedToken = undefined;
@@ -62,10 +64,12 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
         const proofs = token.getProofs(decodedToken);
         if (!proofs || proofs.length === 0) {
           console.error("Decoded token contains no proofs");
+          notifyError("Decoded token contains no proofs");
           return undefined;
         }
       } catch (error) {
         console.error(error);
+        notifyError("Failed to decode token");
         return undefined;
       }
       return decodedToken;


### PR DESCRIPTION
## Summary
- Strip whitespace and newlines from received tokens before validation
- Notify users of invalid or malformed token strings instead of relying on console errors

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b14d3ba6c083309a4d2d9c2d28b652