### PR TITLE
feat: add publish timeout for tier definitions

### DIFF
--- a/test/vitest/__tests__/creatorHub.spec.ts
+++ b/test/vitest/__tests__/creatorHub.spec.ts
@@ -133,6 +133,7 @@ describe("publishTierDefinitions", () => {
       },
     } as any;
     store.tierOrder = ["t1"];
+    useCreatorProfileStore().relays = ["wss://relay" as any];
 
     const res = await store.publishTierDefinitions();
     expect(res).toBe(true);


### PR DESCRIPTION
## Summary
- ensure tier publishing checks for signer and relays
- wrap publishing in timeout with relay connectivity verification
- log relay URLs on success and warn/notify on failure

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b856a140648330a49fcc023ca01fd8