### PR TITLE
feat: unify DM encryption helpers

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -590,7 +590,7 @@ export const useMessengerStore = defineStore("messenger", {
       }
       const decrypted =
         plaintext ??
-        (await nostr.decryptNip04(privKey, event.pubkey, event.content));
+        (await nostr.decryptDmContent(privKey, event.pubkey, event.content));
       let subscriptionInfo: SubscriptionPayment | undefined;
       let tokenPayload: any | undefined;
       const lines = decrypted.split("\n").filter((l) => l.trim().length > 0);

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -18,7 +18,7 @@ vi.mock("../../../src/stores/nostr", async (importOriginal) => {
   const store = {
     sendNip17DirectMessage: sendNip17,
     sendDirectMessageUnified: sendDmLegacy,
-    decryptNip04: decryptDm,
+    decryptDmContent: decryptDm,
     fetchDmRelayUris: vi.fn(async () => ["wss://relay.example"]),
     walletSeedGenerateKeyPair: walletGen,
     initSignerIfNotSet: vi.fn(),


### PR DESCRIPTION
## Summary
- rename encrypt/decrypt helpers to `encryptDmContent`/`decryptDmContent`
- prefer nip44 then nip04 for window.nostr and local fallbacks
- update direct message and NIP-17 flows to use the new helpers

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d22d13048330a9e40d6c142fea8c