### PR TITLE
fix: wrap raw NIP04 events before storing

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1448,7 +1448,7 @@ export const useNostrStore = defineStore("nostr", {
               this.parseMessageForEcash(content, event.pubkey);
               try {
                 const chatStore = useDmChatsStore();
-                chatStore.addIncoming(event.rawEvent() as any);
+                chatStore.addIncoming(new NDKEvent(undefined, event.rawEvent()));
               } catch {}
             },
           );


### PR DESCRIPTION
## Summary
- wrap NIP-04 DM raw events with `NDKEvent` before saving to `dmChats`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d808e5708330a9ef4a59eedeeefe