### PR TITLE
refactor: support extension-based NIP-17 encryption

### DIFF
--- a/test/vitest/__tests__/messenger-send-token.spec.ts
+++ b/test/vitest/__tests__/messenger-send-token.spec.ts
@@ -9,7 +9,10 @@ var addPending: any;
 
 vi.mock("../../../src/stores/nostr", async (importOriginal) => {
   const actual = await importOriginal();
-  sendNip17 = vi.fn(async () => ({ id: "1", created_at: 0 }));
+  sendNip17 = vi.fn(async () => ({
+    success: true,
+    event: { id: "1", created_at: 0 },
+  }));
   sendDmLegacy = vi.fn(async () => ({
     success: true,
     event: { id: "1", created_at: 0 },

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -8,7 +8,10 @@ var walletGen: any;
 
 vi.mock("../../../src/stores/nostr", async (importOriginal) => {
   const actual = await importOriginal();
-  sendNip17 = vi.fn(async () => ({ id: "1", created_at: 0 }));
+  sendNip17 = vi.fn(async () => ({
+    success: true,
+    event: { id: "1", created_at: 0 },
+  }));
   sendDmLegacy = vi.fn(async () => ({
     success: true,
     event: { id: "1", created_at: 0 },
@@ -42,7 +45,12 @@ vi.mock("../../../src/js/nostr-runtime", () => {
     const ev = {
       pubkey: "s",
       content: "c",
-      toNostrEvent: async () => ({ id: "1", pubkey: "s", content: "c", created_at: 1 }),
+      toNostrEvent: async () => ({
+        id: "1",
+        pubkey: "s",
+        content: "c",
+        created_at: 1,
+      }),
     };
     cb && cb(ev as any);
     return vi.fn();


### PR DESCRIPTION
## Summary
- allow browser signers to encrypt NIP-17 messages by routing both seal and wrap through `encryptDmContent`
- sign seal with the user's signer and sign wraps with ephemeral keys
- publish both wraps together and surface `{success, event}` to callers

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d48bf1d083308191629dcbb5e44b