### PR TITLE
refactor: use theme tokens for chat bubbles

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -334,14 +334,18 @@ async function updateAutoRedeem(val: boolean) {
 }
 
 .bubble-outgoing {
-  background-color: var(--q-primary);
-  color: #ffffff;
+  background-color: var(--accent-500);
+  color: var(--text-1);
   border-radius: 12px 0 12px 12px;
 }
 
+body.body--dark .bubble-outgoing {
+  color: var(--text-inverse);
+}
+
 .bubble-incoming {
-  background-color: var(--q-secondary);
-  color: #000000;
+  background-color: var(--surface-2);
+  color: var(--text-1);
   border-radius: 0 12px 12px 12px;
 }
 


### PR DESCRIPTION
## Summary
- style chat bubbles with theme tokens for background and text colors
- use dark-mode override to keep outgoing messages readable

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d281e9c88330afd342c05dabe7be