### PR TITLE
feat: react to nostr identity changes

### DIFF
--- a/src/components/NostrIdentityManager.vue
+++ b/src/components/NostrIdentityManager.vue
@@ -104,8 +104,7 @@ const removeAlias = (key: string) => {
 };
 
 const save = async () => {
-  nostr.relays = relays.value as any;
-  await nostr.initPrivateKeySigner(privKey.value as any);
+  await nostr.updateIdentity(privKey.value as any, relays.value as any);
   pubKey.value = nostr.npub;
   showDialog.value = false;
 };

--- a/src/components/UserInfo.vue
+++ b/src/components/UserInfo.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, watch } from "vue";
 import { useQuasar } from "quasar";
 import { useNostrStore } from "src/stores/nostr";
 import { shortenString } from "src/js/string-utils";
@@ -46,6 +46,14 @@ const profile = computed(() => {
   const entry: any = (nostr.profiles as any)[nostr.pubkey];
   return entry?.profile ?? entry ?? {};
 });
+
+watch(
+  () => nostr.pubkey,
+  (pk) => {
+    if (pk) nostr.getProfile(pk);
+  },
+  { immediate: true },
+);
 
 const initials = computed(() => {
   const name = profile.value.display_name || profile.value.name || "";

--- a/src/pages/NostrLogin.vue
+++ b/src/pages/NostrLogin.vue
@@ -56,7 +56,7 @@ export default defineComponent({
 
     const submitKey = async () => {
       if (!key.value.trim()) return;
-      await nostr.initPrivateKeySigner(normalizeKey(key.value));
+      await nostr.updateIdentity(normalizeKey(key.value));
       if (!nostr.pubkey) return;
       if (redirect) {
         router.replace({ path: redirect, query: tierId ? { tierId } : undefined });
@@ -68,7 +68,7 @@ export default defineComponent({
     const createIdentity = async () => {
       const sk = generateSecretKey();
       const nsec = nip19.nsecEncode(sk);
-      await nostr.initPrivateKeySigner(nsec);
+      await nostr.updateIdentity(nsec);
       if (!nostr.pubkey) return;
       if (redirect) {
         router.replace({ path: redirect, query: tierId ? { tierId } : undefined });


### PR DESCRIPTION
## Summary
- trigger global identity-change handler when pubkey updates
- namespace messenger storage by pubkey and reset on identity swap
- auto-refresh profile panels and consolidate identity updates

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f28f94708330bd7e26d8da5511b7