### PR TITLE
feat: send direct messages via nip-17 with fallback

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -279,6 +279,24 @@ export const useMessengerStore = defineStore("messenger", {
       );
 
       const list = relays && relays.length ? relays : (this.relays as any);
+      let nip17Event: NDKEvent | null = null;
+      try {
+        nip17Event = await nostr.sendNip17DirectMessage(
+          recipient,
+          message,
+          list,
+        );
+      } catch (e) {
+        console.error("[messenger.sendDm] NIP-17", e);
+      }
+      if (nip17Event) {
+        msg.id = nip17Event.id;
+        msg.created_at =
+          nip17Event.created_at ?? Math.floor(Date.now() / 1000);
+        msg.status = "sent";
+        this.pushOwnMessage(nip17Event as any);
+        return { success: true, event: nip17Event } as any;
+      }
       try {
         const { success, event } = await nostr.sendDirectMessageUnified(
           recipient,

--- a/test/vitest/__tests__/messenger-send-token.spec.ts
+++ b/test/vitest/__tests__/messenger-send-token.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-var sendDm: any;
+var sendNip17: any;
+var sendDmLegacy: any;
 var walletSend: any;
 var walletMintWallet: any;
 var serializeProofs: any;
@@ -8,14 +9,16 @@ var addPending: any;
 
 vi.mock("../../../src/stores/nostr", async (importOriginal) => {
   const actual = await importOriginal();
-  sendDm = vi.fn(async () => ({
+  sendNip17 = vi.fn(async () => ({ id: "1", created_at: 0 }));
+  sendDmLegacy = vi.fn(async () => ({
     success: true,
     event: { id: "1", created_at: 0 },
   }));
   return {
     ...actual,
     useNostrStore: () => ({
-      sendDirectMessageUnified: sendDm,
+      sendNip17DirectMessage: sendNip17,
+      sendDirectMessageUnified: sendDmLegacy,
       initSignerIfNotSet: vi.fn(),
       privateKeySignerPrivateKey: "priv",
       seedSignerPrivateKey: "",
@@ -82,13 +85,12 @@ describe("messenger.sendToken", () => {
     expect(success).toBe(true);
     expect(walletMintWallet).toHaveBeenCalledWith("mint", "sat");
     expect(walletSend).toHaveBeenCalled();
-    expect(sendDm).toHaveBeenCalledWith(
+    expect(sendNip17).toHaveBeenCalledWith(
       "receiver",
       expect.stringContaining('"token":"TOKEN"'),
-      "priv",
-      "pub",
       undefined,
     );
+    expect(sendDmLegacy).not.toHaveBeenCalled();
     expect(addPending).toHaveBeenCalledWith({
       amount: -1,
       token: "TOKEN",

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -1,20 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-var sendDm: any;
+var sendNip17: any;
+var sendDmLegacy: any;
 var decryptDm: any;
 var stickySub: any;
 var walletGen: any;
 
 vi.mock("../../../src/stores/nostr", async (importOriginal) => {
   const actual = await importOriginal();
-  sendDm = vi.fn(async () => ({
+  sendNip17 = vi.fn(async () => ({ id: "1", created_at: 0 }));
+  sendDmLegacy = vi.fn(async () => ({
     success: true,
     event: { id: "1", created_at: 0 },
   }));
   decryptDm = vi.fn(async () => "msg");
   walletGen = vi.fn();
   const store = {
-    sendDirectMessageUnified: sendDm,
+    sendNip17DirectMessage: sendNip17,
+    sendDirectMessageUnified: sendDmLegacy,
     decryptNip04: decryptDm,
     walletSeedGenerateKeyPair: walletGen,
     initSignerIfNotSet: vi.fn(),
@@ -67,10 +70,11 @@ beforeEach(() => {
 });
 
 describe("messenger store", () => {
-  it("uses global key when sending DMs", async () => {
+  it("uses NIP-17 when sending DMs", async () => {
     const messenger = useMessengerStore();
     await messenger.sendDm("r", "m");
-    expect(sendDm).toHaveBeenCalledWith("r", "m", "priv", "pub", undefined);
+    expect(sendNip17).toHaveBeenCalledWith("r", "m", undefined);
+    expect(sendDmLegacy).not.toHaveBeenCalled();
   });
 
   it("decrypts incoming messages with global key", async () => {


### PR DESCRIPTION
## Summary
- use `sendNip17DirectMessage` when sending DMs
- fall back to NIP-04 DM when NIP-17 fails or is unavailable
- update tests for NIP-17 DM and token sending

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b33f7c882c8330a34439b7168dc672