### PR TITLE
refactor(ndk): use dynamic import for dexie cache

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -11,12 +11,8 @@ let dexieAdapter: any;
 async function getDexieAdapter() {
   if (dexieAdapter !== undefined) return dexieAdapter;
   try {
-    const loader = new Function(
-      "m",
-      "return import(m)",
-    ) as (m: string) => Promise<any>;
-    const mod = await loader("@nostr-dev-kit/ndk-cache-dexie");
-    dexieAdapter = new mod.NDKCacheAdapterDexie({ dbName: "fundstrCache" });
+    const mod = await import("@nostr-dev-kit/ndk-cache-dexie");
+    dexieAdapter = new mod.default({ dbName: "fundstrCache" });
   } catch (e) {
     console.warn("[NDK] Dexie cache unavailable", e);
     dexieAdapter = undefined;


### PR DESCRIPTION
## Summary
- simplify dexie cache loading in NDK boot by using native dynamic import

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: ERR_PNPM_FETCH_403 GET https://registry.npmjs.org/@quasar%2Fcli)*
- `pnpm quasar build -m spa`
- `node -e "import('@nostr-dev-kit/ndk-cache-dexie').then(m=>{new m.default({dbName:'fundstrCache'}); console.log('Dexie adapter initialized');}).catch(e=>console.error(e)).finally(()=>process.exit())"`

------
https://chatgpt.com/codex/tasks/task_e_68b187b616708330a07e91e7c93ab3f7