### PR TITLE
Reset tier defaults when props change

### DIFF
--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -218,11 +218,20 @@ export default defineComponent({
     watch(
       () => props.tier,
       (val) => {
+        Object.assign(
+          localTier,
+          {
+            media: [],
+            frequency: "monthly" as SubscriptionFrequency,
+            intervalDays: 30,
+          },
+        );
         Object.assign(localTier, val);
-        if (!val.media) {
+        if (!val?.id && "id" in localTier) delete (localTier as any).id;
+        if (!localTier.media) {
           localTier.media = [];
         }
-        if (!val.frequency) {
+        if (!localTier.frequency) {
           localTier.frequency = "monthly";
         }
         localTier.intervalDays = frequencyToDays(


### PR DESCRIPTION
## Summary
- Reset AddTierDialog defaults when tier props change
- Strip stale `id` when new tier lacks one

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6b31f54208330b714c3e2c732890f