### PR TITLE
Improve tier publishing reliability and UX

### DIFF
--- a/src/components/TierItem.vue
+++ b/src/components/TierItem.vue
@@ -1,7 +1,7 @@
 <template>
   <TierCard
     :tier="tierData"
-    @edit="emit('save')"
+    @edit="emit('edit')"
     @delete="emit('delete')"
     @update:tier="emit('update:tierData', $event)"
   />
@@ -12,7 +12,7 @@ import TierCard from "./TierCard.vue";
 import type { Tier } from "stores/types";
 
 const props = defineProps<{ tierData: Tier }>();
-const emit = defineEmits(["save", "delete", "update:tierData"]);
+const emit = defineEmits(["edit", "delete", "update:tierData"]);
 </script>
 
 <style scoped></style>

--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -214,14 +214,24 @@ export function useCreatorHub() {
     await nostr.connect(filteredRelays);
     publishing.value = true;
     try {
+      try {
+        await store.publishTierDefinitions();
+      } catch (e: any) {
+        notifyError(
+          e?.message ||
+            "Failed to publish tier definitions. Please check relay connectivity and try again.",
+        );
+        publishing.value = false;
+        return false;
+      }
       const timeoutMs = 30000;
       await Promise.race([
-          publishDiscoveryProfile({
-            profile: profile.value,
-            p2pkPub: profilePub.value,
-            mints: profileMints.value ? [profileMints.value] : [],
-            relays: filteredRelays,
-          }),
+        publishDiscoveryProfile({
+          profile: profile.value,
+          p2pkPub: profilePub.value,
+          mints: profileMints.value ? [profileMints.value] : [],
+          relays: filteredRelays,
+        }),
         new Promise((_, reject) =>
           setTimeout(() => reject(new PublishTimeoutError()), timeoutMs),
         ),


### PR DESCRIPTION
## Summary
- close tier dialog on successful publish with progress/disabled state
- fall back to default relays when publishing tiers fails
- publish tiers during full profile publish and fix tier edit event

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: ERR_PNPM_FETCH_403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b736d961d48330a0d25543c5af3762