### PR TITLE
feat: emit save after tier publish

### DIFF
--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -283,6 +283,7 @@ export default defineComponent({
         });
         await creatorHub.publishTierDefinitions();
         notifySuccess("Tier saved & published");
+        emit("save");
         emit("update:modelValue", false);
       } catch (e: any) {
         notifyError(e.message);


### PR DESCRIPTION
## Summary
- emit `save` from AddTierDialog after publishing tiers
- confirm CreatorHubPage listens for `@save` to refresh tiers

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6b6e457c883309265d24d53b5d6ef