### PR TITLE
feat: allow silent tier definition fetch

### DIFF
--- a/src/components/ProfileInfoDialog.vue
+++ b/src/components/ProfileInfoDialog.vue
@@ -79,7 +79,7 @@ async function load() {
   following.value = await nostr.fetchFollowingCount(props.pubkey);
   joined.value = await nostr.fetchJoinDate(props.pubkey);
   recentPost.value = await nostr.fetchMostRecentPost(props.pubkey);
-  await creators.fetchTierDefinitions(props.pubkey);
+  await creators.fetchTierDefinitions(props.pubkey, true);
   tiers.value = creators.tiersMap[props.pubkey] || [];
 }
 

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -238,7 +238,7 @@ async function onMessage(ev: MessageEvent) {
     tierTimeout = setTimeout(() => {
       loadingTiers.value = false;
     }, 5000);
-    await creators.fetchTierDefinitions(ev.data.pubkey);
+    await creators.fetchTierDefinitions(ev.data.pubkey, true);
     dialogPubkey.value = ev.data.pubkey; // keep hex
     try {
       const profile = await fetchNutzapProfile(ev.data.pubkey);
@@ -309,7 +309,7 @@ function retryFetchTiers() {
   tierTimeout = setTimeout(() => {
     loadingTiers.value = false;
   }, 5000);
-  creators.fetchTierDefinitions(dialogPubkey.value);
+  creators.fetchTierDefinitions(dialogPubkey.value, true);
 }
 
 function confirmSubscribe({ bucketId, periods, amount, startDate, total }: any) {

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -166,7 +166,7 @@ export default defineComponent({
     const fetchTiers = async () => {
       loadingTiers.value = true;
       try {
-        await creators.fetchTierDefinitions(creatorHex);
+        await creators.fetchTierDefinitions(creatorHex, true);
       } finally {
         loadingTiers.value = false;
       }

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -163,7 +163,7 @@ export const useCreatorsStore = defineStore("creators", {
       }
     },
 
-    async fetchTierDefinitions(creatorNpub: string) {
+    async fetchTierDefinitions(creatorNpub: string, silent = false) {
       this.tierFetchError = false;
 
       let hex = creatorNpub;
@@ -224,7 +224,7 @@ export const useCreatorsStore = defineStore("creators", {
         const indexerUrl = settings.tiersIndexerUrl;
         if (!indexerUrl) {
           this.tierFetchError = true;
-          notifyWarning("Unable to retrieve subscription tiers");
+          if (!silent) notifyWarning("Unable to retrieve subscription tiers");
           return;
         }
         const url = String(indexerUrl).includes("{pubkey}")
@@ -239,7 +239,7 @@ export const useCreatorsStore = defineStore("creators", {
           clearTimeout(id);
           if (!resp.ok) {
             this.tierFetchError = true;
-            notifyWarning("Unable to retrieve subscription tiers");
+            if (!silent) notifyWarning("Unable to retrieve subscription tiers");
             return;
           }
           const data = await resp.json();
@@ -257,7 +257,7 @@ export const useCreatorsStore = defineStore("creators", {
               : null);
           if (!event) {
             this.tierFetchError = true;
-            notifyWarning("Unable to retrieve subscription tiers");
+            if (!silent) notifyWarning("Unable to retrieve subscription tiers");
             return;
           }
           const tiersArray: Tier[] = JSON.parse(event.content).map(
@@ -279,7 +279,7 @@ export const useCreatorsStore = defineStore("creators", {
         } catch (e) {
           console.error("Indexer tier fetch error:", e);
           this.tierFetchError = true;
-          notifyWarning("Unable to retrieve subscription tiers");
+          if (!silent) notifyWarning("Unable to retrieve subscription tiers");
         }
       };
 

--- a/test/profile-info-dialog.spec.ts
+++ b/test/profile-info-dialog.spec.ts
@@ -56,18 +56,18 @@ describe("ProfileInfoDialog", () => {
     await wrapper.setProps({ modelValue: true });
     await flushPromises();
     expect(fetchTiers).toHaveBeenCalledTimes(1);
-    expect(fetchTiers).toHaveBeenCalledWith("pk2");
+    expect(fetchTiers).toHaveBeenCalledWith("pk2", true);
   });
 
   it("reloads when pubkey changes while open", async () => {
     const wrapper = mountDialog({ modelValue: true, pubkey: "pk1" });
     await flushPromises();
     expect(fetchTiers).toHaveBeenCalledTimes(1);
-    expect(fetchTiers).toHaveBeenCalledWith("pk1");
+    expect(fetchTiers).toHaveBeenCalledWith("pk1", true);
 
     await wrapper.setProps({ pubkey: "pk2" });
     await flushPromises();
     expect(fetchTiers).toHaveBeenCalledTimes(2);
-    expect(fetchTiers).toHaveBeenLastCalledWith("pk2");
+    expect(fetchTiers).toHaveBeenLastCalledWith("pk2", true);
   });
 });


### PR DESCRIPTION
## Summary
- add optional `silent` flag to `fetchTierDefinitions` and only warn when false
- suppress tier warning toasts when calling `fetchTierDefinitions` from UI prefetches
- adjust ProfileInfoDialog tests for new signature

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b68d89c77c833093a1236f3237b977