### PR TITLE
Handle publish timeout separately in creator hub

### DIFF
--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -250,7 +250,13 @@ export function useCreatorHub() {
       notifySuccess("Profile and tiers published!");
       return true;
     } catch (e: any) {
-      notifyError("Failed to publish. Check relay connections.");
+      if (e instanceof PublishTimeoutError) {
+        notifyError(
+          "Publishing timed out. Check relay connectivity and try again.",
+        );
+      } else {
+        notifyError("Failed to publish. Check relay connections.");
+      }
       return false;
     } finally {
       publishing.value = false;


### PR DESCRIPTION
## Summary
- Show specific timeout message when publishing creator profiles times out
- Preserve generic error message for other publish failures

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b85c452c1c83309518bb42ea05db0e