### PR TITLE
Polish creator hub publish bar with inline confirmation

### DIFF
--- a/src/components/PublishBar.vue
+++ b/src/components/PublishBar.vue
@@ -1,20 +1,57 @@
 <template>
-  <q-footer class="w-full bg-grey-3 dark:bg-grey-9 text-dark dark:text-white">
-    <q-toolbar class="justify-center">
-      <q-btn
-        color="primary"
-        outline
-        :loading="publishing"
-        :disable="publishing"
-        @click="emit('publish')"
-      >
-        {{ $t("creatorHub.publish") }}
-      </q-btn>
-    </q-toolbar>
-  </q-footer>
+  <q-page-sticky position="bottom-right" :offset="[16, 16]" v-if="show">
+    <q-banner class="bg-surface-2 text-1 shadow-4 flex items-center rounded">
+      <template v-if="!published">
+        <span class="q-mr-md">Unsaved changes</span>
+        <q-btn
+          class="q-ml-auto"
+          color="primary"
+          :loading="publishing"
+          :disable="publishing"
+          @click="emit('publish')"
+        >
+          {{ $t("creatorHub.publish") }}
+        </q-btn>
+      </template>
+      <template v-else>
+        <q-icon name="check" color="positive" class="q-mr-sm" />
+        <span>Published!</span>
+      </template>
+    </q-banner>
+  </q-page-sticky>
 </template>
 
 <script setup lang="ts">
-const { publishing } = defineProps<{ publishing: boolean }>();
-const emit = defineEmits(["publish"]);
+import { ref, watch, onBeforeUnmount } from "vue";
+
+const props = defineProps<{ publishing: boolean; published: boolean }>();
+const emit = defineEmits(["publish", "clear"]);
+
+const show = ref(true);
+let timer: number | undefined;
+
+watch(
+  () => props.published,
+  (val) => {
+    if (val) {
+      show.value = true;
+      timer = window.setTimeout(() => {
+        show.value = false;
+        emit("clear");
+      }, 2000);
+    } else {
+      show.value = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    }
+  },
+  { immediate: true },
+);
+
+onBeforeUnmount(() => {
+  if (timer) clearTimeout(timer);
+});
 </script>
+

--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -12,7 +12,9 @@
     <PublishBar
       v-if="loggedIn && showPublishBar"
       :publishing="publishing"
+      :published="publishSuccess"
       @publish="publishFullProfile"
+      @clear="clearPublishSuccess"
     />
   </q-layout>
 </template>
@@ -38,9 +40,15 @@ export default defineComponent({
     PublishBar,
   },
   setup() {
-    const { loggedIn, publishFullProfile, publishing } = useCreatorHub();
+    const { loggedIn, publishFullProfile, publishing, isDirty, publishSuccess } =
+      useCreatorHub();
     const route = useRoute();
-    const showPublishBar = computed(() => route.path === "/creator-hub");
+    const showPublishBar = computed(
+      () => route.path === "/creator-hub" && (isDirty.value || publishSuccess.value),
+    );
+    function clearPublishSuccess() {
+      publishSuccess.value = false;
+    }
 
     const $q = useQuasar();
     const ui = useUiStore();
@@ -56,6 +64,8 @@ export default defineComponent({
       loggedIn,
       publishFullProfile,
       publishing,
+      publishSuccess,
+      clearPublishSuccess,
       showPublishBar,
       navStyleVars,
       route,

--- a/test/vitest/__tests__/creatorHub-layout.spec.ts
+++ b/test/vitest/__tests__/creatorHub-layout.spec.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi } from "vitest";
 import { shallowMount } from "@vue/test-utils";
-import * as quasar from "quasar";
 
-vi.spyOn(quasar, "useQuasar").mockReturnValue({
-  screen: { lt: { md: false } },
+vi.mock("quasar", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useQuasar: () => ({ screen: { lt: { md: false } } }),
+  };
 });
+
+let currentRoute = { path: "/creator-hub", meta: {} };
+vi.mock("vue-router", () => ({
+  useRoute: () => currentRoute,
+}));
 
 const creatorHubStoreMock = {
   tiers: {},
@@ -32,6 +40,7 @@ const nostrStoreMock = {
   relays: [] as string[],
   connected: true,
   lastError: null,
+  hasIdentity: true,
 };
 
 vi.mock("../../../src/stores/nostr", async (importOriginal) => {
@@ -62,6 +71,7 @@ const profileStoreMock = {
   relays: [] as string[],
   setProfile: vi.fn(),
   markClean: vi.fn(),
+  isDirty: true,
 };
 
 vi.mock("../../../src/stores/creatorProfile", () => ({
@@ -91,19 +101,39 @@ import CreatorHubPage from "../../../src/pages/CreatorHubPage.vue";
 import FullscreenLayout from "../../../src/layouts/FullscreenLayout.vue";
 
 describe("CreatorHubPage layout", () => {
-  it("renders PublishBar only on creator hub page", () => {
-    const wrapper = shallowMount(FullscreenLayout, {
+  it("renders PublishBar only when profile is dirty on creator hub page", () => {
+    profileStoreMock.isDirty = true;
+    currentRoute.path = "/creator-hub";
+    const wrapperDirty = shallowMount(FullscreenLayout, {
       global: {
-        stubs: { "router-view": CreatorHubPage },
-        mocks: { $route: { path: "/creator-hub" } },
+        stubs: {
+          "router-view": CreatorHubPage,
+          "q-layout": { template: "<div><slot /></div>" },
+        },
       },
     });
-    expect(wrapper.find("publish-bar-stub").exists()).toBe(true);
+    expect(wrapperDirty.find("publish-bar-stub").exists()).toBe(true);
 
+    profileStoreMock.isDirty = false;
+    currentRoute.path = "/creator-hub";
+    const wrapperClean = shallowMount(FullscreenLayout, {
+      global: {
+        stubs: {
+          "router-view": CreatorHubPage,
+          "q-layout": { template: "<div><slot /></div>" },
+        },
+      },
+    });
+    expect(wrapperClean.find("publish-bar-stub").exists()).toBe(false);
+
+    profileStoreMock.isDirty = true;
+    currentRoute.path = "/wallet";
     const wrapperOther = shallowMount(FullscreenLayout, {
       global: {
-        stubs: { "router-view": CreatorHubPage },
-        mocks: { $route: { path: "/wallet" } },
+        stubs: {
+          "router-view": CreatorHubPage,
+          "q-layout": { template: "<div><slot /></div>" },
+        },
       },
     });
     expect(wrapperOther.find("publish-bar-stub").exists()).toBe(false);


### PR DESCRIPTION
## Summary
- restyle publish bar as bottom-right banner with theme tokens
- add publishSuccess flag and inline confirmation after publishing
- show publish bar only for dirty profiles and add tests

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm exec vitest run test/vitest/__tests__/creatorHub-layout.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b6a5411c688330a7a3c15700dccad0