### PR TITLE
fix: refresh ndk cache and creator hub connection

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -50,8 +50,7 @@ import {
   notifyWarning,
   notify,
 } from "src/js/notify";
-import { useNdk } from "src/composables/useNdk";
-import { rebuildNdk } from "boot/ndk";
+import { useNdk, rebuildNdk } from "src/composables/useNdk";
 import { useSendTokensStore } from "./sendTokensStore";
 import { usePRStore } from "./payment-request";
 import token from "../js/token";
@@ -1050,6 +1049,8 @@ export const useNostrStore = defineStore("nostr", {
           }
         }),
       );
+
+      return ndk;
     },
     ensureNdkConnected: async function (relays?: string[]) {
       const ndk = await useNdk();


### PR DESCRIPTION
## Summary
- rebuild nostr NDK using composable so global cache updates and return new instance
- refresh Creator Hub's NDK reference after reconnects and add init/reconnect flow
- verify NDK connection before publishing creator profiles

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b971b5c3508330a2259ee8efbf489e