### PR TITLE
feat(nostr): add relay watchdog and sticky DM subscription

### DIFF
--- a/src/js/nostr-runtime.ts
+++ b/src/js/nostr-runtime.ts
@@ -1,0 +1,80 @@
+import type NDK from "@nostr-dev-kit/ndk";
+import { NDKKind, type NDKEvent, type NDKFilter } from "@nostr-dev-kit/ndk";
+import { useNdk } from "src/composables/useNdk";
+
+export class RelayWatchdog {
+  private ndk: NDK;
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(ndk: NDK) {
+    this.ndk = ndk;
+  }
+
+  start(minConnected: number, fallbackRelays: string[]) {
+    const check = async () => {
+      try {
+        const pool = this.ndk.pool;
+        const connected = [...pool.relays.values()].filter(
+          (r: any) => r.connected,
+        ).length;
+        if (connected >= minConnected) return;
+        for (const url of fallbackRelays) {
+          if (!pool.relays.has(url)) {
+            this.ndk.addExplicitRelay(url);
+          }
+        }
+        await this.ndk.connect();
+      } catch (e) {
+        console.error("[RelayWatchdog]", e);
+      }
+    };
+    // run immediately and then periodically
+    void check();
+    this.timer = setInterval(() => {
+      void check();
+    }, 5000);
+  }
+
+  stop() {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+  }
+}
+
+export async function stickyDmSubscription(
+  pubkey: string,
+  getSince: () => number,
+  handler: (ev: NDKEvent) => void | Promise<void>,
+): Promise<() => void> {
+  const ndk = await useNdk();
+  let sub: any;
+
+  const subscribe = () => {
+    const since = getSince();
+    const filter: NDKFilter = {
+      kinds: [NDKKind.EncryptedDirectMessage],
+      "#p": [pubkey],
+      since,
+    };
+    if (sub) {
+      try {
+        sub.stop();
+      } catch {}
+    }
+    sub = ndk.subscribe(filter, { closeOnEose: false, groupable: false });
+    sub.on("event", handler);
+  };
+
+  subscribe();
+  ndk.pool.on("relay:connect", subscribe);
+
+  return () => {
+    ndk.pool.off("relay:connect", subscribe);
+    if (sub) {
+      try {
+        sub.stop();
+      } catch {}
+    }
+  };
+}
+


### PR DESCRIPTION
## Summary
- ensure Nostr connections stay healthy with a RelayWatchdog that auto-reconnects using fallback relays
- keep DM feed alive across reconnects via stickyDmSubscription and messenger resubscribe logic

## Testing
- `pnpm lint` *(fails: command not found)*
- `pnpm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b29883eac48330b41527c7b4daaffa