### PR TITLE
feat: handle non-json incoming messages

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -513,11 +513,15 @@ export const useMessengerStore = defineStore("messenger", {
       let tokenPayload: any | undefined;
       const lines = decrypted.split("\n").filter((l) => l.trim().length > 0);
       for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+          continue;
+        }
         let payload: any;
         try {
-          payload = JSON.parse(line);
+          payload = JSON.parse(trimmed);
         } catch (e) {
-          console.warn("[messenger.addIncomingMessage] invalid JSON", e);
+          console.debug("[messenger.addIncomingMessage] invalid JSON", e);
           continue;
         }
         const sub = parseSubscriptionPaymentPayload(payload);


### PR DESCRIPTION
## Summary
- Skip JSON parsing for non-JSON lines in messenger store
- Downgrade warning to debug log to avoid console clutter

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b75e01708330afc4fab884c8b428