### PR TITLE
feat(nostr): guard session persistence

### DIFF
--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -80,7 +80,7 @@ export const useCreatorHubStore = defineStore("creatorHub", {
     logout() {
       const nostr = useNostrStore();
       nostr.disconnect();
-      nostr.setPubkey("");
+      nostr.setSignerWithSource("", "local");
       this.tiers = {} as any;
       this.tierOrder = [];
       const profileStore = useCreatorProfileStore();


### PR DESCRIPTION
## Summary
- confirm before replacing stored Nostr session when pubkey changes
- add `setSignerWithSource` to atomically set signer and auth source
- refactor signer flows and logout to use `setSignerWithSource`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b17907a73083309273a67f35c0f05d