### PR TITLE
Use toNostrEvent when wrapping sealed messages

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -342,7 +342,8 @@ export const useMessengerStore = defineStore("messenger", {
           const giftWrap = new NDKEvent(ndk);
           giftWrap.kind = 1059 as NDKKind;
           giftWrap.tags = [["p", recipient]];
-          giftWrap.content = await seal.toJson();
+          const sealed = await seal.toNostrEvent();
+          giftWrap.content = JSON.stringify(sealed);
           const ephemeralSigner = new NDKPrivateKeySigner();
           await giftWrap.sign(ephemeralSigner);
 
@@ -995,7 +996,8 @@ export const useMessengerStore = defineStore("messenger", {
                 const giftWrap = new NDKEvent(ndk);
                 giftWrap.kind = 1059 as NDKKind;
                 giftWrap.tags = [["p", msg.pubkey]];
-                giftWrap.content = await seal.toJson();
+                const sealed = await seal.toNostrEvent();
+                giftWrap.content = JSON.stringify(sealed);
                 const ephemeralSigner = new NDKPrivateKeySigner();
                 await giftWrap.sign(ephemeralSigner);
 


### PR DESCRIPTION
## Summary
- Replace `seal.toJson()` with `toNostrEvent` + `JSON.stringify` for NIP-17 gift wrapping
- Apply the same sealing logic in retry path to ensure consistent wrapping

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b541527efc8330828fe56b83d0b6fc