### PR TITLE
Subscribe to NIP-17 direct messages unconditionally

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -728,11 +728,7 @@ export default {
       if (this.nwcEnabled) {
         this.listenToNWCCommands();
       }
-
-      if (this.enablePaymentRequest) {
-        this.subscribeToNip17DirectMessages();
-      }
-
+      this.subscribeToNip17DirectMessages();
       this.subscribeToNip04DirectMessages();
       this.startInvoiceCheckerWorker();
       this.startLockedTokensRedeemWorker();


### PR DESCRIPTION
## Summary
- Call `subscribeToNip17DirectMessages` during wallet initialization without requiring `enablePaymentRequest`
- Align cleanup with existing NIP-04 direct message subscription

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b34117f93c8330ac330379536f4b32