### PR TITLE
Adjust chat bubble avatar layout

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -12,7 +12,7 @@
       <span v-else>{{ initials }}</span>
     </q-avatar>
     <div
-      class="flex column"
+      class="column"
       :class="message.outgoing ? 'items-end' : 'items-start'"
     >
       <div
@@ -96,15 +96,15 @@
           :color="statusColor"
         />
       </div>
-      <q-avatar
-        v-if="message.outgoing && showAvatar"
-        size="32px"
-        class="q-ml-sm"
-      >
-        <img v-if="profile?.picture" :src="profile.picture" />
-        <span v-else>{{ initials }}</span>
-      </q-avatar>
     </div>
+    <q-avatar
+      v-if="message.outgoing && showAvatar"
+      size="32px"
+      class="q-ml-sm"
+    >
+      <img v-if="profile?.picture" :src="profile.picture" />
+      <span v-else>{{ initials }}</span>
+    </q-avatar>
   </div>
 </template>
 

--- a/test/chat-message-bubble.align.spec.ts
+++ b/test/chat-message-bubble.align.spec.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import { createTestingPinia } from "@pinia/testing";
+import { useNostrStore } from "src/stores/nostr";
+import { useMessengerStore } from "src/stores/messenger";
+
+async function mountBubble(message: any, prevMessage?: any) {
+  (window as any).windowMixin = {};
+  const ChatMessageBubble = (
+    await import("src/components/ChatMessageBubble.vue")
+  ).default;
+  const pinia = createTestingPinia({ createSpy: vi.fn });
+  const nostr = useNostrStore();
+  nostr.pubkey = "pk";
+  nostr.getProfile = vi.fn().mockResolvedValue(null);
+  const messenger = useMessengerStore();
+  messenger.aliases = {};
+  return shallowMount(ChatMessageBubble, {
+    props: { message, prevMessage },
+    global: { plugins: [pinia] },
+  });
+}
+
+describe("ChatMessageBubble alignment", () => {
+  it("aligns consecutive outgoing messages without avatar", async () => {
+    const message = {
+      id: "2",
+      pubkey: "pk",
+      content: "hello",
+      created_at: 100,
+      outgoing: true,
+    };
+    const prevMessage = {
+      id: "1",
+      pubkey: "pk",
+      content: "hi",
+      created_at: 90,
+      outgoing: true,
+    };
+    const wrapper = await mountBubble(message, prevMessage);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll("q-avatar-stub").length).toBe(0);
+    expect(wrapper.classes()).toContain("justify-end");
+    const column = wrapper.find("div.column");
+    expect(column.classes()).toContain("items-end");
+  });
+
+  it("aligns consecutive incoming messages without avatar", async () => {
+    const message = {
+      id: "2",
+      pubkey: "other",
+      content: "hello",
+      created_at: 100,
+      outgoing: false,
+    };
+    const prevMessage = {
+      id: "1",
+      pubkey: "other",
+      content: "hi",
+      created_at: 90,
+      outgoing: false,
+    };
+    const wrapper = await mountBubble(message, prevMessage);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll("q-avatar-stub").length).toBe(0);
+    expect(wrapper.classes()).toContain("justify-start");
+    const column = wrapper.find("div.column");
+    expect(column.classes()).toContain("items-start");
+  });
+});


### PR DESCRIPTION
## Summary
- Move outgoing chat avatar beside message column and mirror incoming avatar structure
- Limit message column width to bubble size for proper alignment
- Add tests ensuring consecutive messages without avatars align correctly

## Testing
- `pnpm lint`
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/chat-message-bubble.align.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5dd40ee648330804e2868f00b93aa