### PR TITLE
Load signer relays and keep Creator Hub connections in sync

### DIFF
--- a/src/components/RelayScannerDialog.vue
+++ b/src/components/RelayScannerDialog.vue
@@ -69,13 +69,16 @@ async function scan() {
       relays.value.map(async (r) => {
         try {
           await Promise.race([
-            new Promise<void>((resolve, reject) => {
+            new Promise<void>((resolve) => {
               const ws = new WebSocket(r.url);
               ws.onopen = () => {
                 ws.close();
                 resolve();
               };
-              ws.onerror = () => reject(new Error("error"));
+              ws.onerror = () => {
+                ws.close();
+                /* swallow error */
+              };
             }),
             new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 3000)),
           ]);

--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -249,6 +249,9 @@ export function useCreatorHub() {
   async function checkAndInit() {
     if (!nostr.hasIdentity) return;
     await initPage();
+    if (!profileRelays.value.length && nostr.relays.length) {
+      profileRelays.value = sanitizeRelayUrls(nostr.relays).slice(0, MAX_RELAYS);
+    }
     if (!profileRelays.value.length) return;
     await connectCreatorRelays(profileRelays.value);
   }

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -272,6 +272,19 @@ watch(
   },
 );
 
+watch(
+  profileRelays,
+  (urls) => {
+    if (!localNdk.value) return;
+    localNdk.value.explicitRelayUrls = urls;
+    localNdk.value.pool.relays.forEach((r) => {
+      if (!urls.includes(r.url)) r.disconnect();
+    });
+    localNdk.value.connect();
+  },
+  { immediate: true },
+);
+
 onUnmounted(() => {
   if (localNdk.value) {
     localNdk.value.pool.relays.forEach((r) => r.disconnect());

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -43,6 +43,7 @@ import {
 import { useTokensStore } from "./tokens";
 import { filterHealthyRelays } from "src/utils/relayHealth";
 import { DEFAULT_RELAYS, FREE_RELAYS } from "src/config/relays";
+import { sanitizeRelayUrls } from "src/utils/relay";
 import {
   notifyApiError,
   notifyError,
@@ -1335,6 +1336,16 @@ export const useNostrStore = defineStore("nostr", {
           this.signerType = SignerType.NIP07;
           this.setPubkey(user.pubkey);
           await this.setSigner(signer);
+
+          const relays = await signer.getRelays?.();
+          if (relays) {
+            const urls = sanitizeRelayUrls(Object.keys(relays));
+            if (urls.length) {
+              this.relays = urls;
+              const settings = useSettingsStore();
+              settings.defaultNostrRelays = urls;
+            }
+          }
         }
       } catch (e) {
         console.error("Failed to init NIP07 signer:", e);


### PR DESCRIPTION
## Summary
- pull relay URLs from NIP-07 signer and store them
- default Creator Hub relays from signer list when none configured
- keep local NDK connections in sync with relay list
- silence relay scanner WebSocket errors

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e42297008330a5a9f9535ba413a5