### PR TITLE
feat: persist nostr session and handle account changes

### DIFF
--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -31,6 +31,7 @@ export const LOCAL_STORAGE_KEYS = {
   CASHU_NDK_SEEDSIGNERPRIVATEKEY: "cashu.ndk.seedSignerPrivateKey",
   CASHU_NDK_SEEDSIGNERPUBLICKEY: "cashu.ndk.seedSignerPublicKey",
   CASHU_NDK_SIGNERTYPE: "cashu.ndk.signerType",
+  CASHU_NOSTR_SESSION: "cashu.nostr.session",
   CASHU_NPC_ADDRESS: "cashu.npc.address",
   CASHU_NPC_AUTOMATICCLAIM: "cashu.npc.automaticClaim",
   CASHU_NPC_BASEURL: "cashu.npc.baseURL",


### PR DESCRIPTION
## Summary
- persist nostr account session in local storage
- restore saved session on startup and update when pubkey or signer type changes
- listen for NIP-07 account changes and update session accordingly

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1602f05508330997dc01a95b5f984