### PR TITLE
feat: add relay manager with relay health stats

### DIFF
--- a/src/services/relayManager.ts
+++ b/src/services/relayManager.ts
@@ -1,0 +1,253 @@
+import { filterHealthyRelays } from "src/utils/relayHealth";
+import { useNdk } from "src/composables/useNdk";
+import { useSettingsStore } from "src/stores/settings";
+import { cashuDb, type RelayStat } from "src/stores/dexie";
+import { notifyError, notifySuccess } from "src/js/notify";
+import {
+  NDKEvent,
+  NDKPublishError,
+  NDKRelay,
+  NDKRelaySet,
+} from "@nostr-dev-kit/ndk";
+import { SimplePool, Event as NostrEvent } from "nostr-tools";
+
+export class PublishTimeoutError extends Error {
+  constructor(message = "Publish timed out") {
+    super(message);
+    this.name = "PublishTimeoutError";
+  }
+}
+
+class RelayManager {
+  private failureCounts = new Map<string, number>();
+  private rotationIndex = 0;
+  private loaded = false;
+
+  private async ensureLoaded() {
+    if (this.loaded) return;
+    const stats = await cashuDb.relayStats.toArray();
+    stats.forEach((s) => this.failureCounts.set(s.url, s.failureCount));
+    this.loaded = true;
+  }
+
+  private async recordResult(url: string, success: boolean) {
+    const now = Date.now();
+    const existing = await cashuDb.relayStats.get(url);
+    const updated: RelayStat = {
+      url,
+      successCount: (existing?.successCount ?? 0) + (success ? 1 : 0),
+      failureCount: (existing?.failureCount ?? 0) + (success ? 0 : 1),
+      lastSuccess: success ? now : existing?.lastSuccess,
+      lastFailure: !success ? now : existing?.lastFailure,
+    };
+    await cashuDb.relayStats.put(updated);
+    this.failureCounts.set(url, updated.failureCount);
+  }
+
+  async resetRelaySelection() {
+    this.failureCounts.clear();
+    this.rotationIndex = 0;
+    this.loaded = false;
+    await cashuDb.relayStats.clear();
+  }
+
+  async selectPreferredRelays(relays: string[]): Promise<string[]> {
+    await this.ensureLoaded();
+    const relayUrls = relays
+      .filter((r) => r.startsWith("wss://"))
+      .map((r) => r.replace(/\/+$/, ""));
+    const candidates = relayUrls.filter(
+      (r) => (this.failureCounts.get(r) ?? 0) < 3,
+    );
+    let healthy: string[] = [];
+    try {
+      healthy = await filterHealthyRelays(candidates);
+    } catch {
+      healthy = [];
+    }
+    const healthySet = new Set(healthy);
+    for (const url of candidates) {
+      if (healthySet.has(url)) {
+        this.failureCounts.delete(url);
+      } else {
+        const count = (this.failureCounts.get(url) ?? 0) + 1;
+        this.failureCounts.set(url, count);
+      }
+    }
+    if (healthy.length === 0) return [];
+    const start = this.rotationIndex % healthy.length;
+    this.rotationIndex = (this.rotationIndex + 1) % healthy.length;
+    return healthy.slice(start).concat(healthy.slice(0, start));
+  }
+
+  private async urlsToRelaySet(
+    urls?: string[],
+  ): Promise<NDKRelaySet | undefined> {
+    if (!urls?.length) return undefined;
+    const ndk = await useNdk({ requireSigner: false });
+    const set = new NDKRelaySet(new Set(), ndk);
+    urls.forEach((u) =>
+      set.addRelay(
+        ndk.pool.getRelay(u) ?? new NDKRelay(u, undefined as any, ndk as any),
+      ),
+    );
+    return set;
+  }
+
+  async publishWithTimeout(
+    ev: NDKEvent,
+    relays?: NDKRelaySet,
+    timeoutMs = 30000,
+  ): Promise<void> {
+    const urls = relays?.relayUrls ?? [];
+    try {
+      await Promise.race([
+        ev.publish(relays),
+        new Promise<void>((_, reject) =>
+          setTimeout(() => reject(new PublishTimeoutError()), timeoutMs),
+        ),
+      ]);
+      await Promise.all(urls.map((u) => this.recordResult(u, true)));
+    } catch (e) {
+      await Promise.all(urls.map((u) => this.recordResult(u, false)));
+      throw e;
+    }
+  }
+
+  async publishDmNip04(
+    ev: NDKEvent,
+    relays: string[],
+    timeoutMs = 30000,
+  ): Promise<boolean> {
+    const relaySet = await this.urlsToRelaySet(relays);
+    if (!relaySet) return false;
+    try {
+      await this.publishWithTimeout(ev, relaySet, timeoutMs);
+      notifySuccess("NIP-04 event published");
+      return true;
+    } catch (e) {
+      console.error(e);
+      if (e instanceof NDKPublishError) {
+        const urls = relaySet.relayUrls?.join(", ") || relays.join(", ");
+        notifyError(`Could not publish NIP-04 event to: ${urls}`);
+      } else if (e instanceof PublishTimeoutError) {
+        notifyError(
+          "Publishing NIP-04 event timed out. Check your network connection or relay availability.",
+        );
+      } else {
+        notifyError("Could not publish NIP-04 event");
+      }
+      await Promise.all(relays.map((u) => this.recordResult(u, false)));
+      return false;
+    }
+  }
+
+  async publishWithAcks(
+    event: NostrEvent,
+    relays: string[],
+    timeoutMs = 5000,
+  ): Promise<Record<string, RelayAck>> {
+    const pool = new SimplePool();
+    const results: Record<string, RelayAck> = {};
+    const pub = pool.publish(relays, event as any);
+    return await new Promise((resolve) => {
+      const recordPromises: Promise<void>[] = [];
+      const timer = setTimeout(() => {
+        for (const r of relays) {
+          if (!results[r]) {
+            results[r] = { ok: false, reason: "timeout" };
+            recordPromises.push(this.recordResult(r, false));
+          }
+        }
+        Promise.all(recordPromises).then(() => resolve(results));
+      }, timeoutMs);
+
+      const finish = () => {
+      if (Object.keys(results).length >= relays.length) {
+          clearTimeout(timer);
+          Promise.all(recordPromises).then(() => resolve(results));
+        }
+      };
+
+      pub.on("ok", (relay: any) => {
+        const url = relay.url || relay;
+        results[url] = { ok: true };
+        recordPromises.push(this.recordResult(url, true));
+        finish();
+      });
+
+      pub.on("failed", (relay: any, reason: any) => {
+        const url = relay.url || relay;
+        results[url] = { ok: false, reason };
+        recordPromises.push(this.recordResult(url, false));
+        finish();
+      });
+    });
+  }
+
+  async publishEvent(event: NostrEvent, relays?: string[]): Promise<void> {
+    const relayUrls = (
+      relays ?? useSettingsStore().defaultNostrRelays
+    )
+      .filter((r: string) => r.startsWith("wss://"))
+      .map((r: string) => r.replace(/\/+$/, ""));
+    const healthyRelays = await this.selectPreferredRelays(relayUrls);
+    if (healthyRelays.length === 0) {
+      console.error("[nostr] publish failed: all relays unreachable");
+      return;
+    }
+    const pool = new SimplePool();
+    try {
+      await Promise.any(pool.publish(healthyRelays, event as any));
+      await Promise.all(healthyRelays.map((u) => this.recordResult(u, true)));
+    } catch (e) {
+      await Promise.all(healthyRelays.map((u) => this.recordResult(u, false)));
+      console.error("Failed to publish event", e);
+    }
+  }
+
+  async subscribeToNostr(
+    filter: any,
+    cb: (ev: NostrEvent) => void,
+    relays?: string[],
+  ): Promise<boolean> {
+    const relayUrls = (
+      relays && relays.length > 0
+        ? relays
+        : useSettingsStore().defaultNostrRelays
+    )
+      .filter((r: string) => r.startsWith("wss://"))
+      .map((r: string) => r.replace(/\/+$/, ""));
+    if (!relayUrls.length) {
+      console.warn("[nostr] subscribeMany called with empty relay list");
+      return false;
+    }
+    const healthy = await this.selectPreferredRelays(relayUrls);
+    if (healthy.length === 0) {
+      console.error("[nostr] subscription failed: all relays unreachable");
+      return false;
+    }
+    const pool = new SimplePool();
+    try {
+      pool.subscribeMany(healthy, [filter], { onevent: cb });
+      await Promise.all(healthy.map((u) => this.recordResult(u, true)));
+      return true;
+    } catch (e) {
+      await Promise.all(healthy.map((u) => this.recordResult(u, false)));
+      console.error("Failed to subscribe", e);
+      return false;
+    }
+  }
+}
+
+export const relayManager = new RelayManager();
+
+export const selectPreferredRelays = relayManager.selectPreferredRelays.bind(relayManager);
+export const resetRelaySelection = relayManager.resetRelaySelection.bind(relayManager);
+export const publishWithTimeout = relayManager.publishWithTimeout.bind(relayManager);
+export const publishDmNip04 = relayManager.publishDmNip04.bind(relayManager);
+export const publishWithAcks = relayManager.publishWithAcks.bind(relayManager);
+export const publishEvent = relayManager.publishEvent.bind(relayManager);
+export const subscribeToNostr = relayManager.subscribeToNostr.bind(relayManager);
+
+export type RelayAck = { ok: boolean; reason?: string };

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -102,6 +102,14 @@ export interface SubscriberViewPref {
   activeViewId: string | null;
 }
 
+export interface RelayStat {
+  url: string;
+  successCount: number;
+  failureCount: number;
+  lastSuccess?: number;
+  lastFailure?: number;
+}
+
 // export interface Proof {
 //   id: string
 //   C: string
@@ -119,6 +127,7 @@ export class CashuDexie extends Dexie {
   lockedTokens!: Table<LockedToken, string>;
   subscriberViews!: Table<SubscriberView, string>;
   subscriberViewPrefs!: Table<SubscriberViewPref, string>;
+  relayStats!: Table<RelayStat, string>;
 
   constructor() {
     super("cashuDatabase");
@@ -588,6 +597,20 @@ export class CashuDexie extends Dexie {
         "&id, tokenString, owner, tierId, intervalKey, unlockTs, status, subscriptionEventId, subscriptionId, monthIndex, totalPeriods, autoRedeem, frequency, intervalDays",
       subscriberViews: "&name",
       subscriberViewPrefs: "&id",
+    });
+
+    this.version(24).stores({
+      proofs:
+        "secret, id, C, amount, reserved, quote, bucketId, label, description",
+      profiles: "pubkey",
+      creatorsTierDefinitions: "&creatorNpub, eventId, updatedAt",
+      subscriptions:
+        "&id, creatorNpub, tierId, status, createdAt, updatedAt, frequency, intervalDays",
+      lockedTokens:
+        "&id, tokenString, owner, tierId, intervalKey, unlockTs, status, subscriptionEventId, subscriptionId, monthIndex, totalPeriods, autoRedeem, frequency, intervalDays",
+      subscriberViews: "&name",
+      subscriberViewPrefs: "&id",
+      relayStats: "&url, successCount, failureCount, lastSuccess, lastFailure",
     });
   }
 }

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -14,12 +14,10 @@ import NDK, {
   NDKTag,
   ProfilePointer,
   NDKSubscription,
-  NDKPublishError,
 } from "@nostr-dev-kit/ndk";
 import {
   nip19,
   nip04,
-  SimplePool,
   getEventHash as ntGetEventHash,
   finalizeEvent,
   verifyEvent,
@@ -40,8 +38,30 @@ import {
   Token,
 } from "@cashu/cashu-ts";
 import { useTokensStore } from "./tokens";
-import { filterHealthyRelays } from "src/utils/relayHealth";
 import { DEFAULT_RELAYS, FREE_RELAYS } from "src/config/relays";
+import {
+  selectPreferredRelays,
+  publishDmNip04,
+  publishWithTimeout,
+  publishWithAcks,
+  publishEvent,
+  subscribeToNostr,
+  resetRelaySelection,
+  PublishTimeoutError,
+  type RelayAck,
+} from "src/services/relayManager";
+
+export {
+  selectPreferredRelays,
+  publishDmNip04,
+  publishWithTimeout,
+  publishWithAcks,
+  publishEvent,
+  subscribeToNostr,
+  resetRelaySelection,
+  PublishTimeoutError,
+  type RelayAck,
+};
 import {
   notifyApiError,
   notifyError,
@@ -279,135 +299,6 @@ function connectWithTimeout(relay: any, ms = 6000): Promise<void> {
   });
 }
 
-export class PublishTimeoutError extends Error {
-  constructor(message = "Publish timed out") {
-    super(message);
-    this.name = "PublishTimeoutError";
-  }
-}
-
-export async function publishWithTimeout(
-  ev: NDKEvent,
-  relays?: NDKRelaySet,
-  timeoutMs = 30000,
-): Promise<void> {
-  await Promise.race([
-    ev.publish(relays),
-    new Promise<void>((_, reject) =>
-      setTimeout(() => reject(new PublishTimeoutError()), timeoutMs),
-    ),
-  ]);
-}
-
-const relayFailureCounts = new Map<string, number>();
-let relayRotationIndex = 0;
-const MAX_FAILURES = 3;
-
-export function resetRelaySelection() {
-  relayFailureCounts.clear();
-  relayRotationIndex = 0;
-}
-
-export async function selectPreferredRelays(
-  relays: string[],
-): Promise<string[]> {
-  const relayUrls = relays
-    .filter((r) => r.startsWith("wss://"))
-    .map((r) => r.replace(/\/+$/, ""));
-
-  const candidates = relayUrls.filter(
-    (r) => (relayFailureCounts.get(r) ?? 0) < MAX_FAILURES,
-  );
-
-  let healthy: string[] = [];
-  try {
-    healthy = await filterHealthyRelays(candidates);
-  } catch {
-    healthy = [];
-  }
-
-  const healthySet = new Set(healthy);
-  for (const url of candidates) {
-    if (healthySet.has(url)) {
-      relayFailureCounts.delete(url);
-    } else {
-      const count = (relayFailureCounts.get(url) ?? 0) + 1;
-      relayFailureCounts.set(url, count);
-    }
-  }
-
-  if (healthy.length === 0) return [];
-
-  const start = relayRotationIndex % healthy.length;
-  relayRotationIndex = (relayRotationIndex + 1) % healthy.length;
-  return healthy.slice(start).concat(healthy.slice(0, start));
-}
-
-export async function publishDmNip04(
-  ev: NDKEvent,
-  relays: string[],
-  timeoutMs = 30000,
-): Promise<boolean> {
-  const relaySet = await urlsToRelaySet(relays);
-  if (!relaySet) return false;
-  try {
-    await publishWithTimeout(ev, relaySet, timeoutMs);
-    notifySuccess("NIP-04 event published");
-    return true;
-  } catch (e) {
-    console.error(e);
-    if (e instanceof NDKPublishError) {
-      const urls = relaySet.relayUrls?.join(", ") || relays.join(", ");
-      notifyError(`Could not publish NIP-04 event to: ${urls}`);
-    } else if (e instanceof PublishTimeoutError) {
-      notifyError(
-        "Publishing NIP-04 event timed out. Check your network connection or relay availability.",
-      );
-    } else {
-      notifyError("Could not publish NIP-04 event");
-    }
-    return false;
-  }
-}
-
-export type RelayAck = { ok: boolean; reason?: string };
-
-export async function publishWithAcks(
-  event: NostrEvent,
-  relays: string[],
-  timeoutMs = 5000,
-): Promise<Record<string, RelayAck>> {
-  const pool = new SimplePool();
-  const results: Record<string, RelayAck> = {};
-  const pub = pool.publish(relays, event as any);
-  return await new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      for (const r of relays) {
-        if (!results[r]) results[r] = { ok: false, reason: "timeout" };
-      }
-      resolve(results);
-    }, timeoutMs);
-
-    const finish = () => {
-      if (Object.keys(results).length >= relays.length) {
-        clearTimeout(timer);
-        resolve(results);
-      }
-    };
-
-    pub.on("ok", (relay: any) => {
-      const url = relay.url || relay;
-      results[url] = { ok: true };
-      finish();
-    });
-
-    pub.on("failed", (relay: any, reason: any) => {
-      const url = relay.url || relay;
-      results[url] = { ok: false, reason: String(reason) };
-      finish();
-    });
-  });
-}
 
 /** Resolves once any relay in `ndk.pool` has `connected === true`. */
 export function ensureRelayConnectivity(ndk: NDK): Promise<void> {
@@ -2048,61 +1939,3 @@ export async function signEvent(
   }
 }
 
-export async function publishEvent(event: NostrEvent): Promise<void> {
-  const relayUrls = useSettingsStore()
-    .defaultNostrRelays.filter((r) => r.startsWith("wss://"))
-    .map((r) => r.replace(/\/+$/, ""));
-  let healthyRelays: string[] = [];
-  try {
-    healthyRelays = await filterHealthyRelays(relayUrls);
-  } catch {
-    healthyRelays = [];
-  }
-  if (healthyRelays.length === 0) {
-    console.error("[nostr] publish failed: all relays unreachable");
-    return;
-  }
-  const pool = new SimplePool();
-  try {
-    await Promise.any(pool.publish(healthyRelays, event as any));
-  } catch (e) {
-    console.error("Failed to publish event", e);
-  }
-}
-
-export async function subscribeToNostr(
-  filter: any,
-  cb: (ev: NostrEvent) => void,
-  relays?: string[],
-): Promise<boolean> {
-  const relayUrls = (
-    relays && relays.length > 0 ? relays : useSettingsStore().defaultNostrRelays
-  )
-    .filter((r) => r.startsWith("wss://"))
-    .map((r) => r.replace(/\/+$/, ""));
-  if (!relayUrls || relayUrls.length === 0) {
-    console.warn("[nostr] subscribeMany called with empty relay list");
-    return false;
-  }
-
-  // Ensure at least one relay is reachable before subscribing
-  let healthy: string[] = [];
-  try {
-    healthy = await filterHealthyRelays(relayUrls);
-  } catch {
-    healthy = [];
-  }
-  if (healthy.length === 0) {
-    console.error("[nostr] subscription failed: all relays unreachable");
-    return false;
-  }
-
-  const pool = new SimplePool();
-  try {
-    pool.subscribeMany(healthy, [filter], { onevent: cb });
-    return true;
-  } catch (e) {
-    console.error("Failed to subscribe", e);
-    return false;
-  }
-}

--- a/test/vitest/__tests__/relaySelection.spec.ts
+++ b/test/vitest/__tests__/relaySelection.spec.ts
@@ -5,8 +5,8 @@ import * as relayHealth from "../../../src/utils/relayHealth";
 const filterHealthyRelaysMock = vi.spyOn(relayHealth, "filterHealthyRelays");
 
 describe("selectPreferredRelays", () => {
-  beforeEach(() => {
-    resetRelaySelection();
+  beforeEach(async () => {
+    await resetRelaySelection();
     filterHealthyRelaysMock.mockReset();
   });
 


### PR DESCRIPTION
## Summary
- add relayManager service for relay selection and publish/query logic with IndexedDB-backed health tracking
- persist relay health metrics in new `relayStats` table
- delegate nostr store publish helpers to relayManager service

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm exec vitest run test/vitest/__tests__/relaySelection.spec.ts test/vitest/__tests__/nostr.spec.ts test/vitest/__tests__/creators-tiers.spec.ts` *(fails: Failed to resolve import "@noble/ciphers/aes.js" from "src/stores/nostr.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68b7de5b80708330ba2ee9365317dea3