### PR TITLE
chore: sync assets folder in staging deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -56,6 +56,8 @@ jobs:
         run: |
           rsync -avz --delete -e "ssh -p ${{ secrets.SSH_PORT }}" \
             dist/spa/ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ secrets.SSH_TARGET_STAGING }}
+          rsync -avz --delete -e "ssh -p ${{ secrets.SSH_PORT }}" \
+            dist/spa/assets/ ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ secrets.SSH_TARGET_STAGING }}assets/
 
       - name: Drop deploy marker & perms
         run: |


### PR DESCRIPTION
## Summary
- ensure staging deploy syncs entire `dist/spa/assets` directory

## Testing
- `pnpm quasar build -m spa`
- `pnpm lint`
- `pnpm test`
- `curl -I https://staging.fundstr.me/assets/FullscreenLayout-BmWPYodh.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b17dff1ec08330a8a664008511a008