### PR TITLE
feat: allow multiple trusted mints

### DIFF
--- a/src/components/CreatorProfileForm.vue
+++ b/src/components/CreatorProfileForm.vue
@@ -70,13 +70,16 @@
     </div>
     <q-select
       v-model="profileMintsLocal"
+      multiple
       use-input
+      use-chips
       hide-dropdown-icon
+      new-value-mode="add-unique"
       :options="mintOptions"
       dense
       outlined
       persistent-hint
-      :rules="[urlRule]"
+      :rules="[mintUrlListRule]"
       :hint="$t('creatorHub.urlListHint')"
       :label="$t('creatorHub.trustedMints')"
     />
@@ -177,7 +180,7 @@ const profilePubLocal = computed({
 });
 const profileMintsLocal = computed({
   get: () => profileMints.value,
-  set: (val: string) => (profileMints.value = val),
+  set: (val: string[]) => (profileMints.value = val),
 });
 const profileRelaysLocal = computed({
   get: () => profileRelays.value,
@@ -189,4 +192,6 @@ const urlRule = (val: string) =>
   /^https?:\/\/.+/.test(val) || t("creatorHub.invalidUrl");
 const urlListRule = (val: string[]) =>
   val.every((u) => /^wss?:\/\//.test(u)) || t("creatorHub.invalidUrl");
+const mintUrlListRule = (val: string[]) =>
+  val.every((u) => /^https?:\/\//.test(u)) || t("creatorHub.invalidUrl");
 </script>

--- a/src/components/ProfilePanel.vue
+++ b/src/components/ProfilePanel.vue
@@ -67,7 +67,7 @@ async function publishProfile() {
         about: about.value,
       },
       p2pkPub: profilePub.value || "",
-      mints: profileMints.value ? [profileMints.value] : [],
+      mints: profileMints.value,
       relays: profileRelays.value,
     });
     console.debug('Profile publish ok', {

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -2066,7 +2066,7 @@ export default defineComponent({
             about: profileStore.about,
           },
           p2pkPub: this.firstKey.publicKey,
-          mints: profileStore.mints ? [profileStore.mints] : [],
+          mints: profileStore.mints,
           relays: profileStore.relays,
         });
         notifySuccess("Profile published");

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -247,8 +247,8 @@ export default defineComponent({
         profileStore.setProfile(p);
         profileStore.markClean();
       }
-      if (profileStore.mints) {
-        profileMints.value = profileStore.mints;
+      if (profileStore.mints.length) {
+        profileMints.value = [...profileStore.mints];
       }
       if (profileStore.relays.length) {
         profileRelays.value = [...profileStore.relays];
@@ -291,7 +291,7 @@ export default defineComponent({
         await publishDiscoveryProfile({
           profile: profileData.value,
           p2pkPub: profilePub.value,
-          mints: profileMints.value ? [profileMints.value] : [],
+          mints: profileMints.value,
           relays: profileRelays.value,
         });
         profile.value = { ...profileData.value };

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -53,21 +53,22 @@ export async function maybeRepublishNutzapProfile() {
     throw e;
   }
   const profileStore = useCreatorProfileStore();
-  const desiredMint = profileStore.mints;
+  const desiredMints = profileStore.mints;
   const desiredP2PK = useP2PKStore().firstKey?.publicKey;
 
   if (!desiredP2PK) return;
 
-  const currentMint = current?.trustedMints?.[0] || "";
+  const currentMints = current?.trustedMints || [];
   const hasDiff =
     !current ||
     current.p2pkPubkey !== desiredP2PK ||
-    currentMint !== desiredMint;
+    JSON.stringify([...currentMints].sort()) !==
+      JSON.stringify([...desiredMints].sort());
 
   if (hasDiff) {
     await publishNutzapProfile({
       p2pkPub: desiredP2PK,
-      mints: desiredMint ? [desiredMint] : [],
+      mints: desiredMints,
       relays: [...profileStore.relays],
     });
   }
@@ -125,7 +126,7 @@ export const useCreatorHubStore = defineStore("creatorHub", {
         picture: "",
         about: "",
         pubkey: "",
-        mints: "",
+        mints: [],
         relays: [],
       });
       profileStore.markClean();

--- a/src/stores/creatorProfile.ts
+++ b/src/stores/creatorProfile.ts
@@ -6,7 +6,7 @@ export interface CreatorProfile {
   picture: string;
   about: string;
   pubkey: string;
-  mints: string;
+  mints: string[];
   relays: string[];
 }
 
@@ -27,7 +27,7 @@ export const useCreatorProfileStore = defineStore("creatorProfile", {
     picture: useLocalStorage<string>("creatorProfile.picture", ""),
     about: useLocalStorage<string>("creatorProfile.about", ""),
     pubkey: useLocalStorage<string>("creatorProfile.pubkey", ""),
-    mints: useLocalStorage<string>("creatorProfile.mints", ""),
+    mints: useLocalStorage<string[]>("creatorProfile.mints", []),
     relays: useLocalStorage<string[]>("creatorProfile.relays", []),
     _clean: "",
   }),
@@ -50,7 +50,7 @@ export const useCreatorProfileStore = defineStore("creatorProfile", {
       if (data.picture !== undefined) this.picture = data.picture;
       if (data.about !== undefined) this.about = data.about;
       if (data.pubkey !== undefined) this.pubkey = data.pubkey;
-      if (data.mints !== undefined) this.mints = data.mints;
+      if (data.mints !== undefined) this.mints = [...data.mints];
       if (data.relays !== undefined) this.relays = [...data.relays];
     },
     markClean() {

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -358,8 +358,8 @@ export const useMintsStore = defineStore("mints", {
           await notifySuccess(this.t("wallet.mint.notifications.added"));
         }
         const profileStore = useCreatorProfileStore();
-        if (!profileStore.mints) {
-          profileStore.mints = url;
+        if (!profileStore.mints.length) {
+          profileStore.mints = [url];
         }
         await maybeRepublishNutzapProfile();
         return mintToAdd;
@@ -563,9 +563,7 @@ export const useMintsStore = defineStore("mints", {
         await this.activateMint(this.mints[0], false);
       }
       const profileStore = useCreatorProfileStore();
-      if (profileStore.mints === url) {
-        profileStore.mints = "";
-      }
+      profileStore.mints = profileStore.mints.filter((m) => m !== url);
       notifySuccess(this.t("wallet.mint.notifications.removed"));
     },
     assertMintError: function (response: { error?: any }, verbose = true) {

--- a/test/vitest/__tests__/creatorHub-layout.spec.ts
+++ b/test/vitest/__tests__/creatorHub-layout.spec.ts
@@ -58,7 +58,7 @@ const profileStoreMock = {
   picture: "",
   about: "",
   pubkey: "",
-  mints: "",
+  mints: [] as string[],
   relays: [] as string[],
   setProfile: vi.fn(),
   markClean: vi.fn(),

--- a/test/vitest/__tests__/creatorHub.spec.ts
+++ b/test/vitest/__tests__/creatorHub.spec.ts
@@ -169,7 +169,7 @@ describe("maybeRepublishNutzapProfile", () => {
     const mints = useMintsStore();
     mints.mints = [{ url: "mint1" }, { url: "mint2" }] as any;
     const profileStore = useCreatorProfileStore();
-    profileStore.mints = "mint1";
+    profileStore.mints = ["mint1"];
 
     fetchNutzapProfileMock = vi.fn(async () => ({
       p2pkPubkey: "other",

--- a/test/vitest/__tests__/creatorProfileStore.spec.ts
+++ b/test/vitest/__tests__/creatorProfileStore.spec.ts
@@ -13,7 +13,7 @@ describe("CreatorProfileStore isDirty", () => {
       picture: "pic",
       about: "about",
       pubkey: "pub",
-      mints: "m1",
+      mints: ["m1"],
       relays: ["r1"],
     });
     store.markClean();
@@ -35,7 +35,7 @@ describe("CreatorProfileStore isDirty", () => {
     expect(store.isDirty).toBe(true);
     store.markClean();
 
-    store.mints = "m2";
+    store.mints = ["m2"];
     expect(store.isDirty).toBe(true);
     store.markClean();
 


### PR DESCRIPTION
## Summary
- support multiple mint URLs in CreatorProfile store and form
- merge mint recommendations and handle arrays throughout creator hub
- republish nutzap profiles when any mint changes

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Rollup failed to resolve import "@noble/ciphers/aes.js" from src/stores/nostr.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b8999f3a808330b7ac7786d24c7555