### PR TITLE
Improve Creator Hub drag interactions

### DIFF
--- a/src/components/TiersPanel.vue
+++ b/src/components/TiersPanel.vue
@@ -5,6 +5,9 @@
       v-model="draggableTiers"
       item-key="id"
       handle=".drag-handle"
+      ghost-class="drag-ghost"
+      animation="200"
+      swap-threshold="0.65"
       class="space-y-4"
       @end="updateOrder"
     >

--- a/src/css/creator-hub.scss
+++ b/src/css/creator-hub.scss
@@ -6,6 +6,30 @@
   border-radius: 8px;
 }
 
+:deep(.drag-handle) {
+  cursor: grab;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+:deep(.drag-handle:hover) {
+  background-color: var(--accent-200);
+}
+
+:deep(.drag-handle:active) {
+  cursor: grabbing;
+  background-color: var(--accent-600);
+  color: var(--text-inverse);
+}
+
+:deep(.drag-ghost) {
+  opacity: 0.5;
+}
+
 /* Dark slate gradient backgrounds */
 .gradient-dark-slate {
   background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -62,6 +62,9 @@
                   v-model="draggableTiers"
                   item-key="id"
                   handle=".drag-handle"
+                  ghost-class="drag-ghost"
+                  animation="200"
+                  swap-threshold="0.65"
                   @end="updateOrder"
                 >
                   <template #item="{ element }">
@@ -100,6 +103,9 @@
                     v-model="draggableTiers"
                     item-key="id"
                     handle=".drag-handle"
+                    ghost-class="drag-ghost"
+                    animation="200"
+                    swap-threshold="0.65"
                     @end="updateOrder"
                   >
                     <template #item="{ element }">


### PR DESCRIPTION
## Summary
- Smooth drag & drop on creator tiers with ghost preview, animation and swap threshold
- Enlarge drag handle hit area with hover and active feedback

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` *(fails: GET https://registry.npmjs.org/@quasar%2Fcli: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7415e4fa08330bd9759fd74afd00d