### PR TITLE
fix: harden pubkey and relay handling

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -229,7 +229,10 @@ const profile = computed(() => {
   return entry?.profile ?? entry ?? {};
 });
 
-const alias = computed(() => messenger.aliases[props.pubkey]);
+const alias = computed(() => {
+  const a = messenger.aliases[props.pubkey];
+  return typeof a === "string" ? a : "";
+});
 const profileName = computed(() => {
   const p: any = profile.value;
   return (
@@ -239,10 +242,14 @@ const profileName = computed(() => {
     props.pubkey.slice(0, 8) + "…"
   );
 });
-const displayName = computed(() => alias.value || profileName.value);
+const displayName = computed(() => {
+  const name = alias.value || profileName.value;
+  return typeof name === "string" ? name : "";
+});
 
 const initials = computed(() => {
   const name = displayName.value;
+  if (typeof name !== "string") return "";
   const words = name.split(/\s+/).filter(Boolean);
   const letters = words.slice(0, 2).map((w) => w[0]);
   return letters.join("").toUpperCase();


### PR DESCRIPTION
## Summary
- validate pubkey formats before decoding and skip invalid keys
- guard messenger conversations and initials against bad keys
- cache relay health results and fall back to default relays for DMs

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2aa7edf14833093dcdf02a8495d13