### PR TITLE
refactor: ensure relay connections use nostr protocol

### DIFF
--- a/scripts/update-featured-creators.js
+++ b/scripts/update-featured-creators.js
@@ -5,9 +5,9 @@ import { SimplePool, useWebSocketImplementation } from 'nostr-tools/pool';
 import { nip19 } from 'nostr-tools';
 import WebSocket from 'ws';
 
-// provide WebSocket implementation for nostr-tools in Node with nostr protocol
+// provide WebSocket implementation for nostr-tools in Node without forcing a protocol
 function NostrWebSocket(url, opts) {
-  return new WebSocket(url, 'nostr', opts);
+  return new WebSocket(url, opts);
 }
 useWebSocketImplementation(NostrWebSocket);
 

--- a/src/utils/relayHealth.ts
+++ b/src/utils/relayHealth.ts
@@ -49,7 +49,7 @@ export async function pingRelay(url: string): Promise<boolean> {
       }
     } catch {}
   }
-  const attemptOnce = (useProtocol = true): Promise<boolean> =>
+  const attemptOnce = (useProtocol = false): Promise<boolean> =>
     new Promise((resolve) => {
       let settled = false;
       let ws: WebSocket;
@@ -91,14 +91,14 @@ export async function pingRelay(url: string): Promise<boolean> {
           try {
             ws.close();
           } catch {}
-          if (useProtocol) {
+          if (!useProtocol) {
             if (!handshakeWarned.has(url)) {
               console.warn(
-                `Relay handshake failed for: ${url} (retrying without protocol)`,
+                `Relay handshake failed for: ${url} (retrying with \"nostr\" protocol)`,
               );
               handshakeWarned.add(url);
             }
-            attemptOnce(false).then(resolve);
+            attemptOnce(true).then(resolve);
           } else {
             resolve(false);
           }


### PR DESCRIPTION
## Summary
- avoid forcing a WebSocket subprotocol in node relay utilities
- attempt relay pings without a protocol and retry with `nostr`
- verify at least one reachable relay before sending DMs

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b420293b2c833094f22e74a3128380