### PR TITLE
Improve messenger contrast and accessibility

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -335,18 +335,15 @@ async function updateAutoRedeem(val: boolean) {
 
 .bubble-outgoing {
   background-color: var(--accent-500);
-  color: var(--text-1);
+  color: var(--bubble-outgoing-text);
   border-radius: 12px 0 12px 12px;
 }
 
-body.body--dark .bubble-outgoing {
-  color: var(--text-inverse);
-}
-
 .bubble-incoming {
-  background-color: var(--surface-2);
+  background-color: color-mix(in srgb, var(--surface-2), white 15%);
   color: var(--text-1);
   border-radius: 0 12px 12px 12px;
+  border: 1px solid var(--surface-contrast-border);
 }
 
 .token-wrapper {

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -312,7 +312,8 @@ const deleteItem = () => emit("delete", nostr.resolvePubkey(props.pubkey));
   pointer-events: none; /* don’t block avatar clicks */
 }
 .conversation-item.selected {
-  background-color: color-mix(in srgb, var(--q-primary), transparent 92%);
+  background-color: var(--accent-200);
+  color: var(--text-1);
 }
 .conversation-item:focus {
   border-left: 2px solid var(--q-primary);

--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="row no-wrap items-center q-pa-sm">
-    <q-input v-model="text" class="col" dense outlined @keyup.enter="send">
+    <q-input
+      v-model="text"
+      class="col message-input"
+      dense
+      outlined
+      @keyup.enter="send"
+    >
       <template v-slot:append>
         <q-btn
           flat
@@ -86,3 +92,10 @@ const handleFile = (e: Event) => {
   reader.readAsDataURL(files[0]);
 };
 </script>
+
+<style scoped>
+.message-input .q-field__control {
+  border-color: var(--surface-contrast-border);
+  background: var(--surface-1);
+}
+</style>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -128,6 +128,7 @@ body,
   --accent-500: var(--q-primary);
   --accent-600: color-mix(in srgb, var(--q-primary) 85%, black);
   --accent-200: color-mix(in srgb, var(--q-primary) 25%, white);
+  --bubble-outgoing-text: var(--text-inverse);
   --tab-active: var(--q-primary);
   --tab-inactive: #6b7280;
   --disabled-text: #9ca3af;
@@ -159,6 +160,7 @@ body.body--dark {
   --accent-500: var(--q-primary);
   --accent-600: color-mix(in srgb, var(--q-primary) 80%, white);
   --accent-200: color-mix(in srgb, var(--q-primary) 25%, black);
+  --bubble-outgoing-text: var(--text-1);
   --tab-active: var(--q-primary);
   --tab-inactive: var(--muted-dark);
   --disabled-text: var(--q-color-grey-6);
@@ -178,6 +180,7 @@ body.body--light {
   --border-subtle: 1px solid var(--border-subtle-light);
   --chip-bg: var(--chip-bg-light);
   --chip-text: var(--chip-text-light);
+  --bubble-outgoing-text: var(--text-inverse);
   --progress-ring-fill: var(--progress-ring-fill-light);
   --progress-ring-track: var(--progress-ring-track-light);
   --due-soon-bg: var(--due-soon-bg-light);


### PR DESCRIPTION
## Summary
- lighten incoming message bubbles for better dark-mode readability
- use theme-aware text color for outgoing bubbles
- highlight selected conversation rows and message input borders

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2da8852a4833098c3ef827b33e65f