### PR TITLE
feat: shrink chat bubbles to content

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -320,8 +320,9 @@ async function updateAutoRedeem(val: boolean) {
 }
 
 .bubble {
-  padding: 18px;
-  max-width: 70%;
+  padding: 8px 12px;
+  width: fit-content;
+  max-width: 75%;
   word-break: break-word;
   margin: 2px 0;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- shrink message bubble padding and allow width to fit content capped at 75%

## Testing
- `pnpm lint`
- `pnpm test`
- `node <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68b5e04baacc8330a4e151c6442c5141