### PR TITLE
Fix creator profile save workflow

### DIFF
--- a/src/components/CreatorProfileForm.vue
+++ b/src/components/CreatorProfileForm.vue
@@ -42,6 +42,7 @@
         fill-input
         input-debounce="0"
         :label="$t('creatorHub.p2pkPublicKey')"
+        :rules="[(v) => !!v || t('creatorHub.required')]"
       >
         <template #append>
           <q-btn flat dense icon="add" @click="generateP2PK" />
@@ -101,7 +102,7 @@
       dense
       outlined
       persistent-hint
-      :rules="[urlListRule]"
+      :rules="[urlListRule, (val) => val.length > 0 || t('creatorHub.required')]"
       :hint="$t('creatorHub.urlListHint')"
     >
       <template #label>

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -44,7 +44,10 @@
     >
       <CreatorProfileForm />
       <div class="text-center q-mt-md">
-        <q-btn color="primary" :disable="!isDirty" @click="saveProfile"
+        <q-btn
+          color="primary"
+          :disable="!isDirty || !profilePub || !profileRelays.length"
+          @click="saveProfile"
           >Save Changes</q-btn
         >
       </div>

--- a/src/stores/creatorProfile.ts
+++ b/src/stores/creatorProfile.ts
@@ -22,15 +22,33 @@ function snapshot(p: CreatorProfile) {
 }
 
 export const useCreatorProfileStore = defineStore("creatorProfile", {
-  state: () => ({
-    display_name: useLocalStorage<string>("creatorProfile.display_name", ""),
-    picture: useLocalStorage<string>("creatorProfile.picture", ""),
-    about: useLocalStorage<string>("creatorProfile.about", ""),
-    pubkey: useLocalStorage<string>("creatorProfile.pubkey", ""),
-    mints: useLocalStorage<string>("creatorProfile.mints", ""),
-    relays: useLocalStorage<string[]>("creatorProfile.relays", []),
-    _clean: "",
-  }),
+  state: () => {
+    const display_name = useLocalStorage<string>(
+      "creatorProfile.display_name",
+      "",
+    );
+    const picture = useLocalStorage<string>("creatorProfile.picture", "");
+    const about = useLocalStorage<string>("creatorProfile.about", "");
+    const pubkey = useLocalStorage<string>("creatorProfile.pubkey", "");
+    const mints = useLocalStorage<string>("creatorProfile.mints", "");
+    const relays = useLocalStorage<string[]>("creatorProfile.relays", []);
+    return {
+      display_name,
+      picture,
+      about,
+      pubkey,
+      mints,
+      relays,
+      _clean: snapshot({
+        display_name: display_name.value,
+        picture: picture.value,
+        about: about.value,
+        pubkey: pubkey.value,
+        mints: mints.value,
+        relays: relays.value,
+      } as CreatorProfile),
+    };
+  },
   getters: {
     profile(state): { display_name: string; picture: string; about: string } {
       return {

--- a/test/vitest/__tests__/myProfileSave.spec.ts
+++ b/test/vitest/__tests__/myProfileSave.spec.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCreatorProfileStore } from "../../../src/stores/creatorProfile";
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+vi.mock("quasar", () => ({
+  useQuasar: () => ({ dark: { isActive: false } }),
+}));
+vi.mock("src/composables/useClipboard", () => ({
+  useClipboard: () => ({ copy: vi.fn() }),
+}));
+vi.mock("src/utils/profileUrl", () => ({ buildProfileUrl: vi.fn() }));
+vi.mock("vue-i18n", () => ({ useI18n: () => ({ t: (s: string) => s }) }));
+
+const publishDiscoveryProfile = vi.hoisted(() => vi.fn());
+const nostrStore = vi.hoisted(() => ({
+  hasIdentity: true,
+  getProfile: vi.fn(async () => null),
+  initSignerIfNotSet: vi.fn(),
+  signer: {},
+}));
+vi.mock("../../../src/stores/nostr", () => ({
+  useNostrStore: () => nostrStore,
+  publishDiscoveryProfile,
+}));
+vi.mock("../../../src/stores/creatorHub", () => ({
+  useCreatorHubStore: () => ({ getTierArray: () => [] }),
+}));
+vi.mock("../../../src/stores/p2pk", () => ({
+  useP2PKStore: () => ({
+    showP2PKDialog: false,
+    p2pkKeys: [],
+    createAndSelectNewKey: vi.fn(),
+    showLastKey: vi.fn(),
+    showKeyDetails: vi.fn(),
+  }),
+}));
+vi.mock("../../../src/stores/price", () => ({
+  usePriceStore: () => ({ bitcoinPrice: null }),
+}));
+vi.mock("../../../src/stores/ui", () => ({
+  useUiStore: () => ({ formatCurrency: vi.fn(() => "") }),
+}));
+vi.mock("../../../src/stores/mints", () => ({
+  useMintsStore: () => ({ activeBalance: 0, activeUnit: "SATS" }),
+}));
+vi.mock("../../../src/stores/buckets", () => ({
+  useBucketsStore: () => ({ bucketList: [] }),
+}));
+vi.mock("src/utils/safe-markdown", () => ({ renderMarkdownSafe: (s: string) => s }));
+const notifySuccess = vi.hoisted(() => vi.fn());
+const notifyError = vi.hoisted(() => vi.fn());
+vi.mock("src/js/notify", () => ({ notifySuccess, notifyError }));
+vi.mock("src/js/string-utils", () => ({ shortenString: (s: string) => s }));
+vi.mock("../../../src/components/CreatorProfileForm.vue", () => ({ default: {} }));
+vi.mock("../../../src/components/P2PKDialog.vue", () => ({ default: {} }));
+vi.mock("src/utils/sanitize-url", () => ({ isTrustedUrl: () => true }));
+
+import MyProfilePage from "../../../src/pages/MyProfilePage.vue";
+
+describe("MyProfilePage saveProfile", () => {
+  beforeEach(() => {
+    publishDiscoveryProfile.mockClear();
+    notifySuccess.mockClear();
+    notifyError.mockClear();
+    localStorage.clear();
+  });
+
+  it("publishes profile and resets dirty flag", async () => {
+    const store = useCreatorProfileStore();
+    store.setProfile({
+      display_name: "name",
+      picture: "",
+      about: "",
+      pubkey: "pub", 
+      mints: "",
+      relays: ["wss://relay"],
+    });
+    store.markClean();
+    store.display_name = "changed";
+    expect(store.isDirty).toBe(true);
+
+    const { saveProfile } = (MyProfilePage as any).setup();
+    await saveProfile();
+
+    expect(publishDiscoveryProfile).toHaveBeenCalledWith({
+      profile: { display_name: "changed", picture: "", about: "" },
+      p2pkPub: "pub",
+      mints: [],
+      relays: ["wss://relay"],
+    });
+    expect(notifySuccess).toHaveBeenCalled();
+    expect(store.isDirty).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- initialize creator profile store's clean snapshot on load
- disable save button when profile is incomplete and require P2PK key/relay in form
- add test covering profile save workflow

## Testing
- `corepack pnpm lint`
- `corepack pnpm test`
- `corepack pnpm exec vitest run test/vitest/__tests__/myProfileSave.spec.ts`
- `corepack pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b6978275cc83308b4120976c39b58e