### PR TITLE
feat: reinforce Creator Hub relay handling

### DIFF
--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -177,6 +177,7 @@
 <script lang="ts">
 import { defineComponent, computed, reactive, watch, ref } from "vue";
 import { useCreatorHubStore } from "stores/creatorHub";
+import { RelayConnectionError } from "stores/nostr";
 import type { Tier } from "stores/types";
 import { notifySuccess, notifyError } from "src/js/notify";
 import { useNostrStore } from "stores/nostr";
@@ -302,10 +303,16 @@ export default defineComponent({
         emit("update:modelValue", false);
         notifySuccess("✅ Tier published to Nostr relays");
       } catch (e: any) {
-        notifyError(
-          e?.message ||
-            "Unable to publish to relays. Check signer/relays and try again.",
-        );
+        if (e instanceof RelayConnectionError) {
+          notifyError(
+            "Tier saved locally. Unable to reach relays – will retry automatically.",
+          );
+        } else {
+          notifyError(
+            e?.message ||
+              "Unable to publish to relays. Check signer/relays and try again.",
+          );
+        }
       } finally {
         saving.value = false;
       }

--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -116,6 +116,7 @@ export function useCreatorHub() {
   const currentTier = ref<Partial<Tier>>({});
   const publishing = ref(false);
   const publishSuccess = ref(false);
+  const { publishRetryPending } = storeToRefs(store);
   const npub = computed(() =>
     nostr.pubkey ? nip19.npubEncode(nostr.pubkey) : "",
   );
@@ -342,6 +343,8 @@ export function useCreatorHub() {
     refreshTiers,
     removeTier,
     performDelete,
+    publishRetryPending,
+    retryPublishNow: () => store.retryPublishNow(),
     scanForMints,
     scanningMints,
   };

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -20,8 +20,34 @@ import type { Tier, TierMedia } from "./types";
 import { frequencyToDays } from "src/constants/subscriptionFrequency";
 import { DEFAULT_RELAYS } from "src/config/relays";
 import { useSettingsStore } from "./settings";
+import { filterHealthyRelays } from "src/utils/relayHealth";
 
 const TIER_DEFINITIONS_KIND = 30000;
+
+let publishRetryTimer: ReturnType<typeof setTimeout> | null = null;
+let publishRetryDelay = 2000;
+
+function schedulePublishRetry(store: any) {
+  if (publishRetryTimer) return;
+  const delay = publishRetryDelay;
+  publishRetryDelay = Math.min(publishRetryDelay * 2, 60_000);
+  publishRetryTimer = setTimeout(async () => {
+    publishRetryTimer = null;
+    try {
+      await store.publishTierDefinitions();
+      store.publishRetryPending = false;
+      publishRetryDelay = 2000;
+    } catch (e: any) {
+      if (e instanceof RelayConnectionError) {
+        schedulePublishRetry(store);
+      } else {
+        notifyError(e?.message ?? String(e));
+        store.publishRetryPending = false;
+        publishRetryDelay = 2000;
+      }
+    }
+  }, delay);
+}
 
 export async function maybeRepublishNutzapProfile() {
   const nostrStore = useNostrStore();
@@ -39,13 +65,35 @@ export async function maybeRepublishNutzapProfile() {
   }
   let current = null;
   try {
+    await ensureRelayConnectivity(ndk);
     current = await fetchNutzapProfile(nostrStore.pubkey);
   } catch (e: any) {
     if (e instanceof RelayConnectionError) {
-      notifyError("Unable to connect to Nostr relays");
-      return;
+      const settings = useSettingsStore();
+      const candidates = settings.defaultNostrRelays?.length
+        ? settings.defaultNostrRelays
+        : DEFAULT_RELAYS;
+      const healthy = await filterHealthyRelays(candidates).catch(() => []);
+      if (healthy.length) {
+        try {
+          await nostrStore.ensureNdkConnected(healthy as any);
+          await ensureRelayConnectivity(ndk);
+          current = await fetchNutzapProfile(nostrStore.pubkey);
+        } catch (err) {
+          notifyError(
+            `Unable to connect to Nostr relays: ${healthy.join(", ")}. Update your relay settings and try again.`,
+          );
+          return;
+        }
+      } else {
+        notifyError(
+          `Unable to connect to Nostr relays: attempted ${candidates.join(", ")}. Update your relay settings and try again.`,
+        );
+        return;
+      }
+    } else {
+      throw e;
     }
-    throw e;
   }
   const profileStore = useCreatorProfileStore();
   const desiredMint = profileStore.mints;
@@ -83,7 +131,7 @@ export const useCreatorHubStore = defineStore("creatorHub", {
         }
       },
     );
-    return { tiers, tierOrder };
+    return { tiers, tierOrder, publishRetryPending: false };
   },
   actions: {
     async login(nsec?: string) {
@@ -248,36 +296,62 @@ export const useCreatorHubStore = defineStore("creatorHub", {
       }
 
       await nostr.ensureNdkConnected();
-      try {
-        await ensureRelayConnectivity(ndk);
-      } catch (err) {
-        const defaults =
-          useSettingsStore().defaultNostrRelays || DEFAULT_RELAYS || [];
-        if (!defaults.length) throw err;
-        await nostr.ensureNdkConnected(defaults as any);
-        await ensureRelayConnectivity(ndk);
-      }
 
-      const ev = new NDKEvent(ndk);
-      ev.kind = TIER_DEFINITIONS_KIND as unknown as NDKKind;
-      ev.tags = [["d", "tiers"]];
-      ev.created_at = Math.floor(Date.now() / 1000);
-      ev.content = JSON.stringify(tiersArray);
-      await ev.sign(nostr.signer as any);
       try {
-        await ev.publish();
+        try {
+          await ensureRelayConnectivity(ndk);
+        } catch (err) {
+          const defaults =
+            useSettingsStore().defaultNostrRelays || DEFAULT_RELAYS || [];
+          if (!defaults.length) throw err;
+          await nostr.ensureNdkConnected(defaults as any);
+          await ensureRelayConnectivity(ndk);
+        }
+
+        const ev = new NDKEvent(ndk);
+        ev.kind = TIER_DEFINITIONS_KIND as unknown as NDKKind;
+        ev.tags = [["d", "tiers"]];
+        ev.created_at = Math.floor(Date.now() / 1000);
+        ev.content = JSON.stringify(tiersArray);
+        await ev.sign(nostr.signer as any);
+        try {
+          await ev.publish();
+        } catch (e: any) {
+          notifyError(e?.message ?? String(e));
+          throw e;
+        }
+
+        await db.creatorsTierDefinitions.put({
+          creatorNpub: nostr.pubkey,
+          tiers: tiersArray as any,
+          eventId: ev.id!,
+          updatedAt: ev.created_at!,
+          rawEventJson: JSON.stringify(ev.rawEvent()),
+        });
+
+        if (publishRetryTimer) {
+          clearTimeout(publishRetryTimer);
+          publishRetryTimer = null;
+        }
+        this.publishRetryPending = false;
+        publishRetryDelay = 2000;
       } catch (e: any) {
-        notifyError(e?.message ?? String(e));
+        if (e instanceof RelayConnectionError) {
+          this.publishRetryPending = true;
+          schedulePublishRetry(this);
+        }
         throw e;
       }
-
-      await db.creatorsTierDefinitions.put({
-        creatorNpub: nostr.pubkey,
-        tiers: tiersArray as any,
-        eventId: ev.id!,
-        updatedAt: ev.created_at!,
-        rawEventJson: JSON.stringify(ev.rawEvent()),
-      });
+    },
+    retryPublishNow() {
+      if (publishRetryTimer) {
+        clearTimeout(publishRetryTimer);
+        publishRetryTimer = null;
+      }
+      publishRetryDelay = 2000;
+      if (this.publishRetryPending) {
+        schedulePublishRetry(this);
+      }
     },
     setTierOrder(order: string[]) {
       this.tierOrder = [...order];


### PR DESCRIPTION
## Summary
- add default relay fallback and automatic retry for Nutzap profile publishing
- surface relay connectivity and queued tier publishes in Creator Hub UI
- queue tier definition publishes and allow manual retry when offline

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7458fe5d08330bc1033aec9e38f16