### PR TITLE
refactor: simplify DM flow to NIP-07 extension

### DIFF
--- a/src/nostr/crypto.ts
+++ b/src/nostr/crypto.ts
@@ -1,75 +1,19 @@
-export type DMEncryptionMethod = 'nip44' | 'nip04';
-export type DMEncryptResult = { method: DMEncryptionMethod; content: string };
-
-export function signerCapabilities() {
-  const n = (globalThis as any).nostr;
-  return {
-    hasNip44: !!n?.nip44?.encrypt && !!n?.nip44?.decrypt,
-    hasNip04: !!n?.nip04?.encrypt && !!n?.nip04?.decrypt,
-    hasSigner: !!n,
-  };
-}
-
-async function tryLocalNip04Encrypt(recipientHex: string, plaintext: string, privKeyHex?: string): Promise<string | null> {
-  return null;
-}
-
-async function tryLocalNip04Decrypt(senderHex: string, parsed: ParsedCipher, privKeyHex?: string): Promise<string | null> {
-  return null;
-}
-
-export async function encryptDM(
-  plaintext: string,
-  recipientHex: string,
+export async function decryptDM(
+  senderHex: string,
+  content: string,
   privKeyHex?: string,
-): Promise<DMEncryptResult> {
+): Promise<string | null> {
   const n = (globalThis as any).nostr;
-  const caps = signerCapabilities();
-
-  if (caps.hasNip44) {
-    const content = await n.nip44.encrypt(recipientHex, plaintext);
-    return { method: 'nip44', content };
-  }
-  if (caps.hasNip04) {
-    const content = await n.nip04.encrypt(recipientHex, plaintext);
-    return { method: 'nip04', content };
-  }
-
-  const local = await tryLocalNip04Encrypt(recipientHex, plaintext, privKeyHex);
-  if (local) return { method: 'nip04', content: local };
-
-  throw new Error('No encryption available: enable a NIP-07 signer (e.g., Alby) or import a local key.');
-}
-
-export type ParsedCipher = { scheme: 'nip44' | 'nip04'; ciphertext: string; iv?: string };
-
-export function parseCipher(content: string): ParsedCipher | null {
-  if (/^v\d[\s:,-]/.test(content) || content.startsWith('v1') || content.startsWith('v2')) {
-    return { scheme: 'nip44', ciphertext: content };
-  }
-  const [ct, query] = content.split('?');
-  const iv = new URLSearchParams(query || '').get('iv') || undefined;
-  if (!ct || !iv) return null;
-  return { scheme: 'nip04', ciphertext: ct, iv };
-}
-
-export async function decryptDM(senderHex: string, content: string, privKeyHex?: string): Promise<string | null> {
-  const n = (globalThis as any).nostr;
-  const caps = signerCapabilities();
-  const parsed = parseCipher(content);
-
-  if (!parsed) throw new Error('Invalid encrypted message (missing iv or malformed).');
-
-  if (parsed.scheme === 'nip44' && caps.hasNip44) {
-    try {
-      return await n.nip44.decrypt(senderHex, content);
-    } catch {}
-  }
-  if (caps.hasNip04) {
+  if (n?.nip04?.decrypt) {
     try {
       return await n.nip04.decrypt(senderHex, content);
     } catch {}
   }
-
-  return (await tryLocalNip04Decrypt(senderHex, parsed, privKeyHex)) ?? null;
+  if (privKeyHex) {
+    try {
+      const { nip04 } = await import("nostr-tools");
+      return await nip04.decrypt(privKeyHex, senderHex, content);
+    } catch {}
+  }
+  return null;
 }

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
-var publishWithAcksMock: any;
-var decryptDm: any;
-var walletGen: any;
-var subscribeMock: any;
+var publishMock: any;
+vi.mock("nostr-tools", async (orig) => {
+  const actual = await orig();
+  publishMock = vi.fn(async () => {});
+  return { ...actual, SimplePool: class { publish = publishMock } };
+});
 
 const lsStore: Record<string, string> = {};
 (globalThis as any).localStorage = {
@@ -24,39 +26,22 @@ const lsStore: Record<string, string> = {};
   },
 };
 
+var decryptDm: any;
+var subscribeMock: any;
 vi.mock("../../../src/stores/nostr", async (importOriginal) => {
   const actual = await importOriginal();
-  publishWithAcksMock = vi.fn(async () => ({
-    "wss://relay.example": { ok: true },
-  }));
   decryptDm = vi.fn(async () => "msg");
-  walletGen = vi.fn();
-  const signer = { sign: vi.fn(async () => {}), user: vi.fn(async () => ({})) };
   const store = {
     decryptDmContent: decryptDm,
-    encryptDmContent: vi.fn(async (_k, _r, m) => m),
-    fetchUserRelays: vi.fn(async () => ["wss://relay.example"]),
-    walletSeedGenerateKeyPair: walletGen,
     initSignerIfNotSet: vi.fn(),
+    fetchUserRelays: vi.fn(async () => []),
     privKeyHex: "priv",
     pubkey: "pub",
     connected: true,
-    lastError: null,
-    relays: [] as string[],
-    signerType: "seed",
-    signerCaps: { nip44Encrypt: true, nip44Decrypt: true },
-    signer,
-  };
-  return {
-    ...actual,
-    publishWithAcks: publishWithAcksMock,
-    useNostrStore: () => store,
-  };
+    signerType: "NIP07",
+  } as any;
+  return { ...actual, useNostrStore: () => store };
 });
-
-vi.mock("../../../src/js/nostr-runtime", () => ({
-  RelayWatchdog: class {},
-}));
 
 vi.mock("../../../src/composables/useNdk", () => {
   subscribeMock = vi.fn(() => ({ on: vi.fn(), stop: vi.fn() }));
@@ -68,10 +53,6 @@ vi.mock("../../../src/js/message-utils", () => ({
   sanitizeMessage: vi.fn((s: string) => s),
 }));
 
-vi.mock("../../../src/utils/relayHealth", () => ({
-  filterHealthyRelays: vi.fn(async (relays: string[]) => relays),
-}));
-
 var notifySpy: any;
 var notifyErrorSpy: any;
 vi.mock("../../../src/js/notify", () => {
@@ -81,7 +62,6 @@ vi.mock("../../../src/js/notify", () => {
 });
 
 import { useMessengerStore } from "../../../src/stores/messenger";
-import { useNostrStore } from "../../../src/stores/nostr";
 
 beforeEach(() => {
   setActivePinia(createPinia());
@@ -89,50 +69,50 @@ beforeEach(() => {
   const m = useMessengerStore();
   (m as any).eventLog = [];
   (m as any).conversations = {};
-  vi.clearAllMocks();
+  publishMock.mockClear();
+  notifySpy.mockClear();
+  notifyErrorSpy.mockClear();
 });
 
 describe("messenger store", () => {
-  it("publishes DM with relay acknowledgements", async () => {
+  it("broadcasts DM to all relays", async () => {
     const messenger = useMessengerStore();
+    (globalThis as any).nostr = {
+      nip04: { encrypt: vi.fn(async () => "enc"), decrypt: vi.fn() },
+      signEvent: vi.fn(async (e) => ({ ...e, id: "id", sig: "sig" })),
+    };
+    messenger.relays = ["wss://a", "wss://b"] as any;
     await messenger.sendDm("r", "m");
-    expect(publishWithAcksMock).toHaveBeenCalled();
+    expect(publishMock).toHaveBeenCalledTimes(2);
   });
 
-  it("decrypts incoming messages with global key", async () => {
+  it("decrypts incoming messages with extension", async () => {
     const messenger = useMessengerStore();
+    (globalThis as any).nostr = {
+      nip04: { decrypt: vi.fn(async () => "msg"), encrypt: vi.fn() },
+      signEvent: vi.fn(),
+    };
     await messenger.addIncomingMessage({
       id: "1",
       pubkey: "s",
       content: "c?iv=1",
       created_at: 1,
     } as any);
-    expect(decryptDm).toHaveBeenCalledWith("priv", "s", "c?iv=1");
+    expect(decryptDm).toHaveBeenCalledWith(undefined, "s", "c?iv=1");
   });
 
-  it("subscribes using global key on start", async () => {
+  it("subscribes to kind 4 on start", async () => {
     const messenger = useMessengerStore();
     await messenger.start();
-    expect(subscribeMock).toHaveBeenCalledTimes(2);
-    const call1 = subscribeMock.mock.calls[0][0];
-    expect(call1.kinds).toEqual([4]);
-    expect(call1["#p"]).toEqual(["pub"]);
-    const call2 = subscribeMock.mock.calls[1][0];
-    expect(call2.kinds).toEqual([1059]);
-    expect(call2["#p"]).toEqual(["pub"]);
-  });
-
-  it("notifies when starting without privkey", async () => {
-    const messenger = useMessengerStore();
-    const nostr = useNostrStore();
-    nostr.privateKeySignerPrivateKey = "";
-    await messenger.start();
-    expect(notifyErrorSpy).toHaveBeenCalled();
+    expect(subscribeMock).toHaveBeenCalledTimes(1);
+    const call = subscribeMock.mock.calls[0][0];
+    expect(call.kinds).toEqual([4]);
+    expect(call["#p"]).toEqual(["pub"]);
   });
 
   it("handles multi-line JSON messages", async () => {
     const messenger = useMessengerStore();
-    (decryptDm as any).mockResolvedValue('{"a":1}\n{"b":2}');
+    decryptDm.mockResolvedValue('{"a":1}\n{"b":2}');
     await messenger.addIncomingMessage({
       id: "1",
       pubkey: "s",
@@ -144,8 +124,12 @@ describe("messenger store", () => {
 
   it("handles malformed content when sending", async () => {
     const messenger = useMessengerStore();
+    (globalThis as any).nostr = {
+      nip04: { encrypt: vi.fn(async () => "enc"), decrypt: vi.fn() },
+      signEvent: vi.fn(async (e) => ({ ...e, id: "id", sig: "sig" })),
+    };
     await messenger.sendDm("r", { bad: "obj" } as any);
-    expect(publishWithAcksMock).toHaveBeenCalled();
+    expect(publishMock).toHaveBeenCalled();
     expect(messenger.conversations.r[0].content).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- drop nip44/nip17 flows and rely solely on NIP-07's NIP-04 encryption
- broadcast direct messages to all relays and add manual retry path
- update tests for new direct messaging behavior

## Testing
- `pnpm lint`
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/vitest/__tests__/messenger.spec.ts test/vitest/__tests__/messenger-send-token.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b5668e6db88330bc071ad53a8d2b0d