### PR TITLE
Enhance messenger accessibility and relay view

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -8,6 +8,7 @@
         icon="payments"
         class="q-mr-sm"
         @click="openSendTokenDialog"
+        aria-label="Send token"
       />
       <template v-if="pubkey">
         <q-avatar size="md" class="q-mr-sm relative-position">
@@ -34,6 +35,7 @@
           icon="more_vert"
           class="q-ml-xs"
           @click="showProfileDialog = true"
+          aria-label="More options"
         />
         <q-btn
           flat
@@ -42,6 +44,7 @@
           icon="rss_feed"
           class="q-ml-xs"
           @click="openRelayDialog"
+          aria-label="Manage relays"
         />
         <ProfileInfoDialog
           v-model="showProfileDialog"

--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -14,8 +14,15 @@
           color="primary"
           @click="selectFile"
           icon="attach_file"
+          aria-label="Attach file"
         />
-        <q-btn flat round color="primary" @click="sendToken">
+        <q-btn
+          flat
+          round
+          color="primary"
+          @click="sendToken"
+          aria-label="Send token"
+        >
           <NutIcon />
         </q-btn>
         <q-btn
@@ -26,6 +33,7 @@
           class="q-ml-sm"
           :disable="!text.trim() && !attachment"
           @click="send"
+          aria-label="Send message"
         />
       </template>
     </q-input>

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -1,20 +1,23 @@
 <template>
-  <q-scroll-area class="col column q-pa-md">
-    <template v-for="(msg, idx) in messages" :key="msg.id">
-      <div
-        v-if="showDateSeparator(idx)"
-        class="text-caption text-center q-my-md divider-text"
-      >
-        {{ formatDay(msg.created_at) }}
-      </div>
-      <ChatMessageBubble
-        :message="msg"
-        :delivery-status="msg.status"
-        :prev-message="messages[idx - 1]"
-      />
-    </template>
-    <div ref="bottom"></div>
-  </q-scroll-area>
+  <q-virtual-scroll
+    ref="scroll"
+    class="col column q-pa-md"
+    :items="messages"
+    :virtual-scroll-slice-size="30"
+    v-slot="{ item: msg, index: idx }"
+  >
+    <div
+      v-if="showDateSeparator(idx)"
+      class="text-caption text-center q-my-md divider-text"
+    >
+      {{ formatDay(msg.created_at) }}
+    </div>
+    <ChatMessageBubble
+      :message="msg"
+      :delivery-status="msg.status"
+      :prev-message="messages[idx - 1]"
+    />
+  </q-virtual-scroll>
 </template>
 
 <script lang="ts" setup>
@@ -23,7 +26,7 @@ import type { MessengerMessage } from "src/stores/messenger";
 import ChatMessageBubble from "./ChatMessageBubble.vue";
 
 const props = defineProps<{ messages: MessengerMessage[] }>();
-const bottom = ref<HTMLElement>();
+const scroll = ref<any>();
 
 function formatDay(ts: number) {
   const d = new Date(ts * 1000);
@@ -41,14 +44,11 @@ function showDateSeparator(idx: number) {
 }
 
 watch(
-  () => props.messages,
+  () => props.messages.length,
   () => {
-    nextTick(() => bottom.value?.scrollIntoView({ behavior: "smooth" }));
+    nextTick(() => scroll.value?.scrollTo(props.messages.length - 1, "end"));
   },
-  { deep: true },
 );
-
-const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
 
 defineExpose({ formatDay, showDateSeparator });
 </script>


### PR DESCRIPTION
## Summary
- add ARIA labels for message send controls
- expose header buttons and relay manager with accessible labels and status badges
- virtualize message list for smoother scrolling

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2dc46a304833098c4beb6fa8037b9