### PR TITLE
Deduplicate relay configuration

### DIFF
--- a/src/components/RelayManager.vue
+++ b/src/components/RelayManager.vue
@@ -105,12 +105,13 @@ const connect = async () => {
     .split(/\r?\n/)
     .map((r) => r.trim())
     .filter(Boolean);
+  const uniqueUrls = Array.from(new Set(urls));
   try {
     const ndk = await useNdk({ requireSigner: false });
-    for (const url of urls) {
+    for (const url of uniqueUrls) {
       ndk.addExplicitRelay(url);
     }
-    await messenger.connect(urls);
+    await messenger.connect(uniqueUrls);
     notifySuccess("Connected to relays");
   } catch (err: any) {
     notifyError(err?.message || "Failed to connect");

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -1,10 +1,6 @@
 export const DEFAULT_RELAYS = [
   "wss://relay.damus.io",
   "wss://relay.primal.net",
-  "wss://relay.snort.social",
-  // Replaced unreachable relays with active public ones
-  "wss://nostr-pub.wellorder.net",
-  "wss://relay.nostr.band",
 ];
 
 export const FREE_RELAYS = [

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -78,12 +78,12 @@ export const useMessengerStore = defineStore("messenger", {
         () => `cashu.messenger.${nostrStore.pubkey || "anon"}.${suffix}`,
       );
     if (!Array.isArray(settings.defaultNostrRelays)) {
-      settings.defaultNostrRelays = DEFAULT_RELAYS;
+      settings.defaultNostrRelays = Array.from(new Set(DEFAULT_RELAYS));
     }
     const userRelays = Array.isArray(settings.defaultNostrRelays)
-      ? settings.defaultNostrRelays
+      ? Array.from(new Set(settings.defaultNostrRelays))
       : [];
-    const relays = userRelays.length ? userRelays : DEFAULT_RELAYS;
+    const relays = Array.from(new Set(userRelays.length ? userRelays : DEFAULT_RELAYS));
 
     const conversations = useLocalStorage<Record<string, MessengerMessage[]>>(
       storageKey("conversations"),
@@ -709,13 +709,15 @@ export const useMessengerStore = defineStore("messenger", {
 
     async connect(relays: string[]) {
       const nostr = useNostrStore();
-      this.relays = relays as any;
+      const unique = Array.from(new Set(relays));
+      this.relays = unique as any;
       // Reconnect the nostr store with the updated relays
-      await nostr.connect(relays as any);
+      await nostr.connect(unique as any);
     },
 
     removeRelay(relay: string) {
-      this.relays = (this.relays as any).filter((r: string) => r !== relay);
+      const updated = (this.relays as any).filter((r: string) => r !== relay);
+      this.relays = Array.from(new Set(updated));
       const nostr = useNostrStore();
       nostr.connect(this.relays as any);
     },


### PR DESCRIPTION
## Summary
- reduce default relay list to damus and primal
- guard relay connections against duplicates
- ensure messenger store never keeps duplicate relay URLs

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2016844c48330aa5e0160ff53025d