### PR TITLE
Refine chat message spacing

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="row message-row"
+    class="row message-row q-mx-sm q-my-xs"
     :class="message.outgoing ? 'justify-end' : 'justify-start'"
   >
     <q-avatar
@@ -315,10 +315,6 @@ async function updateAutoRedeem(val: boolean) {
 </script>
 
 <style scoped>
-.message-row {
-  margin: 4px 0;
-}
-
 .bubble {
   padding: 8px 12px;
   width: fit-content;

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -1,14 +1,14 @@
 <template>
   <q-virtual-scroll
     ref="scroll"
-    class="col column q-pa-md"
+    class="col column q-py-md"
     :items="messages"
     :virtual-scroll-slice-size="30"
     v-slot="{ item: msg, index: idx }"
   >
     <div
       v-if="showDateSeparator(idx)"
-      class="text-caption text-center q-my-md divider-text"
+      class="text-caption text-center q-my-md q-mx-sm divider-text"
     >
       {{ formatDay(msg.created_at) }}
     </div>


### PR DESCRIPTION
## Summary
- remove global padding from MessageList and rely on targeted margins
- ensure date separators and message bubbles keep consistent spacing

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e1c71a948330aa7fc5395ede088b