### PR TITLE
fix: use direct notify helpers and handle NIP-07 fallback

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export default configure(() => ({
-  boot: ['welcomeGate', 'cashu', 'i18n', 'node-globals'],
+  boot: ['welcomeGate', 'cashu', 'i18n', 'node-globals', 'notify'],
   css: ['app.scss', 'base.scss', 'buckets.scss'],
   extras: ['roboto-font', 'material-icons'],
   build: {

--- a/src/boot/notify.ts
+++ b/src/boot/notify.ts
@@ -1,0 +1,18 @@
+import { boot } from "quasar/wrappers";
+import {
+  notify,
+  notifyWarning,
+  notifyError,
+  notifySuccess,
+  notifyApiError,
+  notifyRefreshed,
+} from "src/js/notify";
+
+export default boot(({ app }) => {
+  app.config.globalProperties.notify = notify;
+  app.config.globalProperties.notifyWarning = notifyWarning;
+  app.config.globalProperties.notifyError = notifyError;
+  app.config.globalProperties.notifySuccess = notifySuccess;
+  app.config.globalProperties.notifyApiError = notifyApiError;
+  app.config.globalProperties.notifyRefreshed = notifyRefreshed;
+});

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -120,7 +120,6 @@ import {
   defineComponent,
   ref,
   computed,
-  getCurrentInstance,
   onMounted,
   onBeforeUnmount,
   nextTick,
@@ -130,13 +129,17 @@ import { useRoute } from "vue-router";
 import { useUiStore } from "src/stores/ui";
 import { useMessengerStore } from "src/stores/messenger";
 import { useQuasar } from "quasar";
-import { notifySuccess } from "src/js/notify";
+import {
+  notifySuccess,
+  notify,
+  notifyWarning,
+  notifyRefreshed,
+} from "src/js/notify";
 
 export default defineComponent({
   name: "MainHeader",
   mixins: [windowMixin],
   setup() {
-    const vm = getCurrentInstance()?.proxy;
     const ui = useUiStore();
     const route = useRoute();
     const messenger = useMessengerStore();
@@ -202,7 +205,7 @@ export default defineComponent({
         messenger.setDrawer(!messenger.drawerOpen);
       } else {
         messenger.toggleDrawer();
-        vm?.notify(
+        notify(
           messenger.drawerMini ? "Messenger collapsed" : "Messenger expanded",
         );
       }
@@ -225,7 +228,7 @@ export default defineComponent({
           clearInterval(countdownInterval);
           countdown.value = 0;
           reloading.value = false;
-          vm?.notifyWarning("Reload cancelled");
+          notifyWarning("Reload cancelled");
         } finally {
           ui.unlockMutex();
         }
@@ -235,12 +238,12 @@ export default defineComponent({
       ui.lockMutex();
       reloading.value = true;
       countdown.value = 3;
-      vm?.notify("Reloading in 3 seconds…");
+      notify("Reloading in 3 seconds…");
       countdownInterval = setInterval(() => {
         countdown.value--;
         if (countdown.value === 0) {
           clearInterval(countdownInterval);
-          vm?.notifyRefreshed("Reloading…");
+          notifyRefreshed("Reloading…");
           try {
             location.reload();
           } finally {

--- a/src/js/notify.ts
+++ b/src/js/notify.ts
@@ -53,6 +53,13 @@ async function notifySuccess(
   });
 }
 
+function notifyRefreshed(
+  message: string,
+  position = "top" as QNotifyCreateOptions["position"],
+) {
+  return notifySuccess(message, position);
+}
+
 async function notifyError(msg: any, caption?: any) {
   Notify.create({
     color: "red",
@@ -114,4 +121,11 @@ async function notify(
   });
 }
 
-export { notifyApiError, notifySuccess, notifyError, notifyWarning, notify };
+export {
+  notifyApiError,
+  notifySuccess,
+  notifyError,
+  notifyWarning,
+  notify,
+  notifyRefreshed,
+};

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -74,6 +74,7 @@ import MessageInput from "components/MessageInput.vue";
 import ChatSendTokenDialog from "components/ChatSendTokenDialog.vue";
 import NostrSetupWizard from "components/NostrSetupWizard.vue";
 import { useQuasar, TouchSwipe } from "quasar";
+import { notifyWarning, notifyError } from "src/js/notify";
 
 export default defineComponent({
   name: "NostrMessenger",
@@ -253,15 +254,16 @@ export default defineComponent({
     };
 
     const switchAccount = async () => {
-      const hasExt = await nostr.checkNip07Signer(true);
-      if (!hasExt) {
-        $q.notify({ type: "negative", message: "No NIP-07 extension detected" });
-        return;
-      }
       try {
+        const hasExt = await nostr.checkNip07Signer(true);
+        if (!hasExt) {
+          notifyWarning("No NIP-07 extension detected");
+          return;
+        }
         await nostr.connectBrowserSigner();
       } catch (e) {
         console.error(e);
+        notifyError("Failed to connect NIP-07 provider");
       }
     };
 


### PR DESCRIPTION
## Summary
- fix reload button by calling notify helpers directly
- show warning when NIP-07 provider is missing
- expose notify helpers as global properties

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2bc84e49c83309fb4674122b12a73