### PR TITLE
fix: guard messenger event log

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -123,6 +123,7 @@ export const useMessengerStore = defineStore("messenger", {
       storageKey("eventLog"),
       [] as MessengerMessage[],
     );
+    if (!Array.isArray(eventLog.value)) eventLog.value = [];
     const drawerOpen = useLocalStorage<boolean>(storageKey("drawerOpen"), true);
     const drawerMini = useLocalStorage<boolean>(
       storageKey("drawerMini"),
@@ -160,6 +161,7 @@ export const useMessengerStore = defineStore("messenger", {
       return nostr.connected;
     },
     sendQueue(): MessengerMessage[] {
+      if (!Array.isArray(this.eventLog)) this.eventLog = [];
       return this.eventLog.filter(
         (m) => m.outgoing && m.status === "failed",
       );
@@ -546,6 +548,7 @@ export const useMessengerStore = defineStore("messenger", {
       }
     },
     async retryFailedMessages() {
+      if (!Array.isArray(this.eventLog)) this.eventLog = [];
       for (const msg of this.sendQueue) {
         await this.retryMessage(msg);
       }
@@ -610,6 +613,7 @@ export const useMessengerStore = defineStore("messenger", {
       } catch {}
     },
     async addIncomingMessage(event: NostrEvent, plaintext?: string) {
+      if (!Array.isArray(this.eventLog)) this.eventLog = [];
       await this.loadIdentity();
       const nostr = useNostrStore();
       let privKey: string | undefined = undefined;

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -132,4 +132,15 @@ describe("messenger store", () => {
     expect(publishMock).toHaveBeenCalled();
     expect(messenger.conversations.r[0].content).toBe("");
   });
+
+  it("recovers from corrupted event log in localStorage", () => {
+    lsStore["cashu.messenger.pub.eventLog"] = "{\"bad\":1}";
+    setActivePinia(createPinia());
+    const messenger = useMessengerStore();
+    expect(Array.isArray(messenger.eventLog)).toBe(true);
+    expect(messenger.eventLog.length).toBe(0);
+    (messenger as any).eventLog = { bad: true } as any;
+    expect(messenger.sendQueue.length).toBe(0);
+    expect(Array.isArray(messenger.eventLog)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- guard messenger event log against malformed localStorage
- reset event log when getters/actions encounter corrupted data
- test recovery from bad event log storage

## Testing
- `corepack pnpm test`
- `corepack pnpm exec vitest run test/vitest/__tests__/messenger.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b67d545be08330bdaaa93cf7174316