### PR TITLE
fix: stabilize creator hub relay connections

### DIFF
--- a/src/components/CreatorProfileForm.vue
+++ b/src/components/CreatorProfileForm.vue
@@ -54,16 +54,18 @@
           </q-item>
         </template>
       </q-select>
-      <div v-else class="row items-center q-gutter-sm">
-        <div class="text-caption">{{ $t("creatorHub.noP2pkPublicKey") }}</div>
-        <q-btn
-          flat
-          dense
-          color="primary"
-          :label="$t('creatorHub.generate')"
-          @click="generateP2PK"
-        />
-      </div>
+      <q-banner v-else class="bg-orange text-white">
+        {{ $t("creatorHub.noP2pkPublicKey") }}
+        <template #action>
+          <q-btn
+            flat
+            dense
+            color="white"
+            :label="$t('creatorHub.generate')"
+            @click="generateP2PK"
+          />
+        </template>
+      </q-banner>
       <div v-if="profilePubLocal" class="text-caption q-mt-xs">
         {{ selectedKeyShort }}
       </div>
@@ -185,7 +187,7 @@ const profileMintsLocal = computed({
 });
 const profileRelaysLocal = computed({
   get: () => profileRelays.value,
-  set: (val: string[]) => (profileRelays.value = sanitizeRelayUrls(val)),
+  set: (val: string[]) => (profileRelays.value = sanitizeRelayUrls(val).slice(0, 8)),
 });
 
 const validUrl = computed(() => /^https?:\/\/.+/.test(pictureLocal.value));


### PR DESCRIPTION
## Summary
- attach creator hub's NDK to the nostr signer and watch for signer changes
- relax relay connection gating and show connected/total counts
- filter and cap creator relays to healthy set; highlight missing P2PK key

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9dd605afc8330a9db90b6275a82c0