### PR TITLE
chore: serve nostr provider script

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -14,3 +14,7 @@
     Header set Expires "0"
   </FilesMatch>
 </IfModule>
+# Ensure Nostr provider served as JavaScript
+<Files "nostr-provider.js">
+  ForceType application/javascript
+</Files>

--- a/public/nostr-provider.js
+++ b/public/nostr-provider.js
@@ -1,0 +1,9 @@
+/**
+ * Placeholder Nostr provider script.
+ * Browser extensions (e.g., NIP-07 wallets) intercept requests to this path
+ * and inject their own implementation. If no extension is installed,
+ * this file simply warns so the request does not fall back to index.html.
+ */
+if (typeof window !== 'undefined' && typeof (window as any).nostr === 'undefined') {
+  console.warn('No Nostr provider detected.');
+}


### PR DESCRIPTION
## Summary
- add placeholder `public/nostr-provider.js` so Nostr extensions can inject providers
- ensure `.htaccess` serves `nostr-provider.js` with `application/javascript`

## Testing
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*
- `curl -I https://staging.fundstr.me/nostr-provider.js` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b185da25a083309149c49627cddda1