### PR TITLE
feat: cache relay health and enhance ndk setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Think Patreon, but built for the Nostr ecosystem and leveraging the privacy and 
 - **Subscriber Analytics Dashboard** – KPI cards and charts visualize subscriber counts, status mix and projected revenue. The final KPI toggles between upcoming week or month to estimate expected income.
 - **Direct Cashu Donations & Pledges** – One-time or recurring support using P2PK and timelocks.
 - **Nostr Direct Messages** – NIP-04 encrypted chat with creators and other users.
+- **Relay Management & Caching** – Relay ping results are cached to avoid console floods while NDK's outbox model auto-connects to user relays. Events persist locally in a Dexie-backed cache for offline access. If every relay is unreachable, the app warns about possible network restrictions and health checks can be disabled in Settings.
 - **Privacy-Preserving** – Chaumian ecash via Cashu.
 - **Cross-Platform** – Web App, PWA and native Android/iOS.
 - **npub.cash Integration** – Option to receive funds via a Lightning Address.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@gandlaf21/bc-ur": "^1.1.12",
     "@noble/hashes": "^1.8.0",
     "@nostr-dev-kit/ndk": "^2.14.32",
+    "@nostr-dev-kit/ndk-cache-dexie": "^1.0.0",
     "@quasar/extras": "^1.16.11",
     "@quasar/icongenie": "^4.0.0",
     "@scure/bip32": "^1.7.0",

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -29,6 +29,10 @@ export const useSettingsStore = defineStore("settings", {
         "cashu.settings.useWebsockets",
         true,
       ),
+      relayHealthChecks: useLocalStorage<boolean>(
+        "cashu.settings.relayHealthChecks",
+        true,
+      ),
       defaultNostrRelays: useLocalStorage<string[]>(
         "cashu.settings.defaultNostrRelays",
         DEFAULT_RELAYS,

--- a/test/vitest/__tests__/relayHealth.spec.ts
+++ b/test/vitest/__tests__/relayHealth.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { pingRelay } from "../../../src/utils/relayHealth";
+
+class FailingWS {
+  static count = 0;
+  static CONNECTING = 0;
+  static OPEN = 1;
+  readyState = FailingWS.CONNECTING;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((ev: any) => void) | null = null;
+  constructor(url: string) {
+    FailingWS.count++;
+    setTimeout(() => {
+      this.onerror && this.onerror();
+    }, 0);
+  }
+  close() {}
+}
+
+describe("pingRelay cache", () => {
+  it("reuses cached failure", async () => {
+    // @ts-ignore
+    const OriginalWS = globalThis.WebSocket;
+    // @ts-ignore
+    globalThis.WebSocket = FailingWS;
+    vi.useFakeTimers();
+    const p1 = pingRelay("wss://bad");
+    await vi.runAllTimersAsync();
+    const r1 = await p1;
+    const r2 = await pingRelay("wss://bad");
+    expect(r1).toBe(false);
+    expect(r2).toBe(false);
+    expect(FailingWS.count).toBe(3);
+    vi.useRealTimers();
+    // @ts-ignore
+    globalThis.WebSocket = OriginalWS;
+  });
+});
+


### PR DESCRIPTION
## Summary
- cache relay ping results to reduce log noise
- enable optional Dexie-backed caching and outbox model in NDK boot
- add setting and docs for relay health checks

## Testing
- `pnpm lint`
- `pnpm test`
- `npx vitest run test/vitest/__tests__/relayHealth.spec.ts`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b15c58eba48330a9a141081776d443