### PR TITLE
feat(nostr): preload keys before app routing

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -7,7 +7,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export default configure(() => ({
-  boot: ['welcomeGate', 'cashu', 'i18n', 'node-globals', 'notify'],
+  boot: ['nostr-init', 'welcomeGate', 'cashu', 'i18n', 'node-globals', 'notify'],
   css: ['app.scss', 'base.scss', 'buckets.scss'],
   extras: ['roboto-font', 'material-icons'],
   build: {

--- a/src/boot/nostr-init.ts
+++ b/src/boot/nostr-init.ts
@@ -1,0 +1,6 @@
+import { boot } from 'quasar/wrappers';
+import { useNostrStore } from 'src/stores/nostr';
+
+export default boot(async () => {
+  await useNostrStore().loadKeysFromStorage();
+});

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -38,10 +38,15 @@ export default route(function (/* { store, ssrContext } */) {
   });
 
   Router.beforeEach(async (to, _from, next) => {
+    const nostrStore = useNostrStore();
+    if (!nostrStore.secureStorageLoaded) {
+      await nostrStore.loadKeysFromStorage();
+    }
+
     if (to.path === "/nostr-login") {
       Loading.show({ spinner: QSpinner });
       try {
-        await useNostrStore().initSignerIfNotSet();
+        await nostrStore.initSignerIfNotSet();
       } finally {
         Loading.hide();
       }

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -716,7 +716,6 @@ export const useNostrStore = defineStore("nostr", {
       this.secureStorageLoaded = true;
     },
     initNdkReadOnly: async function () {
-      await this.loadKeysFromStorage();
       const ndk = await useNdk({ requireSigner: false });
       if (this.connected) return;
       try {
@@ -827,7 +826,6 @@ export const useNostrStore = defineStore("nostr", {
       }
     },
     initSignerIfNotSet: async function () {
-      await this.loadKeysFromStorage();
       if (!this.signer) {
         if (
           this.signerType === SignerType.NIP07 &&


### PR DESCRIPTION
## Summary
- load nostr keys from secure storage during boot
- delay router navigation until nostr keys have been loaded
- drop redundant key loading calls

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2e12cb3a08330824dfc997725f60e