### PR TITLE
Improve relay selection and management

### DIFF
--- a/src/components/NostrIdentityManager.vue
+++ b/src/components/NostrIdentityManager.vue
@@ -80,8 +80,10 @@ import { ref, onMounted } from "vue";
 import { storeToRefs } from "pinia";
 import { useNostrStore } from "src/stores/nostr";
 import { useMessengerStore } from "src/stores/messenger";
+import { useSettingsStore } from "src/stores/settings";
 
 const nostr = useNostrStore();
+const settings = useSettingsStore();
 const { nip07SignerAvailable } = storeToRefs(nostr);
 const { checkNip07Signer, connectBrowserSigner } = nostr;
 const hasNip07 = ref(false);
@@ -103,7 +105,7 @@ const showDialog = ref(false);
 const privKey = ref(nostr.activePrivateKeyNsec);
 const pubKey = ref(nostr.npub);
 const relayInput = ref("");
-const relays = ref<string[]>([...nostr.relays]);
+const relays = ref<string[]>([...settings.defaultNostrRelays]);
 const messenger = useMessengerStore();
 const aliases = messenger.aliases as any;
 const aliasPubkey = ref("");
@@ -141,7 +143,8 @@ const useNip07 = async () => {
 };
 
 const save = async () => {
-  await nostr.updateIdentity(privKey.value as any, relays.value as any);
+  settings.defaultNostrRelays = [...relays.value];
+  await nostr.updateIdentity(privKey.value as any, settings.defaultNostrRelays);
   pubKey.value = nostr.npub;
   showDialog.value = false;
 };

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -1,10 +1,17 @@
 export const DEFAULT_RELAYS = [
   "wss://relay.damus.io",
   "wss://relay.primal.net",
+  "wss://nos.lol",
+  "wss://eden.nostr.land",
+  "wss://relay.snort.social",
 ];
 
 export const FREE_RELAYS = [
   "wss://relay.damus.io",
   "wss://relay.primal.net",
   "wss://relayable.org",
+  "wss://nos.lol",
+  "wss://eden.nostr.land",
+  "wss://relay.snort.social",
+  "wss://nostr.mom",
 ];

--- a/test/vitest/__tests__/relaySelection.spec.ts
+++ b/test/vitest/__tests__/relaySelection.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, beforeEach, expect, vi } from "vitest";
+import { selectPreferredRelays, resetRelaySelection } from "../../../src/stores/nostr";
+import * as relayHealth from "../../../src/utils/relayHealth";
+
+const filterHealthyRelaysMock = vi.spyOn(relayHealth, "filterHealthyRelays");
+
+describe("selectPreferredRelays", () => {
+  beforeEach(() => {
+    resetRelaySelection();
+    filterHealthyRelaysMock.mockReset();
+  });
+
+  it("rotates among healthy relays", async () => {
+    filterHealthyRelaysMock.mockResolvedValue(["wss://a", "wss://b"]);
+    const first = await selectPreferredRelays(["wss://a", "wss://b"]);
+    const second = await selectPreferredRelays(["wss://a", "wss://b"]);
+    expect(first).toEqual(["wss://a", "wss://b"]);
+    expect(second).toEqual(["wss://b", "wss://a"]);
+  });
+
+  it("drops relays that repeatedly fail", async () => {
+    filterHealthyRelaysMock.mockResolvedValueOnce([]);
+    await selectPreferredRelays(["wss://bad"]);
+    filterHealthyRelaysMock.mockResolvedValueOnce([]);
+    await selectPreferredRelays(["wss://bad"]);
+    filterHealthyRelaysMock.mockResolvedValueOnce([]);
+    await selectPreferredRelays(["wss://bad"]);
+    filterHealthyRelaysMock.mockResolvedValue(["wss://good"]);
+    const res = await selectPreferredRelays(["wss://bad", "wss://good"]);
+    expect(res).toEqual(["wss://good"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add additional default and free Nostr relays
- rotate healthy relays and prune failures in selectPreferredRelays
- allow editing Nostr relay list via settings in identity manager
- add tests for relay rotation and failure pruning

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm vitest run test/vitest/__tests__/relaySelection.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b2b2a682208330b2bd0c0888819d8c