### PR TITLE
chore: log tier and profile publish

### DIFF
--- a/src/components/ProfilePanel.vue
+++ b/src/components/ProfilePanel.vue
@@ -60,7 +60,7 @@ async function publishProfile() {
   }
   publishing.value = true;
   try {
-    await publishDiscoveryProfile({
+    const ids = await publishDiscoveryProfile({
       profile: {
         display_name: display_name.value,
         picture: picture.value,
@@ -68,6 +68,10 @@ async function publishProfile() {
       },
       p2pkPub: profilePub.value || "",
       mints: profileMints.value ? [profileMints.value] : [],
+      relays: profileRelays.value,
+    });
+    console.debug('Profile publish ok', {
+      id: ids,
       relays: profileRelays.value,
     });
     notifySuccess("Profile updated");
@@ -78,6 +82,7 @@ async function publishProfile() {
     } else {
       notifyError(e?.message || "Failed to publish profile");
     }
+    console.warn('Profile publish failed', e);
   } finally {
     publishing.value = false;
   }

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -317,21 +317,21 @@ export const useCreatorHubStore = defineStore("creatorHub", {
       try {
         await ensureRelayConnectivity(ndk);
         await publishWithTimeout(ev, undefined, 30000);
+        console.debug('Tier publish ok', {
+          id: ev.id,
+          kind: ev.kind,
+          relays: ndk.pool.connectedRelays(),
+        });
       } catch (e: any) {
         if (e instanceof PublishTimeoutError) {
           notifyError('Publishing tier definitions timed out');
         } else {
           notifyError(e?.message || 'Failed to publish tier definitions');
         }
-        console.warn('Failed to publish tier definitions', e);
+        console.warn('Tier publish failed', e);
         revertStatuses();
         return false;
       }
-
-      const connectedRelays = Array.from(ndk.pool.relays.values())
-        .filter((r: any) => r.connected)
-        .map((r: any) => r.url);
-      console.debug('Published tier definitions', ev.id, ev.kind, connectedRelays);
 
       await db.creatorsTierDefinitions.put({
         creatorNpub: nostr.pubkey,


### PR DESCRIPTION
## Summary
- log tier publish relay and ids on success and warn on failure
- add profile publish debug and warn logs

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85d55a0f483309bd0003db282d53c