### PR TITLE
fix: dedupe relay disconnect logs

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -32,11 +32,12 @@ export function mergeDefaultRelays(ndk: NDK) {
   }
 }
 
+const reportedRelays = new Set<string>();
+
 function attachRelayErrorHandlers(ndk: NDK) {
-  const reported = new Set<string>();
   ndk.pool.on("relay:disconnect", (relay: any) => {
-    if (reported.has(relay.url)) return;
-    reported.add(relay.url);
+    if (reportedRelays.has(relay.url)) return;
+    reportedRelays.add(relay.url);
     console.debug(`[NDK] relay disconnected: ${relay.url}`);
   });
   ndk.pool.on("notice", (relay: any, notice: string) => {


### PR DESCRIPTION
## Summary
- track disconnected relays at module scope to avoid duplicate logs across rebuilds

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1d681e3408330a6d3f4f5e9e3b8d7