### PR TITLE
refactor: unify DM send path

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -213,7 +213,7 @@ export async function ndkSend(
     );
   }
   const list = relays.length ? relays : ["wss://relay.damus.io"];
-  const { success } = await nostr.sendNip04DirectMessage(
+  const { success } = await nostr.sendDirectMessageUnified(
     toNpub,
     plaintext,
     undefined,

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1218,7 +1218,7 @@ export default defineComponent({
             };
             const dmContent = JSON.stringify(payload);
             const { success, event } =
-              await useNostrStore().sendNip04DirectMessage(
+              await useNostrStore().sendDirectMessageUnified(
                 recipient,
                 dmContent,
               );
@@ -1372,7 +1372,7 @@ export default defineComponent({
             };
             const dmContent2 = JSON.stringify(payload2);
             const { success, event } =
-              await useNostrStore().sendNip04DirectMessage(
+              await useNostrStore().sendDirectMessageUnified(
                 recipient,
                 dmContent2,
               );

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -424,7 +424,7 @@ export default {
     ...mapActions(useNWCStore, ["listenToNWCCommands"]),
     ...mapActions(useNPCStore, ["generateNPCConnection", "claimAllTokens"]),
     ...mapActions(useNostrStore, [
-      "sendNip04DirectMessage",
+      "sendDirectMessageUnified",
       "subscribeToNip04DirectMessages",
       "subscribeToNip17DirectMessages",
       "initSigner",

--- a/test/vitest/__tests__/messenger-send-token.spec.ts
+++ b/test/vitest/__tests__/messenger-send-token.spec.ts
@@ -15,7 +15,7 @@ vi.mock("../../../src/stores/nostr", async (importOriginal) => {
   return {
     ...actual,
     useNostrStore: () => ({
-      sendNip04DirectMessage: sendDm,
+      sendDirectMessageUnified: sendDm,
       initSignerIfNotSet: vi.fn(),
       privateKeySignerPrivateKey: "priv",
       seedSignerPrivateKey: "",

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -19,7 +19,7 @@ vi.mock("../../../src/stores/nostr", async (importOriginal) => {
   );
   walletGen = vi.fn();
   const store = {
-    sendNip04DirectMessage: sendDm,
+    sendDirectMessageUnified: sendDm,
     decryptNip04: decryptDm,
     subscribeToNip04DirectMessagesCallback: subscribe,
     walletSeedGenerateKeyPair: walletGen,

--- a/test/vitest/__tests__/nostr.spec.ts
+++ b/test/vitest/__tests__/nostr.spec.ts
@@ -68,10 +68,10 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("sendNip04DirectMessage", () => {
+describe("sendDirectMessageUnified", () => {
   it("returns signed event when published", async () => {
     const store = useNostrStore();
-    const promise = store.sendNip04DirectMessage("r", "m");
+    const promise = store.sendDirectMessageUnified("r", "m");
     vi.runAllTimers();
     const res = await promise;
     expect(res.success).toBe(true);
@@ -84,7 +84,7 @@ describe("sendNip04DirectMessage", () => {
 
   it("constructs event with correct kind and tags", async () => {
     const store = useNostrStore();
-    const res = await store.sendNip04DirectMessage("receiver", "msg");
+    const res = await store.sendDirectMessageUnified("receiver", "msg");
     vi.runAllTimers();
     expect(res.event!.kind).toBe(NDKKind.EncryptedDirectMessage);
     expect(res.event!.tags).toContainEqual(["p", "receiver"]);
@@ -94,7 +94,7 @@ describe("sendNip04DirectMessage", () => {
   it("generates keypair if not set", async () => {
     const store = useNostrStore();
     expect(store.seedSignerPrivateKey).toBe("");
-    const res = await store.sendNip04DirectMessage("receiver", "msg");
+    const res = await store.sendDirectMessageUnified("receiver", "msg");
     vi.runAllTimers();
     expect(res.success).toBe(true);
     expect(res.event).not.toBeNull();
@@ -104,7 +104,7 @@ describe("sendNip04DirectMessage", () => {
   it("returns null when publish fails", async () => {
     const store = useNostrStore();
     publishSuccess = false;
-    const promise = store.sendNip04DirectMessage("r", "m");
+    const promise = store.sendDirectMessageUnified("r", "m");
     vi.runAllTimers();
     const res = await promise;
     expect(res.success).toBe(false);


### PR DESCRIPTION
## Summary
- add relay selection and NIP-04 publish helpers
- unify direct message sending with `sendDirectMessageUnified`
- update messenger and UI to await send result

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm vitest run test/vitest/__tests__/nostr.spec.ts test/vitest/__tests__/messenger.spec.ts test/vitest/__tests__/messenger-send-token.spec.ts` *(fails: Cannot access 'notifySuccess' before initialization, other mock/setup errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b293e8c44c833096c836828a821cbe