### PR TITLE
feat: improve relay handling and creator hub UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,18 +250,18 @@ returned.
 
 You can also override the relays used by the creator search. Set
 `cashu.settings.defaultNostrRelays` in local storage with an array of relay
-URLs. If not defined, the search falls back to the following list:
+URLs. If not defined, the search falls back to a short curated list defined in
+[`src/config/relays.ts`](src/config/relays.ts):
 
 ```
 wss://relay.damus.io/
-wss://relay.primal.net/
-wss://eden.nostr.land/
 wss://nos.lol/
-wss://nostr-pub.wellorder.net/
-wss://nostr.bitcoiner.social/
-wss://relay.nostr.band/
+wss://relay.primal.net/
 wss://relay.snort.social/
 ```
+
+You can edit that file to customise or extend the defaults for your own
+deployment.
 
 ### Sharing Creator Links
 

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -13,11 +13,9 @@ export const FREE_RELAYS = [
 
 // This list should only contain relays that are known to be reliable and fast.
 export const DEFAULT_RELAYS = [
-  "wss://purplepag.es",
   "wss://relay.damus.io",
-  "wss://relay.primal.net",
-  "wss://relay.nostr.band",
-  "wss://relay.snort.social",
   "wss://nos.lol",
+  "wss://relay.primal.net",
+  "wss://relay.snort.social",
 ];
 

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -108,6 +108,29 @@
             </template>
           </q-input>
         </div>
+        <div class="q-mb-md">
+          <div class="text-subtitle1 q-mb-sm">Relays</div>
+          <q-list bordered>
+            <q-item v-for="url in profileRelays" :key="url">
+              <q-item-section avatar>
+                <q-icon
+                  :name="failedRelays.includes(url) ? 'cloud_off' : 'cloud_done'"
+                  :color="failedRelays.includes(url) ? 'negative' : 'positive'"
+                />
+              </q-item-section>
+              <q-item-section>{{ url }}</q-item-section>
+              <q-item-section side>
+                <q-btn
+                  flat
+                  round
+                  dense
+                  icon="close"
+                  @click="removeRelay(url)"
+                />
+              </q-item-section>
+            </q-item>
+          </q-list>
+        </div>
         <q-splitter v-if="!isMobile" v-model="splitterModel">
           <template #before>
             <q-card class="section-card">
@@ -311,6 +334,14 @@ const failedRelays = computed(() => {
 
 function onRelaysSelected(urls: string[]) {
   profileRelays.value = urls.slice(0, 8);
+  if (localNdk.value) {
+    localNdk.value.explicitRelayUrls = profileRelays.value;
+    localNdk.value.connect();
+  }
+}
+
+function removeRelay(url: string) {
+  profileRelays.value = profileRelays.value.filter((r) => r !== url);
   if (localNdk.value) {
     localNdk.value.explicitRelayUrls = profileRelays.value;
     localNdk.value.connect();


### PR DESCRIPTION
## Summary
- throttle relay reconnects and abort publish when no relays reachable
- cache NIP-07 relay list and replace dead default relays
- show relay health in creator hub with option to remove

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e88393c08330a19ba8b8e3a49a7c