### PR TITLE
feat: sanitize tier inputs before saving

### DIFF
--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -242,11 +242,16 @@ export default defineComponent({
     );
 
     const save = async () => {
-      if (!localTier.name || !localTier.name.trim()) {
+      localTier.name = (localTier.name || "").trim();
+      localTier.description = (localTier.description || "")
+        .trim()
+        .slice(0, 2000);
+
+      if (!localTier.name) {
         notifyError("Tier name is required");
         return;
       }
-      if (!localTier.description || !localTier.description.trim()) {
+      if (!localTier.description) {
         notifyError("Description is required");
         return;
       }
@@ -265,9 +270,7 @@ export default defineComponent({
           );
           return;
         }
-        if (localTier.media) {
-          localTier.media = filterValidMedia(localTier.media);
-        }
+        localTier.media = filterValidMedia(localTier.media);
         await creatorHub.addOrUpdateTier({
           ...localTier,
           media: localTier.media,


### PR DESCRIPTION
## Summary
- trim tier name and description before saving and cap description length
- filter out empty or invalid media URLs when saving tiers

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm dlx @quasar/cli build -m spa` (fails: ERR_PNPM_FETCH_403 GET https://registry.npmjs.org/@quasar%2Fcli)

------
https://chatgpt.com/codex/tasks/task_e_68b85b6df7588330ba7620dfe6b0d21a