### PR TITLE
feat: use receiver DM relay list when sending

### DIFF
--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -19,6 +19,7 @@ vi.mock("../../../src/stores/nostr", async (importOriginal) => {
     sendNip17DirectMessage: sendNip17,
     sendDirectMessageUnified: sendDmLegacy,
     decryptNip04: decryptDm,
+    fetchDmRelayUris: vi.fn(async () => ["wss://relay.example"]),
     walletSeedGenerateKeyPair: walletGen,
     initSignerIfNotSet: vi.fn(),
     privateKeySignerPrivateKey: "priv",
@@ -73,7 +74,7 @@ describe("messenger store", () => {
   it("uses NIP-17 when sending DMs", async () => {
     const messenger = useMessengerStore();
     await messenger.sendDm("r", "m");
-    expect(sendNip17).toHaveBeenCalledWith("r", "m", undefined);
+    expect(sendNip17).toHaveBeenCalledWith("r", "m", ["wss://relay.example"]);
     expect(sendDmLegacy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- fetch recipient's kind:10050 event to derive DM relay URIs
- warn and allow cancel if no DM relay list is found
- merge receiver relays with sender relays when sending NIP-17/NIP-04 DMs

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3485fe9548330afcc9166c1688109