### PR TITLE
Normalize Nostr relays and keep navigation toggle visible

### DIFF
--- a/public/relayHealth.js
+++ b/public/relayHealth.js
@@ -10,6 +10,7 @@ const FREE_RELAYS = [
 const reportedFailures = new Map();
 const alreadyReported = new Set();
 let aggregateTimer = null;
+let allFailedWarned = false;
 
 function scheduleFailureLog() {
   if (aggregateTimer) return;
@@ -115,9 +116,12 @@ export async function filterHealthyRelays(relays) {
     const batchHealthy = results.filter((u) => !!u);
     healthy.push(...batchHealthy);
   }
-
   if (healthy.length === 0) {
-    throw new Error("no reachable relays");
+    if (!allFailedWarned) {
+      console.warn("No reachable relays; falling back to FREE_RELAYS");
+      allFailedWarned = true;
+    }
+    return FREE_RELAYS;
   }
 
   return healthy.length >= 2 ? healthy : FREE_RELAYS;

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-header class="bg-transparent">
+  <q-header class="bg-transparent" style="z-index: 2000">
     <q-toolbar class="app-toolbar" dense>
       <div class="left-controls row items-center no-wrap" v-if="!isWelcomePage">
           <q-btn
@@ -15,13 +15,12 @@
           <q-tooltip>Chats</q-tooltip>
         </q-btn>
           <q-btn
-            v-if="!ui.mainNavOpen"
             flat
             dense
             round
-            icon="menu"
+            :icon="ui.mainNavOpen ? 'close' : 'menu'"
             color="primary"
-            aria-label="Open navigation"
+            aria-label="Toggle navigation"
             :aria-expanded="String(ui.mainNavOpen)"
             aria-controls="app-nav"
             @click="ui.toggleMainNav"

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1236,9 +1236,9 @@ export const useNostrStore = defineStore("nostr", {
       ];
       await event.sign(signer);
 
-      const relayUrls = (relays ?? this.relays).filter((r) =>
-        r.startsWith("wss://"),
-      );
+      const relayUrls = (relays ?? this.relays)
+        .filter((r) => r.startsWith("wss://"))
+        .map((r) => r.replace(/\/+$/, ""));
       let healthyRelays: string[] = [];
       try {
         healthyRelays = await filterHealthyRelays(relayUrls);
@@ -1414,9 +1414,9 @@ export const useNostrStore = defineStore("nostr", {
       wrapEvent.id = wrapEvent.getEventHash();
       wrapEvent.sig = await wrapEvent.sign();
 
-      const relayUrls = (relays ?? this.relays).filter((r) =>
-        r.startsWith("wss://"),
-      );
+      const relayUrls = (relays ?? this.relays)
+        .filter((r) => r.startsWith("wss://"))
+        .map((r) => r.replace(/\/+$/, ""));
       let healthyRelays: string[] = [];
       try {
         healthyRelays = await filterHealthyRelays(relayUrls);
@@ -1766,9 +1766,9 @@ export async function signEvent(
 }
 
 export async function publishEvent(event: NostrEvent): Promise<void> {
-  const relayUrls = useSettingsStore().defaultNostrRelays.filter((r) =>
-    r.startsWith("wss://"),
-  );
+  const relayUrls = useSettingsStore().defaultNostrRelays
+    .filter((r) => r.startsWith("wss://"))
+    .map((r) => r.replace(/\/+$/, ""));
   let healthyRelays: string[] = [];
   try {
     healthyRelays = await filterHealthyRelays(relayUrls);
@@ -1795,7 +1795,9 @@ export async function subscribeToNostr(
   const relayUrls = (relays && relays.length > 0
     ? relays
     : useSettingsStore().defaultNostrRelays
-  ).filter((r) => r.startsWith("wss://"));
+  )
+    .filter((r) => r.startsWith("wss://"))
+    .map((r) => r.replace(/\/+$/, ""));
   if (!relayUrls || relayUrls.length === 0) {
     console.warn("[nostr] subscribeMany called with empty relay list");
     return false;

--- a/src/utils/relayHealth.ts
+++ b/src/utils/relayHealth.ts
@@ -6,6 +6,7 @@ import { FREE_RELAYS } from "src/config/relays";
 const reportedFailures = new Map<string, number>();
 const alreadyReported = new Set<string>();
 let aggregateTimer: ReturnType<typeof setTimeout> | null = null;
+let allFailedWarned = false;
 
 function scheduleFailureLog() {
   if (aggregateTimer) return;
@@ -111,9 +112,12 @@ export async function filterHealthyRelays(relays: string[]): Promise<string[]> {
     const batchHealthy = results.filter((u): u is string => !!u);
     healthy.push(...batchHealthy);
   }
-
   if (healthy.length === 0) {
-    throw new Error("no reachable relays");
+    if (!allFailedWarned) {
+      console.warn("No reachable relays; falling back to FREE_RELAYS");
+      allFailedWarned = true;
+    }
+    return FREE_RELAYS;
   }
 
   return healthy.length >= 2 ? healthy : FREE_RELAYS;


### PR DESCRIPTION
## Summary
- Trim trailing slashes from relay URLs before health checks
- Fallback to FREE_RELAYS with single warning when all pings fail
- Keep navigation button visible with toggle icon and higher z-index

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2871f8ce483308bc18610befdcfca