### PR TITLE
feat: initialize nostr signer before login

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -30,6 +30,6 @@ export default configure(() => ({
     config: {
       dark: true
     },
-    plugins: ['Notify', 'LocalStorage']
+    plugins: ['Notify', 'LocalStorage', 'Loading']
   }
 }))

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,6 +8,8 @@ import {
 import routes from "./routes";
 import { hasSeenWelcome } from "src/composables/useWelcomeGate";
 import { useRestoreStore } from "src/stores/restore";
+import { useNostrStore } from "src/stores/nostr";
+import { Loading, QSpinner } from "quasar";
 
 /*
  * If not building with SSR mode, you can
@@ -35,7 +37,16 @@ export default route(function (/* { store, ssrContext } */) {
     history: createHistory(process.env.VUE_ROUTER_BASE),
   });
 
-  Router.beforeEach((to, _from, next) => {
+  Router.beforeEach(async (to, _from, next) => {
+    if (to.path === "/nostr-login") {
+      Loading.show({ spinner: QSpinner });
+      try {
+        await useNostrStore().initSignerIfNotSet();
+      } finally {
+        Loading.hide();
+      }
+    }
+
     const seen = hasSeenWelcome();
     const isWelcome = to.path.startsWith("/welcome");
     const isPublicProfile =


### PR DESCRIPTION
## Summary
- ensure Nostr signer is initialized before rendering the login page
- enable Quasar's Loading plugin to display a spinner during init

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2df66c5bc8330a50016ed021f5f46