### PR TITLE
Verify NIP-17 direct message seal

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1681,6 +1681,17 @@ export const useNostrStore = defineStore("nostr", {
               ),
             );
             dmEvent = JSON.parse(dmEventString) as NDKEvent;
+
+            if (sealEvent.pubkey !== dmEvent.pubkey) {
+              debug(
+                "### NIP-17 DM verification failed: pubkey mismatch",
+                sealEvent.pubkey,
+                dmEvent.pubkey,
+              );
+              notifyWarning("Discarded invalid NIP-17 direct message");
+              return;
+            }
+
             content = dmEvent.content;
             debug("### NIP-17 DM from", dmEvent.pubkey);
             debug("Content:", content);


### PR DESCRIPTION
## Summary
- Parse sealed and inner events when decrypting NIP-17 messages
- Ensure pubkey of sealed event matches inner event and discard mismatches
- Warn when verification fails to aid debugging

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b33e6d92cc8330a62f0990f04af599