### PR TITLE
feat: show connected relay list

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="row items-center justify-between q-pt-xs q-pb-none q-px-sm">
+  <div class="column q-pt-xs q-pb-none q-px-sm">
     <div class="row items-center">
       <q-btn
         flat
@@ -53,6 +53,13 @@
         <div class="text-grey-6">Select a conversation to start chatting.</div>
       </template>
     </div>
+    <div
+      v-if="connectedRelayHosts.length"
+      class="text-caption text-2 ellipsis q-mt-xs"
+    >
+      Relays: {{ connectedRelayHosts.join(', ') }}
+      <q-tooltip>{{ connectedRelayHosts.join(', ') }}</q-tooltip>
+    </div>
     <ChatSendTokenDialog
       ref="chatSendTokenDialogRef"
       :recipient="props.pubkey"
@@ -70,7 +77,7 @@ import { nip19 } from "nostr-tools";
 import ProfileInfoDialog from "./ProfileInfoDialog.vue";
 import RelayManagerDialog from "./RelayManagerDialog.vue";
 
-const props = defineProps<{ pubkey: string }>();
+const props = defineProps<{ pubkey: string; relays: { url: string; connected: boolean }[] }>();
 const nostr = useNostrStore();
 const messenger = useMessengerStore();
 const profile = ref<any>(null);
@@ -122,6 +129,18 @@ const relayManagerDialogRef = ref<InstanceType<
   typeof RelayManagerDialog
 > | null>(null);
 const showProfileDialog = ref(false);
+
+const connectedRelayHosts = computed(() =>
+  (props.relays || [])
+    .filter((r) => r.connected)
+    .map((r) => {
+      try {
+        return new URL(r.url).host;
+      } catch {
+        return r.url;
+      }
+    })
+);
 
 function openSendTokenDialog() {
   if (!props.pubkey) return;

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -34,7 +34,7 @@
         <q-btn flat dense label="Switch Account" @click="switchAccount" />
       </div>
       <q-spinner v-if="loading" size="lg" color="primary" />
-      <ActiveChatHeader :pubkey="selected" />
+      <ActiveChatHeader :pubkey="selected" :relays="relayInfos" />
       <MessageList :messages="messages" class="col" />
       <MessageInput @send="sendMessage" @sendToken="openSendTokenDialog" />
       <ChatSendTokenDialog ref="chatSendTokenDialogRef" :recipient="selected" />
@@ -176,6 +176,14 @@ export default defineComponent({
 
     const totalRelays = computed(() => ndkRef.value?.pool.relays.size || 0);
 
+    const relayInfos = computed(() => {
+      if (!ndkRef.value) return [] as { url: string; connected: boolean }[];
+      return Array.from(ndkRef.value.pool.relays.values()).map((r) => ({
+        url: r.url,
+        connected: r.connected,
+      }));
+    });
+
     const nextReconnectIn = computed(() => {
       if (!ndkRef.value) return null;
       let earliest: number | null = null;
@@ -280,6 +288,7 @@ export default defineComponent({
       reconnectAll,
       connectedCount,
       totalRelays,
+      relayInfos,
       nextReconnectIn,
       setupComplete,
       switchAccount,


### PR DESCRIPTION
## Summary
- pass NDK relay info to chat header and compute connection status
- display connected relay hostnames in chat header with tooltip for full list

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d6fec4f88330abbcfcb298d003ec