### PR TITLE
Guard send queue access and wire retry

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -13,11 +13,11 @@
             @click.stop="toggleMessengerDrawer"
           >
           <q-badge
-            v-if="messenger.sendQueue.length"
+            v-if="(messenger.sendQueue || []).length"
             color="negative"
             floating
           >
-            {{ messenger.sendQueue.length }}
+            {{ (messenger.sendQueue || []).length }}
           </q-badge>
           <q-tooltip>Chats</q-tooltip>
         </q-btn>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -32,14 +32,19 @@
         </q-banner>
         <NostrRelayErrorBanner />
         <q-banner
-          v-if="messenger.sendQueue.length"
+          v-if="(messenger.sendQueue || []).length"
           dense
           class="bg-orange-2 q-mb-sm"
         >
           <div class="row items-center no-wrap">
-            <span>{{ messenger.sendQueue.length }} message(s) failed</span>
+            <span>{{ (messenger.sendQueue || []).length }} message(s) failed</span>
             <q-space />
-            <q-btn flat dense label="Retry" @click="retryQueued" />
+            <q-btn
+              flat
+              dense
+              label="Retry"
+              @click="messenger.retryFailedMessages"
+            />
           </div>
         </q-banner>
         <div class="row justify-end q-mb-sm" v-if="!loading">
@@ -166,8 +171,6 @@ export default defineComponent({
     });
 
     const route = useRoute();
-
-    const retryQueued = () => messenger.retryFailedMessages();
 
     const openDrawer = () => {
       if ($q.screen.lt.md) {
@@ -310,7 +313,6 @@ export default defineComponent({
       switchAccount,
       openDrawer,
       ui,
-      retryQueued,
     };
   },
 });


### PR DESCRIPTION
## Summary
- avoid runtime errors by guarding `sendQueue` length access
- call `retryFailedMessages` directly from banner retry button

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57794a3148330b447effbdb6c2bc5