### PR TITLE
Harden Nostr DM handling and relay resilience

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -178,6 +178,8 @@ const statusIcon = computed(() => {
       return "check";
     case "failed":
       return "error";
+    case "failed-decrypt":
+      return "lock";
     case "delivered":
       return "check";
     default:
@@ -188,6 +190,7 @@ const statusIcon = computed(() => {
 const statusColor = computed(() => {
   const status = props.message.status;
   if (status === "failed") return "negative";
+  if (status === "failed-decrypt") return "warning";
   return "grey";
 });
 

--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -6,6 +6,7 @@
       dense
       outlined
       @keyup.enter="send"
+      @paste="onPaste"
     >
       <template v-slot:append>
         <q-btn
@@ -52,6 +53,7 @@
 
 <script lang="ts" setup>
 import { ref, computed } from "vue";
+import { notifyWarning } from "src/js/notify";
 import { Nut as NutIcon } from "lucide-vue-next";
 
 const emit = defineEmits(["send", "sendToken"]);
@@ -64,7 +66,10 @@ const fileInput = ref<HTMLInputElement>();
 
 const send = () => {
   const m = text.value.trim();
-  if (!m && !attachment.value) return;
+  if (!m && !attachment.value) {
+    notifyWarning("Message cannot be empty");
+    return;
+  }
   const payload: any = { text: m };
   if (attachment.value) {
     payload.attachment = {
@@ -98,6 +103,11 @@ const handleFile = (e: Event) => {
     attachmentType.value = files[0].type;
   };
   reader.readAsDataURL(files[0]);
+};
+
+const onPaste = (e: ClipboardEvent) => {
+  const txt = e.clipboardData?.getData("text") || "";
+  if (txt.trim().length === 0) e.preventDefault();
 };
 </script>
 

--- a/src/components/subscribers/SubscriberDrawer.vue
+++ b/src/components/subscribers/SubscriberDrawer.vue
@@ -204,6 +204,8 @@ import { format, formatDistanceToNow } from "date-fns";
 import { useQuasar } from "quasar";
 import type { Subscriber } from "src/types/subscriber";
 import { copyNpub } from "src/utils/clipboard";
+import { normalizeToHexPubkey } from "src/utils/nostr-ids";
+import { notifyError } from "src/js/notify";
 
 const props = defineProps<{
   modelValue: boolean;
@@ -248,9 +250,14 @@ function copyCurrentNpub() {
 
 function dmSubscriber() {
   if (!props.subscriber) return;
+  const hex = normalizeToHexPubkey(props.subscriber.npub);
+  if (!hex) {
+    notifyError("Invalid Nostr pubkey");
+    return;
+  }
   router.push({
     path: "/nostr-messenger",
-    query: { pubkey: props.subscriber.npub },
+    query: { pubkey: hex },
   });
 }
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -98,6 +98,8 @@ import { useNutzapStore } from "src/stores/nutzap";
 import { useMessengerStore } from "src/stores/messenger";
 import { useUiStore } from "src/stores/ui";
 import { NAV_DRAWER_WIDTH, NAV_DRAWER_GUTTER } from "src/constants/layout";
+import { normalizeToHexPubkey } from "src/utils/nostr-ids";
+import { notifyError } from "src/js/notify";
 
 export default defineComponent({
   name: "MainLayout",
@@ -184,8 +186,13 @@ export default defineComponent({
     };
 
     const selectConversation = (pubkey) => {
-      messenger.markRead(pubkey);
-      messenger.setCurrentConversation(pubkey);
+      const hex = normalizeToHexPubkey(pubkey);
+      if (!hex) {
+        notifyError("Invalid Nostr pubkey");
+        return;
+      }
+      messenger.markRead(hex);
+      messenger.setCurrentConversation(hex);
       if ($q.screen.lt.md) {
         messenger.setDrawer(false);
       }
@@ -195,8 +202,13 @@ export default defineComponent({
     };
 
     const startChat = (pubkey) => {
-      messenger.startChat(pubkey);
-      selectConversation(pubkey);
+      const hex = normalizeToHexPubkey(pubkey);
+      if (!hex) {
+        notifyError("Invalid Nostr pubkey");
+        return;
+      }
+      messenger.startChat(hex);
+      selectConversation(hex);
     };
 
     const isMessengerRoute = computed(() =>

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -139,7 +139,7 @@ import {
   fetchNutzapProfile,
   RelayConnectionError,
 } from "stores/nostr";
-import { notifyWarning } from "src/js/notify";
+import { notifyWarning, notifyError } from "src/js/notify";
 import { useRouter, useRoute } from "vue-router";
 import { useMessengerStore } from "stores/messenger";
 import { useI18n } from "vue-i18n";
@@ -153,6 +153,7 @@ import {
   useQuasar,
 } from "quasar";
 import { nip19 } from "nostr-tools";
+import { normalizeToHexPubkey } from "src/utils/nostr-ids";
 
 const iframeEl = ref<HTMLIFrameElement | null>(null);
 const iframeLoaded = ref(false);
@@ -208,15 +209,6 @@ function getPrice(t: any): number {
   return t.price_sats ?? t.price ?? 0;
 }
 
-function bech32ToHex(pubkey: string): string {
-  try {
-    const decoded = nip19.decode(pubkey);
-    return typeof decoded.data === "string" ? decoded.data : pubkey;
-  } catch {
-    return pubkey;
-  }
-}
-
 function formatTs(ts: number): string {
   const d = new Date(ts * 1000);
   return `${d.getFullYear()}-${("0" + (d.getMonth() + 1)).slice(-2)}-${(
@@ -228,7 +220,12 @@ function formatTs(ts: number): string {
 
 async function onMessage(ev: MessageEvent) {
   if (ev.data && ev.data.type === "donate" && ev.data.pubkey) {
-    selectedPubkey.value = ev.data.pubkey; // keep hex
+    const hex = normalizeToHexPubkey(ev.data.pubkey);
+    if (!hex) {
+      notifyError("Invalid Nostr pubkey");
+      return;
+    }
+    selectedPubkey.value = hex;
     showDonateDialog.value = true;
   } else if (ev.data && ev.data.type === "viewProfile" && ev.data.pubkey) {
     loadingTiers.value = true;
@@ -238,10 +235,15 @@ async function onMessage(ev: MessageEvent) {
     tierTimeout = setTimeout(() => {
       loadingTiers.value = false;
     }, 5000);
-    await creators.fetchTierDefinitions(ev.data.pubkey);
-    dialogPubkey.value = ev.data.pubkey; // keep hex
+    const hex = normalizeToHexPubkey(ev.data.pubkey);
+    if (!hex) {
+      notifyError("Invalid Nostr pubkey");
+      return;
+    }
+    await creators.fetchTierDefinitions(hex);
+    dialogPubkey.value = hex;
     try {
-      const profile = await fetchNutzapProfile(ev.data.pubkey);
+      const profile = await fetchNutzapProfile(hex);
       nutzapProfile.value = profile;
     } catch (e: any) {
       if (e instanceof RelayConnectionError) {
@@ -255,7 +257,11 @@ async function onMessage(ev: MessageEvent) {
     await nextTick();
     showTierDialog.value = true;
   } else if (ev.data && ev.data.type === "startChat" && ev.data.pubkey) {
-    const pubkey = nostr.resolvePubkey(ev.data.pubkey);
+    const pubkey = normalizeToHexPubkey(ev.data.pubkey);
+    if (!pubkey) {
+      notifyError("Invalid Nostr pubkey");
+      return;
+    }
     router.push({ path: "/nostr-messenger", query: { pubkey } });
     const stop = watch(
       () => messenger.started,

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -23,6 +23,7 @@
         <div class="row items-center q-gutter-sm">
           <span>
             Offline - {{ connectedCount }}/{{ totalRelays }} connected
+            <span v-if="messenger.sendQueue.length">. Message queued.</span>
             <span v-if="nextReconnectIn !== null">
               - reconnecting in {{ nextReconnectIn }}s
             </span>
@@ -37,7 +38,7 @@
           class="bg-orange-2 q-mb-sm"
         >
           <div class="row items-center no-wrap">
-            <span>{{ messenger.sendQueue.length }} message(s) failed</span>
+            <span>{{ messenger.sendQueue.length }} message(s) failed or are queued while offline.</span>
             <q-space />
             <q-btn flat dense label="Retry" @click="retryQueued" />
           </div>
@@ -78,7 +79,7 @@ import { useMessengerStore } from "src/stores/messenger";
 import { useNdk } from "src/composables/useNdk";
 import { useNostrStore } from "src/stores/nostr";
 import { useUiStore } from "src/stores/ui";
-import { nip19 } from "nostr-tools";
+import { normalizeToHexPubkey } from "src/utils/nostr-ids";
 import type NDK from "@nostr-dev-kit/ndk";
 import ActiveChatHeader from "components/ActiveChatHeader.vue";
 import MessageList from "components/MessageList.vue";
@@ -113,14 +114,7 @@ export default defineComponent({
     const now = ref(Date.now());
     let timer: ReturnType<typeof setInterval> | undefined;
 
-    function bech32ToHex(pubkey: string): string {
-      try {
-        const decoded = nip19.decode(pubkey);
-        return typeof decoded.data === "string" ? decoded.data : pubkey;
-      } catch {
-        return pubkey;
-      }
-    }
+    
 
     function timeout(ms: number) {
       return new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -140,9 +134,13 @@ export default defineComponent({
         loading.value = false;
         const qp = route.query.pubkey as string | undefined;
         if (qp) {
-          const hex = bech32ToHex(qp);
-          messenger.startChat(hex);
-          messenger.setCurrentConversation(hex);
+          const hex = normalizeToHexPubkey(qp);
+          if (hex) {
+            messenger.startChat(hex);
+            messenger.setCurrentConversation(hex);
+          } else {
+            notifyError("Invalid Nostr pubkey");
+          }
         }
       }
     }
@@ -262,6 +260,7 @@ export default defineComponent({
       connecting.value = true;
       try {
         await messenger.reconnectAll();
+        await messenger.retryFailedMessages();
       } catch (e) {
         console.error(e);
       } finally {

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -9,6 +9,7 @@ import {
   RelayAck,
 } from "./nostr";
 import { encryptFor, decryptFrom } from "src/utils/dm-crypto";
+import { normalizeToHexPubkey } from "src/utils/nostr-ids";
 import { v4 as uuidv4 } from "uuid";
 import { useSettingsStore } from "./settings";
 import { DEFAULT_RELAYS } from "src/config/relays";
@@ -32,6 +33,11 @@ import { frequencyToDays } from "src/constants/subscriptionFrequency";
 import { useNdk } from "src/composables/useNdk";
 import { NDKKind, NDKEvent } from "@nostr-dev-kit/ndk";
 import { filterHealthyRelays } from "src/utils/relayHealth";
+
+const DEBUG = import.meta.env.VITE_DEBUG_NOSTR === "true";
+const dbg = (...args: any[]) => {
+  if (DEBUG) console.debug("[messenger]", ...args);
+};
 
 function normalizeRelayUrls(urls: string[]): string[] {
   const set = new Set<string>();
@@ -97,7 +103,12 @@ export type MessengerMessage = {
   content: string;
   created_at: number;
   outgoing: boolean;
-  status?: "pending" | "sent" | "delivered" | "failed";
+  status?:
+    | "pending"
+    | "sent"
+    | "delivered"
+    | "failed"
+    | "failed-decrypt";
   protocol?: "nip17" | "nip04";
   attachment?: MessageAttachment;
   subscriptionPayment?: SubscriptionPayment;
@@ -105,6 +116,7 @@ export type MessengerMessage = {
   autoRedeem?: boolean;
   rawContent?: string;
   relayResults?: Record<string, RelayAck>;
+  queueReason?: string;
 };
 
 export const useMessengerStore = defineStore("messenger", {
@@ -193,11 +205,9 @@ export const useMessengerStore = defineStore("messenger", {
   },
   actions: {
     normalizeKey(pk: string): string {
-      const ns: any = useNostrStore();
-      const resolved =
-        typeof ns?.resolvePubkey === "function" ? ns.resolvePubkey(pk) : pk;
+      const resolved = normalizeToHexPubkey(pk);
       if (!resolved) {
-        console.warn("[messenger] invalid pubkey", pk);
+        dbg("invalid pubkey", pk);
         return "";
       }
       return resolved;
@@ -302,24 +312,22 @@ export const useMessengerStore = defineStore("messenger", {
       attachment?: MessageAttachment,
       tokenPayload?: any,
     ) {
-      recipient = this.normalizeKey(recipient);
-      if (!recipient) return { success: false, event: null };
+      const hex = this.normalizeKey(recipient);
+      if (!hex) {
+        notifyError("Invalid Nostr pubkey");
+        return { success: false, event: null, reason: "invalid_pubkey" } as any;
+      }
       await this.loadIdentity();
       const nostr = useNostrStore();
 
       const { content: safeMessage } = generateContentTags(message);
       if (!safeMessage.trim()) {
-        return { success: false, event: null };
+        notifyWarning("Cannot send empty message");
+        return { success: false, event: null, reason: "empty" } as any;
       }
 
-      const userRelays = await nostr.fetchUserRelays(recipient);
-      const targetRelays = relays || userRelays || (this.relays as any);
-      const healthyRelays = await filterHealthyRelays(
-        normalizeRelayUrls(targetRelays),
-      );
-
       const msg = this.addOutgoingMessage(
-        recipient,
+        hex,
         safeMessage,
         undefined,
         undefined,
@@ -328,10 +336,31 @@ export const useMessengerStore = defineStore("messenger", {
         tokenPayload,
       );
 
-      if (!healthyRelays.length) {
-        msg.status = "failed";
+      const { connected, total } = await this.hasConnectedWriteRelays();
+      if (connected === 0) {
+        msg.queueReason = "no_relay";
         this.sendQueue.push(msg);
-        return { success: false, event: null };
+        notifyWarning(
+          `Offline – ${connected}/${total} relays connected. Message queued.`,
+        );
+        dbg("queued:no_relay", hex.slice(0, 6) + "…" + hex.slice(-6));
+        return { success: false, event: null, reason: "no_relay" } as any;
+      }
+
+      const userRelays = await nostr.fetchUserRelays(hex);
+      const targetRelays = relays || userRelays || (this.relays as any);
+      const healthyRelays = await filterHealthyRelays(
+        normalizeRelayUrls(targetRelays),
+      );
+
+      if (!healthyRelays.length) {
+        msg.queueReason = "no_relay";
+        this.sendQueue.push(msg);
+        notifyWarning(
+          `Offline – ${connected}/${total} relays connected. Message queued.`,
+        );
+        dbg("queued:no_healthy", hex.slice(0, 6) + "…" + hex.slice(-6));
+        return { success: false, event: null, reason: "no_relay" } as any;
       }
 
       let event: NDKEvent | null = null;
@@ -339,7 +368,12 @@ export const useMessengerStore = defineStore("messenger", {
       let protocolUsed: "nip17" | "nip04" | null = null;
 
       try {
-        const enc = await encryptFor(recipient, safeMessage);
+        const enc = await encryptFor(hex, safeMessage);
+        protocolUsed = enc.protocol === "nip44" ? "nip17" : "nip04";
+        dbg("encrypt", {
+          to: hex.slice(0, 6) + "…" + hex.slice(-6),
+          scheme: enc.protocol,
+        });
         const ndk = await useNdk();
         const dmEvent = new NDKEvent(ndk);
         dmEvent.kind =
@@ -349,16 +383,18 @@ export const useMessengerStore = defineStore("messenger", {
         dmEvent.content = enc.content;
         dmEvent.tags =
           enc.protocol === "nip44"
-            ? [["p", recipient]]
-            : [["p", recipient], ["p", nostr.pubkey]];
+            ? [["p", hex]]
+            : [["p", hex], ["p", nostr.pubkey]];
         await dmEvent.sign(nostr.signer);
         const raw = await dmEvent.toNostrEvent();
         results = await publishWithAcks(raw, healthyRelays);
-        const success = Object.values(results).some((r) => r.ok);
+        const okCount = Object.values(results).filter((r) => r.ok).length;
+        const errCount = Object.values(results).length - okCount;
+        dbg("publish", { ok: okCount, err: errCount });
+        const success = okCount > 0;
         msg.relayResults = results;
         if (success) {
           msg.status = "sent";
-          protocolUsed = enc.protocol === "nip44" ? "nip17" : "nip04";
           msg.protocol = protocolUsed;
           notifySuccess(
             protocolUsed === "nip17"
@@ -370,12 +406,14 @@ export const useMessengerStore = defineStore("messenger", {
           throw new Error("No relay accepted event");
         }
         return { success, event };
-      } catch (e) {
+      } catch (e: any) {
         console.error("Failed to send DM", e);
         msg.status = "failed";
+        msg.relayResults = results;
         this.sendQueue.push(msg);
         notifyError("Failed to send DM");
-        return { success: false, event: null };
+        dbg("send error", e?.message || e);
+        return { success: false, event: null, reason: e?.message } as any;
       }
     },
     async sendToken(
@@ -617,18 +655,21 @@ export const useMessengerStore = defineStore("messenger", {
         try {
           const res = await decryptFrom(event.pubkey, ciphertext);
           decrypted = res.plaintext;
+          if (!decrypted && res.error) {
+            dbg("decrypt failed", { id: event.id, reason: res.error });
+          }
         } catch (e) {
-          /* ignore */
+          dbg("decrypt exception", e);
         }
       }
       if (!decrypted) {
         const msg: MessengerMessage = {
           id: event.id,
           pubkey: event.pubkey,
-          content: "[Unable to decrypt]",
+          content: "Unable to decrypt",
           created_at: event.created_at,
           outgoing: false,
-          status: "failed",
+          status: "failed-decrypt",
           protocol: event.kind === 14 ? "nip17" : "nip04",
           rawContent: event.content,
         };
@@ -905,6 +946,14 @@ export const useMessengerStore = defineStore("messenger", {
       return nostr.connected;
     },
 
+    async hasConnectedWriteRelays(): Promise<{ connected: number; total: number }> {
+      const ndk = await useNdk({ requireSigner: false });
+      const relays = Array.from(ndk.pool.relays.values());
+      const writeRelays = relays.filter((r: any) => r.policy?.write !== false);
+      const connected = writeRelays.filter((r: any) => r.connected).length;
+      return { connected, total: writeRelays.length };
+    },
+
     async connect(relays: string[]) {
       const nostr = useNostrStore();
       const unique = normalizeRelayUrls(Array.from(new Set(relays)));
@@ -942,7 +991,8 @@ export const useMessengerStore = defineStore("messenger", {
 
     async retryFailedMessages() {
       const attempt = async () => {
-        if (!this.isConnected() || !this.sendQueue.length) {
+        const { connected } = await this.hasConnectedWriteRelays();
+        if (!connected || !this.sendQueue.length) {
           if (this.retryTimer) {
             clearInterval(this.retryTimer);
             this.retryTimer = null;
@@ -958,7 +1008,8 @@ export const useMessengerStore = defineStore("messenger", {
               normalizeRelayUrls(targets),
             );
             if (!healthy.length) {
-              msg.status = "failed";
+              msg.status = "pending";
+              msg.queueReason = "no_relay";
               continue;
             }
 
@@ -979,7 +1030,8 @@ export const useMessengerStore = defineStore("messenger", {
               await dmEvent.sign(nostr.signer);
               const raw = await dmEvent.toNostrEvent();
               results = await publishWithAcks(raw, healthy);
-              if (Object.values(results).some((r) => r.ok)) {
+              const ok = Object.values(results).some((r) => r.ok);
+              if (ok) {
                 msg.id = dmEvent.id;
                 msg.created_at =
                   dmEvent.created_at ?? Math.floor(Date.now() / 1000);

--- a/src/utils/dm-crypto.ts
+++ b/src/utils/dm-crypto.ts
@@ -50,19 +50,8 @@ export async function decryptFrom(
 ): Promise<DecryptResult> {
   const nostr = useNostrStore();
   const tried: ('nip44' | 'nip04')[] = [];
-  if (looksLikeNip04(ciphertext) && nostr.canNip04) {
-    tried.push('nip04');
-    try {
-      return {
-        protocolTried: tried,
-        plaintext: await nostr.nip04Decrypt(pubkey, ciphertext),
-        protocol: 'nip04',
-      };
-    } catch {
-      /* ignore */
-    }
-  }
-  if (nostr.canNip44) {
+  const prefer44 = looksLikeNip44(ciphertext);
+  if (prefer44 && nostr.canNip44) {
     tried.push('nip44');
     try {
       return {
@@ -74,13 +63,25 @@ export async function decryptFrom(
       /* ignore */
     }
   }
-  if (looksLikeNip44(ciphertext) && nostr.canNip04 && !tried.includes('nip04')) {
+  if (nostr.canNip04) {
     tried.push('nip04');
     try {
       return {
         protocolTried: tried,
         plaintext: await nostr.nip04Decrypt(pubkey, ciphertext),
         protocol: 'nip04',
+      };
+    } catch {
+      /* ignore */
+    }
+  }
+  if (!prefer44 && nostr.canNip44 && !tried.includes('nip44')) {
+    tried.push('nip44');
+    try {
+      return {
+        protocolTried: tried,
+        plaintext: await nostr.nip44Decrypt(pubkey, ciphertext),
+        protocol: 'nip44',
       };
     } catch {
       /* ignore */

--- a/src/utils/nostr-ids.ts
+++ b/src/utils/nostr-ids.ts
@@ -1,0 +1,27 @@
+import { nip19 } from 'nostr-tools';
+import { bytesToHex } from '@noble/hashes/utils';
+
+/**
+ * Normalize a user supplied pubkey identifier (hex, npub, nprofile) to 64-char hex.
+ * Returns null if input cannot be parsed.
+ */
+export function normalizeToHexPubkey(input: string): string | null {
+  if (typeof input !== 'string') return null;
+  const trimmed = input.trim();
+  if (/^[0-9a-fA-F]{64}$/.test(trimmed)) return trimmed.toLowerCase();
+  try {
+    const decoded = nip19.decode(trimmed);
+    if (decoded.type === 'npub') {
+      return typeof decoded.data === 'string'
+        ? decoded.data.toLowerCase()
+        : bytesToHex(decoded.data as Uint8Array).toLowerCase();
+    }
+    if (decoded.type === 'nprofile') {
+      const pubkey = (decoded.data as any).pubkey;
+      if (typeof pubkey === 'string' && /^[0-9a-fA-F]{64}$/.test(pubkey)) {
+        return pubkey.toLowerCase();
+      }
+    }
+  } catch {}
+  return null;
+}

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -95,19 +95,21 @@ beforeEach(() => {
 describe("messenger store", () => {
   it("publishes DM with relay acknowledgements", async () => {
     const messenger = useMessengerStore();
-    await messenger.sendDm("r", "m");
+    const hex = "f".repeat(64);
+    await messenger.sendDm(hex, "m");
     expect(publishWithAcksMock).toHaveBeenCalled();
   });
 
   it("decrypts incoming messages with global key", async () => {
     const messenger = useMessengerStore();
+    const hex = "e".repeat(64);
     await messenger.addIncomingMessage({
       id: "1",
-      pubkey: "s",
+      pubkey: hex,
       content: "c?iv=1",
       created_at: 1,
     } as any);
-    expect(decryptDm).toHaveBeenCalledWith("priv", "s", "c?iv=1");
+    expect(decryptDm).toHaveBeenCalledWith("priv", hex, "c?iv=1");
   });
 
   it("subscribes using global key on start", async () => {
@@ -133,9 +135,10 @@ describe("messenger store", () => {
   it("handles multi-line JSON messages", async () => {
     const messenger = useMessengerStore();
     (decryptDm as any).mockResolvedValue('{"a":1}\n{"b":2}');
+    const hex = "d".repeat(64);
     await messenger.addIncomingMessage({
       id: "1",
-      pubkey: "s",
+      pubkey: hex,
       content: "c",
       created_at: 1,
     } as any);
@@ -144,8 +147,9 @@ describe("messenger store", () => {
 
   it("handles malformed content when sending", async () => {
     const messenger = useMessengerStore();
-    await messenger.sendDm("r", { bad: "obj" } as any);
+    const hex = "c".repeat(64);
+    await messenger.sendDm(hex, { bad: "obj" } as any);
     expect(publishWithAcksMock).toHaveBeenCalled();
-    expect(messenger.conversations.r[0].content).toBe("");
+    expect(messenger.conversations[hex][0].content).toBe("");
   });
 });

--- a/test/vitest/__tests__/nostr-ids.spec.ts
+++ b/test/vitest/__tests__/nostr-ids.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import { normalizeToHexPubkey } from 'src/utils/nostr-ids';
+
+const sampleHex = 'a'.repeat(64);
+
+describe('normalizeToHexPubkey', () => {
+  it('returns hex when given hex', () => {
+    expect(normalizeToHexPubkey(sampleHex)).toBe(sampleHex);
+  });
+
+  it('decodes npub', () => {
+    const npub = nip19.npubEncode(sampleHex);
+    expect(normalizeToHexPubkey(npub)).toBe(sampleHex);
+  });
+
+  it('decodes nprofile', () => {
+    const np = nip19.nprofileEncode({ pubkey: sampleHex, relays: [] });
+    expect(normalizeToHexPubkey(np)).toBe(sampleHex);
+  });
+
+  it('rejects invalid input', () => {
+    expect(normalizeToHexPubkey('invalid')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- normalize npub/nprofile to hex pubkeys and apply across chat flows
- guard DM sends: reject empty or invalid recipients, queue when offline, and log debug traces
- improve decrypt detection and show status for undecryptable messages
- update messenger UI banners and message bubble icons for queued/offline states

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b530ce7cd08330bc47d5908fbcc0c7