### PR TITLE
feat: add durable outbox with retry

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -239,6 +239,7 @@ export default defineComponent({
         messenger.disconnect();
         messenger.started = false;
         await messenger.start();
+        await messenger.retryOutbox();
       } catch (e) {
         console.error(e);
       } finally {

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -43,6 +43,12 @@ function parseSubscriptionPaymentPayload(obj: any):
   };
 }
 
+export function computeNextRetry(attempts: number): number {
+  const base = Math.min(60 * 60, Math.pow(2, attempts) * 5);
+  const jitter = Math.floor(Math.random() * base);
+  return Math.floor(Date.now() / 1000) + base + jitter;
+}
+
 export interface SubscriptionPayment {
   token: string;
   subscription_id: string;
@@ -69,6 +75,10 @@ export type MessengerMessage = {
   subscriptionPayment?: SubscriptionPayment;
   tokenPayload?: any;
   autoRedeem?: boolean;
+  attempts?: number;
+  lastTriedAt?: number;
+  nextRetryAt?: number;
+  relayAcks?: string[];
 };
 
 export const useMessengerStore = defineStore("messenger", {
@@ -107,6 +117,10 @@ export const useMessengerStore = defineStore("messenger", {
       storageKey("eventLog"),
       [] as MessengerMessage[],
     );
+    const outbox = useLocalStorage<MessengerMessage[]>(
+      storageKey("outbox"),
+      [] as MessengerMessage[],
+    );
     const drawerOpen = useLocalStorage<boolean>(storageKey("drawerOpen"), true);
     const drawerMini = useLocalStorage<boolean>(storageKey("drawerMini"), false);
 
@@ -118,6 +132,7 @@ export const useMessengerStore = defineStore("messenger", {
         pinned.value = {} as any;
         aliases.value = {} as any;
         eventLog.value = [] as any;
+        outbox.value = [] as any;
       },
     );
 
@@ -128,7 +143,7 @@ export const useMessengerStore = defineStore("messenger", {
       pinned,
       aliases,
       eventLog,
-      sendQueue: [] as MessengerMessage[],
+      outbox,
       currentConversation: "",
       drawerOpen,
       drawerMini,
@@ -218,7 +233,7 @@ export const useMessengerStore = defineStore("messenger", {
       let privKey: string | undefined = undefined;
       if (nostr.signerType !== "NIP07" && nostr.signerType !== "NIP46") {
         privKey = nostr.privKeyHex;
-        if (!privKey) return { success: false, event: null } as any;
+        if (!privKey) return { success: false, message: null } as any;
       }
       const msg = this.addOutgoingMessage(
         recipient,
@@ -229,29 +244,30 @@ export const useMessengerStore = defineStore("messenger", {
         "pending",
         tokenPayload,
       );
-
+      msg.attempts = (msg.attempts || 0) + 1;
+      msg.lastTriedAt = Math.floor(Date.now() / 1000);
       const list = relays && relays.length ? relays : (this.relays as any);
       try {
-        const { success, event } = await nostr.sendDirectMessageUnified(
+        const { ok, acks } = await nostr.publishNip04ToRelaysWithAcks(
           recipient,
           message,
-          privKey,
-          nostr.pubkey,
           list,
+          privKey,
         );
-        if (success && event) {
-          msg.id = event.id;
-          msg.created_at = event.created_at ?? Math.floor(Date.now() / 1000);
+        msg.relayAcks = acks;
+        if (ok) {
           msg.status = "sent";
-          this.pushOwnMessage(event as any);
-          return { success: true, event } as any;
+          return { success: true, message: msg } as any;
         }
       } catch (e) {
         console.error("[messenger.sendDm]", e);
       }
       msg.status = "failed";
-      this.sendQueue.push(msg);
-      return { success: false } as any;
+      msg.nextRetryAt = computeNextRetry(msg.attempts || 0);
+      const idx = this.outbox.findIndex((m) => m.id === msg.id);
+      if (idx >= 0) this.outbox[idx] = msg;
+      else this.outbox.push(msg);
+      return { success: false, message: msg } as any;
     },
     async sendToken(
       recipient: string,
@@ -309,19 +325,19 @@ export const useMessengerStore = defineStore("messenger", {
               referenceId: uuidv4(),
             };
 
-        const { success, event } = await this.sendDm(
+        const { success, message: sentMsg } = await this.sendDm(
           recipient,
           JSON.stringify(payload),
           undefined,
           undefined,
           { token: tokenStr, amount: sendAmount, memo },
         );
-        if (success && event) {
+        if (success && sentMsg) {
           if (subscription) {
             const msg = this.conversations[recipient]?.find(
-              (m) => m.id === event.id,
+              (m) => m.id === sentMsg.id,
             );
-            const logMsg = this.eventLog.find((m) => m.id === event.id);
+            const logMsg = this.eventLog.find((m) => m.id === sentMsg.id);
             const payment: SubscriptionPayment & { htlc_hash?: string } = {
               token: tokenStr,
               subscription_id: subscription.subscription_id,
@@ -389,15 +405,14 @@ export const useMessengerStore = defineStore("messenger", {
           memo: memo || undefined,
         };
 
-        const { success, event } = await this.sendDm(
+        const { success } = await this.sendDm(
           recipient,
           JSON.stringify(payload),
           undefined,
           undefined,
           { token: tokenStr, amount: sendAmount, memo },
         );
-
-        if (success && event) {
+        if (success) {
           tokens.addPendingToken({
             amount: -sendAmount,
             tokenStr: tokenStr,
@@ -436,6 +451,8 @@ export const useMessengerStore = defineStore("messenger", {
         attachment,
         status,
         tokenPayload,
+        attempts: 0,
+        relayAcks: [],
       };
       if (!this.conversations[pubkey]) this.conversations[pubkey] = [];
       if (!this.conversations[pubkey].some((m) => m.id === messageId))
@@ -660,7 +677,7 @@ export const useMessengerStore = defineStore("messenger", {
         watch(
           () => useNostrStore().connected,
           (val) => {
-            if (val) this.retryFailedMessages();
+            if (val) this.retryOutbox();
           },
         );
         this.watchInitialized = true;
@@ -696,6 +713,7 @@ export const useMessengerStore = defineStore("messenger", {
         console.error("[messenger.start]", e);
       } finally {
         this.started = true;
+        await this.retryOutbox();
       }
     },
 
@@ -724,8 +742,9 @@ export const useMessengerStore = defineStore("messenger", {
       nostr.disconnect();
     },
 
-    async retryFailedMessages() {
-      if (!this.isConnected() || !this.sendQueue.length) return;
+    async retryOutbox() {
+      if (!this.isConnected() || !this.outbox.length) return;
+      await this.loadIdentity();
       const nostr = useNostrStore();
       let privKey: string | undefined = undefined;
       if (nostr.signerType !== "NIP07" && nostr.signerType !== "NIP46") {
@@ -733,29 +752,31 @@ export const useMessengerStore = defineStore("messenger", {
         if (!privKey) return;
       }
       const list = this.relays as any;
-      for (const msg of [...this.sendQueue]) {
+      const now = Math.floor(Date.now() / 1000);
+      for (const msg of [...this.outbox]) {
+        if (msg.nextRetryAt && msg.nextRetryAt > now) continue;
+        msg.attempts = (msg.attempts || 0) + 1;
+        msg.lastTriedAt = now;
         try {
-          const { success, event } = await nostr.sendDirectMessageUnified(
+          const { ok, acks } = await nostr.publishNip04ToRelaysWithAcks(
             msg.pubkey,
             msg.content,
-            privKey,
-            nostr.pubkey,
             list,
+            privKey,
           );
-          if (success && event) {
-            msg.id = event.id;
-            msg.created_at =
-              event.created_at ?? Math.floor(Date.now() / 1000);
+          msg.relayAcks = acks;
+          if (ok) {
             msg.status = "sent";
-            this.pushOwnMessage(event as any);
-            const idx = this.sendQueue.indexOf(msg);
-            if (idx >= 0) this.sendQueue.splice(idx, 1);
+            const idx = this.outbox.indexOf(msg);
+            if (idx >= 0) this.outbox.splice(idx, 1);
           } else {
-            if (msg.status !== "sent") msg.status = "failed";
+            msg.status = "failed";
+            msg.nextRetryAt = computeNextRetry(msg.attempts);
           }
         } catch (e) {
-          console.error("[messenger.retryFailedMessages]", e);
-          if (msg.status !== "sent") msg.status = "failed";
+          console.error("[messenger.retryOutbox]", e);
+          msg.status = "failed";
+          msg.nextRetryAt = computeNextRetry(msg.attempts);
         }
       }
     },


### PR DESCRIPTION
## Summary
- add message metadata and exponential backoff scheduling helper
- persist messenger outbox in localStorage and retry with concurrent relay publishing
- reconnect action retries unsent messages

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a29b26808330be133bb7deef74f8