### PR TITLE
Ensure Nostr keys load before router init

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -299,6 +299,8 @@ export async function ndkSend(
 }
 
 export default boot(async ({ app }) => {
+  const nostrStore = useNostrStore();
+  await nostrStore.loadKeysFromStorage();
   ndkPromise = getNdk();
   app.provide("$ndkPromise", ndkPromise);
   ndkPromise.catch((e) => useBootErrorStore().set(e as NdkBootError));

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,6 +8,7 @@ import {
 import routes from "./routes";
 import { hasSeenWelcome } from "src/composables/useWelcomeGate";
 import { useRestoreStore } from "src/stores/restore";
+import { useNostrStore } from "src/stores/nostr";
 
 /*
  * If not building with SSR mode, you can
@@ -18,7 +19,8 @@ import { useRestoreStore } from "src/stores/restore";
  * with the Router instance.
  */
 
-export default route(function (/* { store, ssrContext } */) {
+export default route(async function (/* { store, ssrContext } */) {
+  await useNostrStore().loadKeysFromStorage();
   const createHistory = process.env.SERVER
     ? createMemoryHistory
     : process.env.VUE_ROUTER_MODE === "history"


### PR DESCRIPTION
## Summary
- load Nostr keys from storage during NDK boot
- delay router creation until keys are loaded so pubkey and signerType are ready

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5e74b67bc8330bb59d9eecea92356