### PR TITLE
Centralize Nostr identity checks

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -227,7 +227,7 @@ const gotoTerms = () => goto("/terms");
 const gotoAbout = () => goto("/about");
 const gotoWelcome = () => goto("/welcome");
 
-const needsNostrLogin = computed(() => !nostrStore.privateKeySignerPrivateKey);
+const needsNostrLogin = computed(() => !nostrStore.hasIdentity);
 const isGuest = computed(() => !welcomeStore.welcomeCompleted);
 
 const drawerContentClass = computed(() =>

--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -109,7 +109,7 @@ export function useCreatorHub() {
   const splitterModel = ref(50);
   const tab = ref<"profile" | "tiers">("profile");
 
-  const loggedIn = computed(() => !!useNostrStore().pubkey);
+  const loggedIn = computed(() => useNostrStore().hasIdentity);
   const tierList = computed<Tier[]>(() => store.getTierArray());
   const draggableTiers = ref<Tier[]>([]);
   const deleteDialog = ref(false);
@@ -139,7 +139,7 @@ export function useCreatorHub() {
   }
 
   async function initPage() {
-    if (!nostr.pubkey) return;
+    if (!nostr.hasIdentity) return;
     await nostr.initSignerIfNotSet();
     const p = await nostr.getProfile(nostr.pubkey);
     if (p) profileStore.setProfile(p);
@@ -275,7 +275,7 @@ export function useCreatorHub() {
   }
 
   onMounted(() => {
-    if (nostr.pubkey) initPage();
+    if (nostr.hasIdentity) initPage();
   });
 
   return {

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -237,7 +237,7 @@ export default defineComponent({
     );
 
     async function initProfile() {
-      if (!npub.value) return;
+      if (!nostr.hasIdentity) return;
       const p = await nostr.getProfile(npub.value);
       if (p) {
         if (p.picture && !isTrustedUrl(p.picture)) {

--- a/src/pages/NostrLogin.vue
+++ b/src/pages/NostrLogin.vue
@@ -57,7 +57,7 @@ export default defineComponent({
     const submitKey = async () => {
       if (!key.value.trim()) return;
       await nostr.updateIdentity(normalizeKey(key.value));
-      if (!nostr.pubkey) return;
+      if (!nostr.hasIdentity) return;
       if (redirect) {
         router.replace({ path: redirect, query: tierId ? { tierId } : undefined });
       } else {
@@ -69,7 +69,7 @@ export default defineComponent({
       const sk = generateSecretKey();
       const nsec = nip19.nsecEncode(sk);
       await nostr.updateIdentity(nsec);
-      if (!nostr.pubkey) return;
+      if (!nostr.hasIdentity) return;
       if (redirect) {
         router.replace({ path: redirect, query: tierId ? { tierId } : undefined });
       } else {

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -134,7 +134,7 @@ export default defineComponent({
     }
 
     async function checkAndInit() {
-      if (!nostr.pubkey || nostr.relays.length === 0) {
+      if (!nostr.hasIdentity || nostr.relays.length === 0) {
         loading.value = false;
         showSetupWizard.value = true;
         return;

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -196,7 +196,7 @@ export default defineComponent({
         showSetupDialog.value = true
         return
       }
-      if (!nostr.pubkey && !nostr.signer) {
+      if (!nostr.hasIdentity) {
         showSetupDialog.value = true
         return
       }
@@ -216,7 +216,7 @@ export default defineComponent({
       await loadProfile()
 
       const tierId = route.query.tierId as string | undefined
-      if (!nostr.pubkey || !tierId) return
+      if (!nostr.hasIdentity || !tierId) return
       const tryOpen = () => {
         const t = tiers.value.find((ti: any) => ti.id === tierId)
         if (t) {

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -660,6 +660,7 @@ export const useNostrStore = defineStore("nostr", {
           return "";
       }
     },
+    hasIdentity: (state) => Boolean(state.pubkey && state.signerType),
   },
   actions: {
     loadKeysFromStorage: async function () {

--- a/test/vitest/__tests__/creatorHub-navigation.spec.ts
+++ b/test/vitest/__tests__/creatorHub-navigation.spec.ts
@@ -33,8 +33,8 @@ vi.mock('nostr-tools', () => ({ nip19: { npubEncode: (s: string) => `npub${s}`, 
 vi.mock('../../../src/composables/useCreatorHub', () => ({
   useCreatorHub: () => {
     const nostr = useNostrStore()
-    const loggedIn = computed(() => !!nostr.pubkey)
-    const npub = computed(() => (nostr.pubkey ? `npub${nostr.pubkey}` : ''))
+    const loggedIn = computed(() => nostr.hasIdentity)
+    const npub = computed(() => (nostr.hasIdentity ? `npub${nostr.pubkey}` : ''))
     return {
       loggedIn,
       npub,

--- a/test/vitest/__tests__/nostr-login-flow.spec.ts
+++ b/test/vitest/__tests__/nostr-login-flow.spec.ts
@@ -43,8 +43,8 @@ vi.mock("nostr-tools", () => ({
 vi.mock("../../../src/composables/useCreatorHub", () => ({
   useCreatorHub: () => {
     const nostr = useNostrStore();
-    const loggedIn = computed(() => !!nostr.pubkey);
-    const npub = computed(() => (nostr.pubkey ? `npub${nostr.pubkey}` : ""));
+    const loggedIn = computed(() => nostr.hasIdentity);
+    const npub = computed(() => (nostr.hasIdentity ? `npub${nostr.pubkey}` : ""));
     return {
       loggedIn,
       npub,


### PR DESCRIPTION
## Summary
- add `hasIdentity` getter to Pinia Nostr store as the single source for login state
- replace scattered `pubkey` and `privateKeySignerPrivateKey` checks in components with `nostr.hasIdentity`
- update creator hub composable and tests to reflect new identity API

## Testing
- `pnpm lint`
- `pnpm test`
- ⚠️ `npx vitest test/vitest/__tests__/nostr-login-flow.spec.ts test/vitest/__tests__/creatorHub-navigation.spec.ts` (JavaScript heap out of memory)


------
https://chatgpt.com/codex/tasks/task_e_68b2c16052048330acf083db99cffa1f