### PR TITLE
Handle legacy profile storage and tolerate relay failures

### DIFF
--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -29,6 +29,30 @@
           <q-btn flat label="Check Settings" @click="goToSettings" />
         </template>
       </q-banner>
+      <q-banner
+        v-if="publishFailures.length"
+        class="text-white bg-orange"
+      >
+        <div>
+          Profile published, but these relays failed:
+          <ul class="q-pl-md">
+            <li
+              v-for="r in publishFailures"
+              :key="r"
+              style="word-break: break-all"
+            >
+              {{ r }}
+            </li>
+          </ul>
+        </div>
+        <template #action>
+          <q-btn
+            flat
+            label="Retry without failed relays"
+            @click="retryWithoutFailedRelays"
+          />
+        </template>
+      </q-banner>
       <div class="row items-center justify-between q-mb-lg">
         <div class="text-h5">Creator Hub</div>
         <div class="row items-center q-gutter-sm">
@@ -206,9 +230,11 @@ const {
   publishing,
   isDirty,
   publishFullProfile,
+  retryWithoutFailedRelays,
   connectedCount,
   totalRelays,
   failedRelays,
+  publishFailures,
   profileRelays,
   nostr,
 } = useCreatorHub();

--- a/src/utils/safeLocalStorage.ts
+++ b/src/utils/safeLocalStorage.ts
@@ -6,8 +6,10 @@ export function safeUseLocalStorage<T>(key: string, defaultValue: T) {
     try {
       JSON.parse(raw);
     } catch (e) {
-      console.warn(`Invalid JSON for ${key}, resetting`, e);
-      localStorage.removeItem(key);
+      // Legacy values may be stored as plain strings. Wrap them in JSON so
+      // they can be read on the next access instead of dropping the data.
+      console.warn(`Invalid JSON for ${key}, migrating to JSON`, e);
+      localStorage.setItem(key, JSON.stringify(raw));
     }
   }
   const serializer = {


### PR DESCRIPTION
## Summary
- migrate non-JSON `creatorProfile` localStorage entries instead of clearing them
- allow `publishDiscoveryProfile` to succeed after first relay ack and report failed relays
- surface failed relay list in Creator Hub UI with retry helper

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Rollup could not resolve import "@noble/ciphers/aes.js")*


------
https://chatgpt.com/codex/tasks/task_e_68b98569d6c48330b29bf87908b566f5