### PR TITLE
Improve relay health handling

### DIFF
--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -1,14 +1,18 @@
 export const DEFAULT_RELAYS = [
-  "wss://relay.damus.io",
-  "wss://relay.primal.net",
-  "wss://relay.snort.social",
-  // Updated to currently active public relays
-  "wss://relay.f7z.io",
+  "wss://relay.nostr.band",
+  "wss://nostr.wine",
+  "wss://nostr.mom",
+  "wss://relayable.org",
   "wss://nos.lol",
 ];
 
+export const FALLBACK_RELAYS = [
+  "wss://nostr.oxtr.dev",
+  "wss://purplerelay.com",
+];
+
 export const FREE_RELAYS = [
-  "wss://relay.damus.io",
-  "wss://relay.primal.net",
+  "wss://relay.nostr.band",
+  "wss://nostr.mom",
   "wss://relayable.org",
 ];

--- a/src/utils/relayHealth.ts
+++ b/src/utils/relayHealth.ts
@@ -1,4 +1,4 @@
-import { FREE_RELAYS } from "src/config/relays";
+import { FREE_RELAYS, FALLBACK_RELAYS } from "src/config/relays";
 
 // keep track of relays that have already produced a constructor error so we only
 // emit a single console message per relay. This keeps startup logs readable when
@@ -121,8 +121,16 @@ export async function filterHealthyRelays(relays: string[]): Promise<string[]> {
   }
 
   if (healthy.length === 0) {
-    throw new Error("no reachable relays");
+    const msg = "No reachable relays. Falling back to public relays.";
+    if (typeof window !== "undefined" && typeof window.alert === "function") {
+      window.alert(msg);
+    } else {
+      console.error(msg);
+    }
+    return FALLBACK_RELAYS;
   }
 
-  return healthy.length >= 2 ? healthy : FREE_RELAYS;
+  return healthy.length >= 2
+    ? healthy
+    : Array.from(new Set([...healthy, ...FALLBACK_RELAYS]));
 }


### PR DESCRIPTION
## Summary
- Replace stale default relays and add explicit fallback relay list
- Gracefully alert when no relays are reachable and merge fallback relays

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b181401f108330ad00ce6599c0cfce