### PR TITLE
fix: handle nostr publish ack variants

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -402,33 +402,69 @@ export async function publishWithAcks(
   const pool = new SimplePool();
   const results: Record<string, RelayAck> = {};
   const pub = pool.publish(relays, event as any);
-  return await new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      for (const r of relays) {
-        if (!results[r]) results[r] = { ok: false, reason: "timeout" };
-      }
-      resolve(results);
-    }, timeoutMs);
 
-    const finish = () => {
-      if (Object.keys(results).length >= relays.length) {
-        clearTimeout(timer);
+  // Newer versions of nostr-tools return an array of Promises
+  if (Array.isArray(pub)) {
+    await Promise.all(
+      pub.map((p: Promise<any>, i: number) => {
+        const url = relays[i];
+        return new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            results[url] = { ok: false, reason: "timeout" };
+            resolve();
+          }, timeoutMs);
+
+          p.then(() => {
+            clearTimeout(timer);
+            results[url] = { ok: true };
+            resolve();
+          }).catch((err) => {
+            clearTimeout(timer);
+            results[url] = { ok: false, reason: String(err) };
+            resolve();
+          });
+        });
+      }),
+    );
+    return results;
+  }
+
+  // Older versions returned an event emitter
+  if (pub && typeof (pub as any).on === "function") {
+    return await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        for (const r of relays) {
+          if (!results[r]) results[r] = { ok: false, reason: "timeout" };
+        }
         resolve(results);
-      }
-    };
+      }, timeoutMs);
 
-    pub.on("ok", (relay: any) => {
-      const url = relay.url || relay;
-      results[url] = { ok: true };
-      finish();
-    });
+      const finish = () => {
+        if (Object.keys(results).length >= relays.length) {
+          clearTimeout(timer);
+          resolve(results);
+        }
+      };
 
-    pub.on("failed", (relay: any, reason: any) => {
-      const url = relay.url || relay;
-      results[url] = { ok: false, reason: String(reason) };
-      finish();
+      pub.on("ok", (relay: any) => {
+        const url = relay.url || relay;
+        results[url] = { ok: true };
+        finish();
+      });
+
+      pub.on("failed", (relay: any, reason: any) => {
+        const url = relay.url || relay;
+        results[url] = { ok: false, reason: String(reason) };
+        finish();
+      });
     });
-  });
+  }
+
+  // Fallback: mark all as failed
+  for (const r of relays) {
+    results[r] = { ok: false, reason: "unknown" };
+  }
+  return results;
 }
 
 /** Resolves once any relay in `ndk.pool` has `connected === true`. */


### PR DESCRIPTION
## Summary
- feature-detect SimplePool.publish return shape
- support both Promise and emitter forms for relay acks

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5426ebda88330aa2e45b0aacec2cf