### PR TITLE
Avoid signing NIP-17 message events

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1497,9 +1497,21 @@ export const useNostrStore = defineStore("nostr", {
       dmEvent.tags = [["p", recipient]];
       dmEvent.created_at = Math.floor(Date.now() / 1000);
       dmEvent.pubkey = this.pubkey;
-      await dmEvent.sign(this.signer);
-      dmEvent.id = dmEvent.getEventHash();
-      const dmEventString = JSON.stringify(await dmEvent.toNostrEvent());
+      dmEvent.id = ntGetEventHash({
+        kind: dmEvent.kind,
+        content: dmEvent.content,
+        tags: dmEvent.tags,
+        created_at: dmEvent.created_at,
+        pubkey: dmEvent.pubkey,
+      } as any);
+      const dmEventString = JSON.stringify({
+        id: dmEvent.id,
+        kind: dmEvent.kind,
+        content: dmEvent.content,
+        tags: dmEvent.tags,
+        created_at: dmEvent.created_at,
+        pubkey: dmEvent.pubkey,
+      });
 
       const sealEvent = new NDKEvent();
       sealEvent.kind = 13;


### PR DESCRIPTION
## Summary
- stop signing kind-14 NIP-17 messages and compute their id with `getEventHash`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b310f0f2b483309e4562164b5975c8