### PR TITLE
chore: remove dashboard route

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,12 +1,5 @@
 const routes = [
   {
-    path: "/dashboard",
-    component: () => import("layouts/MainLayout.vue"),
-    children: [
-      { path: "", component: () => import("src/pages/WalletPage.vue") },
-    ],
-  },
-  {
     path: "/wallet",
     component: () => import("layouts/MainLayout.vue"),
     children: [
@@ -15,7 +8,7 @@ const routes = [
   },
   {
     path: "/",
-    redirect: "/dashboard",
+    redirect: "/wallet",
   },
   {
     path: "/settings",


### PR DESCRIPTION
## Summary
- remove obsolete /dashboard route since /wallet is identical
- redirect root path to /wallet

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1eee40e708330a61e2b2396567af2