### PR TITLE
feat: auto-publish tier order changes

### DIFF
--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -279,8 +279,17 @@ export function useCreatorHub() {
     deleteDialog.value = true;
   }
 
-  function updateOrder() {
+  async function updateOrder() {
     store.setTierOrder(draggableTiers.value.map((t) => t.id));
+    publishing.value = true;
+    try {
+      await store.publishTierDefinitions();
+      notifySuccess("Tier order updated");
+    } catch (e: any) {
+      notifyError(e?.message || "Failed to update tier order");
+    } finally {
+      publishing.value = false;
+    }
   }
 
   function refreshTiers() {


### PR DESCRIPTION
## Summary
- publish tier definition order immediately when dragging tiers
- show success or error notifications for tier order updates

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b73ff39ab08330aecb036329336e9a