### PR TITLE
Handle failed DM sending with notification and retry

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -270,8 +270,12 @@ export const useMessengerStore = defineStore("messenger", {
       } catch (e) {
         console.error("[messenger.sendDm]", e);
       }
+      notifyError("Unable to encrypt or send DM");
       msg.status = "failed";
       this.sendQueue.push(msg);
+      if (this.isConnected()) {
+        this.retryFailedMessages();
+      }
       return { success: false } as any;
     },
     async sendToken(


### PR DESCRIPTION
## Summary
- notify users when `sendDirectMessageUnified` fails to send or encrypt a direct message
- queue failed messages and automatically attempt to resend when connected

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b326b34d0c8330a6116cd962b0f061