### PR TITLE
feat(messenger): prefer NIP-17 and improve retries

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1639,9 +1639,7 @@ export const useNostrStore = defineStore("nostr", {
           nostrRecipient as any,
           nostrSender as any,
         );
-        const chatStore = useDmChatsStore();
-        chatStore.addOutgoing(dmEvent);
-        return { success: true, event: dmEvent };
+        return { success: true, event: wrapEventSender };
       } catch (e) {
         console.error(e);
         return { success: false };


### PR DESCRIPTION
## Summary
- always try NIP-17 direct messages and log them in dmChatsStore using wrap event id
- remove legacy chat-store push from `sendNip17DirectMessage`
- retry failed messages with NIP-17 first, falling back to legacy send

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d92da1088330ad828cd3eb7afca7