### PR TITLE
feat(nostr): recheck nip07 availability

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -902,15 +902,16 @@ export const useNostrStore = defineStore("nostr", {
       }
     },
     checkNip07Signer: async function (force = false): Promise<boolean> {
-      if (this.nip07Checked && !force) return this.nip07SignerAvailable;
+      if (this.nip07Checked && this.nip07SignerAvailable && !force) return true;
       const signer = new NDKNip07Signer();
       try {
         await signer.user();
         this.nip07SignerAvailable = true;
+        this.nip07Checked = true;
       } catch (e) {
         this.nip07SignerAvailable = false;
+        this.nip07Checked = false;
       }
-      this.nip07Checked = true;
       return this.nip07SignerAvailable;
     },
     initNip07Signer: async function () {


### PR DESCRIPTION
## Summary
- poll for NIP-07 extension in identity and welcome flows
- show disabled NIP-07 option with guidance when extension locked
- allow store to retry NIP-07 detection after failures

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1fabdd15083309f7ce0133bfc453a