### PR TITLE
Use open fallback relays for tier publishing

### DIFF
--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -1,10 +1,14 @@
+// Curated public write relays used ONLY as fallback when user relays don't ACK.
+// Keep this list short to reduce latency and avoid closed/paid/whitelisted relays.
 export const FREE_RELAYS = [
-  "wss://purplepag.es",
-  "wss://relay.damus.io",
-  "wss://relay.primal.net",
-  "wss://relay.nostr.band",
-  "wss://relay.snort.social",
-  "wss://nos.lol",
+  "wss://nostr.fmt.wiz.biz",
+  "wss://nostr.oxtr.dev",
+  "wss://nostr.mom",
+  "wss://no.str.cr",
+  "wss://relay.nostr.bg",
+  "wss://offchain.pub",
+  "wss://relay.plebstr.com",
+  "wss://nostr.zebedee.cloud",
 ];
 
 // This list should only contain relays that are known to be reliable and fast.


### PR DESCRIPTION
## Summary
- replace FREE_RELAYS with a curated set of public write relays
- ensure tier publishing always includes the curated fallback set and proceeds even when user relays are empty

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88af40c6c8330a17d8b6c8936eb95