### PR TITLE
feat: prefer nip17 dms with fallback

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -252,8 +252,32 @@ export const useMessengerStore = defineStore("messenger", {
       );
 
       const list = relays && relays.length ? relays : (this.relays as any);
+
+      // Prefer NIP-17 if both parties have DM relays
       try {
-        const { success, event } = await nostr.sendDirectMessageUnified(
+        const dmRelays = await nostr.canUseNip17(recipient);
+        if (dmRelays && dmRelays.length > 0) {
+          const event = await nostr.sendNip17DirectMessage(
+            recipient,
+            message,
+            dmRelays,
+          );
+          if (event) {
+            msg.id = event.id;
+            msg.created_at =
+              event.created_at ?? Math.floor(Date.now() / 1000);
+            msg.status = "sent";
+            this.pushOwnMessage(event as any);
+            return { success: true, event } as any;
+          }
+        }
+      } catch (e) {
+        console.error("[messenger.sendDm] NIP17", e);
+      }
+
+      // Fallback to NIP-04
+      try {
+        const { success, event } = await nostr.sendNip04DirectMessage(
           recipient,
           message,
           privKey,

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1467,6 +1467,39 @@ export const useNostrStore = defineStore("nostr", {
     randomTimeUpTo2DaysInThePast: function () {
       return Math.floor(Date.now() / 1000) - Math.floor(Math.random() * 172800);
     },
+    canUseNip17: async function (
+      pubkey: string,
+    ): Promise<string[] | null> {
+      const resolved = this.resolvePubkey(pubkey);
+      if (!resolved) return null;
+      await this.initNdkReadOnly();
+      try {
+        const ndk = await useNdk();
+        const user = ndk.getUser({ pubkey: resolved });
+        const relays = await (user as any).fetchRelays?.();
+        const urls: string[] = [];
+        const collect = (rs: any) => {
+          if (!rs) return;
+          if (Array.isArray(rs)) {
+            for (const r of rs) urls.push(typeof r === "string" ? r : r?.url);
+          } else if (rs instanceof Set) {
+            for (const r of Array.from(rs))
+              urls.push(typeof r === "string" ? r : (r as any)?.url);
+          } else if (typeof rs === "object") {
+            for (const r of Array.from(rs.values?.() ?? []))
+              urls.push(typeof r === "string" ? r : (r as any)?.url);
+          }
+        };
+        collect(relays?.writeRelays ?? relays);
+        const cleaned = urls
+          .filter((u) => typeof u === "string" && u.startsWith("wss://"))
+          .map((u) => u.replace(/\/+$/, ""));
+        return cleaned.length ? cleaned : null;
+      } catch (e) {
+        console.error("[nostr.canUseNip17]", e);
+        return null;
+      }
+    },
     sendNip17DirectMessage: async function (
       recipient: string,
       message: string,


### PR DESCRIPTION
## Summary
- add nostr.canUseNip17 to detect DM relay support
- send messenger DMs via NIP-17 when possible, otherwise fall back to NIP-04
- expand tests for messenger DM and token flows

## Testing
- `pnpm lint`
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/vitest/__tests__/messenger.spec.ts test/vitest/__tests__/messenger-send-token.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b3151d11f48330a6eb889ba6292108