### PR TITLE
feat(nostr): remove sender tag from direct messages

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1321,16 +1321,12 @@ export const useNostrStore = defineStore("nostr", {
         return { success: false, event: null };
       }
       const signer = privKey ? new NDKPrivateKeySigner(privKey) : this.signer;
-      const senderPubkey =
-        pubKey || (privKey ? getPublicKey(hexToBytes(privKey)) : this.pubkey);
       const ndk = await useNdk();
       const event = new NDKEvent(ndk);
       event.kind = NDKKind.EncryptedDirectMessage;
       event.content = await this.encryptNip04(key, recipient, message);
-      event.tags = [
-        ["p", recipient],
-        ["p", senderPubkey],
-      ];
+      // Event should include only a single recipient tag
+      event.tags = [["p", recipient]];
       await event.sign(signer);
 
       const relayCandidates = relays && relays.length ? relays : this.relays;

--- a/test/vitest/__tests__/nostr.spec.ts
+++ b/test/vitest/__tests__/nostr.spec.ts
@@ -100,8 +100,11 @@ describe.skip("sendDirectMessageUnified", () => {
     const res = await store.sendDirectMessageUnified("receiver", "msg");
     vi.runAllTimers();
     expect(res.event!.kind).toBe(NDKKind.EncryptedDirectMessage);
-    expect(res.event!.tags).toContainEqual(["p", "receiver"]);
-    expect(res.event!.tags).toContainEqual(["p", store.seedSignerPublicKey]);
+    expect(res.event!.tags).toEqual([["p", "receiver"]]);
+    expect(res.event!.tags).not.toContainEqual([
+      "p",
+      store.seedSignerPublicKey,
+    ]);
   });
 
   it("generates keypair if not set", async () => {


### PR DESCRIPTION
## Summary
- ensure direct messages include only the recipient tag
- test that no sender tag is present on direct message events

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b313e08a088330b87eeb3a6869f2cc