### PR TITLE
Ensure DM relays connect before publishing NIP-04

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1307,6 +1307,16 @@ export const useNostrStore = defineStore("nostr", {
           return { success: false, event: null };
         }
       }
+      await this.ensureNdkConnected(selected);
+      try {
+        await ensureRelayConnectivity(ndk);
+      } catch (e: any) {
+        notifyError(
+          "Unable to connect to Nostr relays",
+          e?.message ?? String(e),
+        );
+        return { success: false, event: null };
+      }
       const success = await publishDmNip04(event, selected);
       return { success, event: success ? event : null };
     },


### PR DESCRIPTION
## Summary
- ensure NDK connects to selected relays before sending DMs
- surface relay connection failures with clear error notifications

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b1683d3c83308ab8526614544a11