### PR TITLE
fix: guard non-string aliases in chat header

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -104,7 +104,7 @@ watch(
 const displayName = computed(() => {
   if (!props.pubkey) return "";
   const alias = messenger.aliases[props.pubkey];
-  if (alias) return alias;
+  if (typeof alias === "string") return alias;
   const p: any = profile.value;
   if (p?.display_name) return p.display_name;
   if (p?.name) return p.name;
@@ -116,7 +116,9 @@ const displayName = computed(() => {
 });
 
 const initials = computed(() => {
-  const name = displayName.value.trim();
+  const name = (typeof displayName.value === "string"
+    ? displayName.value
+    : "").trim();
   if (!name) return "";
   const parts = name.split(" ");
   if (parts.length >= 2) {

--- a/test/active-chat-header.alias.spec.ts
+++ b/test/active-chat-header.alias.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import { createTestingPinia } from "@pinia/testing";
+import { useMessengerStore } from "src/stores/messenger";
+import { useNostrStore } from "src/stores/nostr";
+
+describe("ActiveChatHeader", () => {
+  it("ignores non-string aliases", async () => {
+    const ActiveChatHeader = (await import("src/components/ActiveChatHeader.vue")).default;
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    const messenger = useMessengerStore();
+    messenger.aliases["pk"] = {} as any;
+    const nostr = useNostrStore();
+    nostr.getProfile = vi.fn().mockResolvedValue(null);
+    nostr.resolvePubkey = vi.fn().mockReturnValue("pk");
+    const wrapper = shallowMount(ActiveChatHeader, {
+      props: { pubkey: "pk", relays: [] },
+      global: { plugins: [pinia] },
+    });
+    expect(wrapper.find(".text-h6").text()).not.toBe("[object Object]");
+  });
+});


### PR DESCRIPTION
## Summary
- ensure alias is string in `ActiveChatHeader` display name
- safely coerce display name when computing initials
- add test guarding against non-string aliases

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm vitest run test/active-chat-header.alias.spec.ts`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b67ea91494833085254a1f0347be2f