### PR TITLE
feat: specify nostr subprotocol for relay pings

### DIFF
--- a/src/utils/relayHealth.ts
+++ b/src/utils/relayHealth.ts
@@ -38,7 +38,7 @@ export async function pingRelay(url: string): Promise<boolean> {
       let settled = false;
       let ws: WebSocket;
       try {
-        ws = new WebSocket(url);
+        ws = new WebSocket(url, 'nostr');
       } catch {
         resolve(false);
         return;


### PR DESCRIPTION
## Summary
- use nostr subprotocol when pinging relays to handle servers that require it

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: ERR_PNPM_FETCH_403 Forbidden)*
- `pnpm quasar build -m spa`
- `node - <<'NODE' ...` *(ENETUNREACH attempting to ping relays)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b04e33d48330888d7764039adf8f