### PR TITLE
fix: use notify helpers in header reload

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -117,11 +117,9 @@
 
 <script>import windowMixin from 'src/mixins/windowMixin'
 import {
-
   defineComponent,
   ref,
   computed,
-  getCurrentInstance,
   onMounted,
   onBeforeUnmount,
   nextTick,
@@ -131,13 +129,12 @@ import { useRoute } from "vue-router";
 import { useUiStore } from "src/stores/ui";
 import { useMessengerStore } from "src/stores/messenger";
 import { useQuasar } from "quasar";
-import { notifySuccess } from "src/js/notify";
+import { notifySuccess, notify, notifyWarning, notifyRefreshed } from "src/js/notify";
 
 export default defineComponent({
   name: "MainHeader",
   mixins: [windowMixin],
   setup() {
-    const vm = getCurrentInstance()?.proxy;
     const ui = useUiStore();
     const route = useRoute();
     const messenger = useMessengerStore();
@@ -203,7 +200,7 @@ export default defineComponent({
         messenger.setDrawer(!messenger.drawerOpen);
       } else {
         messenger.toggleDrawer();
-        vm?.notify(
+        notify(
           messenger.drawerMini ? "Messenger collapsed" : "Messenger expanded",
         );
       }
@@ -226,7 +223,7 @@ export default defineComponent({
           clearInterval(countdownInterval);
           countdown.value = 0;
           reloading.value = false;
-          vm?.notifyWarning("Reload cancelled");
+          notifyWarning("Reload cancelled");
         } finally {
           ui.unlockMutex();
         }
@@ -236,12 +233,12 @@ export default defineComponent({
       ui.lockMutex();
       reloading.value = true;
       countdown.value = 3;
-      vm?.notify("Reloading in 3 seconds…");
+      notify("Reloading in 3 seconds…");
       countdownInterval = setInterval(() => {
         countdown.value--;
         if (countdown.value === 0) {
           clearInterval(countdownInterval);
-          vm?.notifyRefreshed("Reloading…");
+          notifyRefreshed("Reloading…");
           try {
             location.reload();
           } finally {

--- a/src/js/notify.ts
+++ b/src/js/notify.ts
@@ -93,6 +93,26 @@ async function notifyWarning(
   });
 }
 
+async function notifyRefreshed(
+  message: string,
+  position = "top" as QNotifyCreateOptions["position"],
+) {
+  Notify.create({
+    timeout: 5000,
+    type: "positive",
+    message,
+    position,
+    progress: true,
+    actions: [
+      {
+        icon: "close",
+        color: "white",
+        handler: () => {},
+      },
+    ],
+  });
+}
+
 async function notify(
   message: string,
   position = "top" as QNotifyCreateOptions["position"],
@@ -114,4 +134,11 @@ async function notify(
   });
 }
 
-export { notifyApiError, notifySuccess, notifyError, notifyWarning, notify };
+export {
+  notifyApiError,
+  notifySuccess,
+  notifyError,
+  notifyWarning,
+  notify,
+  notifyRefreshed,
+};


### PR DESCRIPTION
## Summary
- import notify helpers in `MainHeader.vue`
- replace `vm?.notify*` calls with helpers to prevent undefined `vm`
- add `notifyRefreshed` helper in `notify.ts`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b17f81bb1c833090dc0fd6305d0ab6