### PR TITLE
chore: refresh relay list and reduce ping noise

### DIFF
--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -2,9 +2,9 @@ export const DEFAULT_RELAYS = [
   "wss://relay.damus.io",
   "wss://relay.primal.net",
   "wss://relay.snort.social",
-  // Replaced unreachable relays with active public ones
-  "wss://nostr-pub.wellorder.net",
-  "wss://relay.nostr.band",
+  // Updated to currently active public relays
+  "wss://relay.f7z.io",
+  "wss://nos.lol",
 ];
 
 export const FREE_RELAYS = [

--- a/src/utils/relayHealth.ts
+++ b/src/utils/relayHealth.ts
@@ -47,7 +47,7 @@ export async function pingRelay(url: string): Promise<boolean> {
           }
           resolve(false);
         }
-      }, 1000);
+      }, 2000);
       ws.onopen = () => {
         if (!settled) {
           settled = true;
@@ -77,8 +77,8 @@ export async function pingRelay(url: string): Promise<boolean> {
       };
     });
 
-  const maxAttempts = 6;
-  let delay = 1000;
+  const maxAttempts = 3;
+  let delay = 2000;
   for (let i = 0; i < maxAttempts; i++) {
     if (await attemptOnce()) return true;
     if (i < maxAttempts - 1) {


### PR DESCRIPTION
## Summary
- replace dead relays with active public endpoints
- lower relay ping attempts and lengthen timeout to cut WebSocket noise

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm dlx @quasar/cli build -m spa` *(fails: ERR_PNPM_FETCH_403 GET https://registry.npmjs.org/@quasar%2Fcli)*

------
https://chatgpt.com/codex/tasks/task_e_68b1570ef2608330a6e824878708007d