### PR TITLE
Guard menu target ref in BucketCard

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -78,6 +78,7 @@
     </div>
 
     <q-menu
+      v-if="menuTarget"
       v-model="menu"
       anchor="top right"
       self="top right"


### PR DESCRIPTION
## Summary
- guard BucketCard menu with `v-if` so position engine isn't passed a null target

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b189dc8fbc8330aa9a21b8d6209b37