### PR TITLE
feat: bound relay writes and publish feedback

### DIFF
--- a/src/components/NostrRelayErrorBanner.vue
+++ b/src/components/NostrRelayErrorBanner.vue
@@ -1,15 +1,22 @@
 <template>
-  <q-banner v-if="nostr.connectionFailed" dense class="bg-red-2 q-mb-sm">
-    <div class="row items-center no-wrap">
-      <span>Unable to reach Nostr relays – retry</span>
-      <q-space />
-      <q-btn flat dense label="Reconnect" @click="nostr.connect()" />
+  <q-banner v-if="error" inline-actions dense class="bg-negative text-white">
+    <div class="text-body2">
+      {{ error.message }}
+      <div v-if="error.details" class="q-mt-xs">
+        Tried: {{ error.details.urlsTried?.length || 0 }},
+        Connected: {{ error.details.urlsConnected?.length || 0 }},
+        OK: {{ error.details.okOn?.length || 0 }},
+        Failed: {{ error.details.failedOn?.length || 0 }},
+        No ACK: {{ error.details.missingAcks?.length || 0 }}
+      </div>
     </div>
+    <template #action>
+      <q-btn flat dense label="Retry" @click="$emit('retry')" />
+    </template>
   </q-banner>
 </template>
 
-<script lang="ts" setup>
-import { useNostrStore } from "src/stores/nostr";
-
-const nostr = useNostrStore();
+<script setup lang="ts">
+defineProps<{ error?: { message: string; details?: any } }>();
+defineEmits<{ 'retry': [] }>();
 </script>

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -1,21 +1,27 @@
-// Curated public write relays used ONLY as fallback when user relays don't ACK.
-// Keep this list short to reduce latency and avoid closed/paid/whitelisted relays.
-export const FREE_RELAYS = [
-  "wss://nostr.fmt.wiz.biz",
-  "wss://nostr.oxtr.dev",
-  "wss://nostr.mom",
-  "wss://no.str.cr",
-  "wss://relay.nostr.bg",
-  "wss://offchain.pub",
-  "wss://relay.plebstr.com",
-  "wss://nostr.zebedee.cloud",
-];
-
-// This list should only contain relays that are known to be reliable and fast.
+// Curated default read relays – these are added at boot for read operations only.
 export const DEFAULT_RELAYS = [
   "wss://relay.damus.io",
-  "wss://nos.lol",
+  "wss://relay.snort.social",
   "wss://relay.primal.net",
+  "wss://nos.lol",
+];
+
+// Small set of known-open relays used as fallback for write operations.
+export const FREE_RELAYS = [
+  "wss://offchain.pub",
+  "wss://no.str.cr",
+  "wss://nostr.mom",
+  // Last resort large pools
+  "wss://relay.damus.io",
   "wss://relay.snort.social",
 ];
 
+// Optional: allow overrides via env (comma-separated)
+export function envRelayList(key: string, fallback: string[]): string[] {
+  const v = (import.meta as any).env?.[key];
+  if (!v) return fallback;
+  return v
+    .split(",")
+    .map((s: string) => s.trim())
+    .filter(Boolean);
+}

--- a/src/utils/relay.ts
+++ b/src/utils/relay.ts
@@ -1,10 +1,20 @@
-export function sanitizeRelayUrls(relays: string[]): string[] {
-  return Array.from(
-    new Set(
-      (Array.isArray(relays) ? relays : [])
-        .filter(Boolean)
-        .map((u) => String(u).trim().replace(/\/+$/, ""))
-        .filter((u) => u.startsWith("ws")),
-    ),
-  );
+export function sanitizeRelayUrls(relays: string[], cap = 10): string[] {
+  const cleaned: string[] = [];
+  for (const r of Array.isArray(relays) ? relays : []) {
+    if (!r) continue;
+    let url = String(r).trim();
+    if (!url) continue;
+    if (/^https?:\/\//i.test(url)) {
+      url = url.replace(/^https?/i, "wss");
+    } else if (/^ws:\/\//i.test(url)) {
+      url = url.replace(/^ws:/i, "wss:");
+    } else if (!/^wss?:\/\//i.test(url)) {
+      url = `wss://${url}`;
+    }
+    if (!url.startsWith("wss://")) continue;
+    url = url.replace(/\/+$/, "");
+    cleaned.push(url);
+    if (cleaned.length >= cap) break;
+  }
+  return Array.from(new Set(cleaned));
 }

--- a/src/utils/relayHealth.ts
+++ b/src/utils/relayHealth.ts
@@ -1,184 +1,39 @@
+import { getNdk } from "src/boot/ndk";
+import { sanitizeRelayUrls } from "./relay";
 import { FREE_RELAYS } from "src/config/relays";
 
-// keep track of relays that have already produced a constructor error so we only
-// emit a single console message per relay. This keeps startup logs readable when
-// many relays are unreachable.
-const reportedFailures = new Map<string, number>();
-const alreadyReported = new Set<string>();
-const handshakeWarned = new Set<string>();
-let aggregateTimer: ReturnType<typeof setTimeout> | null = null;
-let allFailedWarned = false;
-
 const CACHE_TTL_MS = 60_000;
-const pingCache = new Map<string, { ts: number; ok: boolean }>();
-const ls =
-  typeof localStorage !== "undefined" ? (localStorage as Storage) : null;
-const filterCache = new Map<string, { ts: number; res: string[] }>();
-
-function scheduleFailureLog() {
-  if (aggregateTimer) return;
-  aggregateTimer = setTimeout(() => {
-    const entries = Array.from(reportedFailures.entries());
-    reportedFailures.clear();
-    aggregateTimer = null;
-    if (!entries.length) return;
-    const summary = entries
-      .map(([u, c]) => (c > 1 ? `${u} (x${c})` : u))
-      .join(", ");
-    for (const [u] of entries) {
-      alreadyReported.add(u);
-    }
-    console.error(`WebSocket ping failed for: ${summary}`);
-  }, 0);
-}
-
-export async function pingRelay(url: string): Promise<boolean> {
-  const now = Date.now();
-  const cacheKey = `relayHealth.${url}`;
-  const cached = pingCache.get(url);
-  if (cached && now - cached.ts < CACHE_TTL_MS) return cached.ok;
-  if (ls) {
-    try {
-      const raw = ls.getItem(cacheKey);
-      if (raw) {
-        const data = JSON.parse(raw) as { ts: number; ok: boolean };
-        if (now - data.ts < CACHE_TTL_MS) {
-          pingCache.set(url, data);
-          return data.ok;
-        }
-      }
-    } catch {}
-  }
-  const attemptOnce = (useProtocol = false): Promise<boolean> =>
-    new Promise((resolve) => {
-      let settled = false;
-      let ws: WebSocket;
-      try {
-        ws = useProtocol ? new WebSocket(url, "nostr") : new WebSocket(url);
-      } catch {
-        resolve(false);
-        return;
-      }
-      const timer = setTimeout(() => {
-        if (!settled) {
-          settled = true;
-          if (ws.readyState === WebSocket.OPEN) {
-            try {
-              ws.close();
-            } catch {}
-          } else if (ws.readyState === WebSocket.CONNECTING) {
-            ws.onopen = () => {
-              try {
-                ws.close();
-              } catch {}
-            };
-          }
-          resolve(false);
-        }
-      }, 1000);
-      ws.onopen = () => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(timer);
-          ws.close();
-          resolve(true);
-        }
-      };
-      ws.onerror = () => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(timer);
-          try {
-            ws.close();
-          } catch {}
-          if (!useProtocol) {
-            if (!handshakeWarned.has(url)) {
-              console.warn(
-                `Relay handshake failed for: ${url} (retrying with \"nostr\" protocol)`,
-              );
-              handshakeWarned.add(url);
-            }
-            attemptOnce(true).then(resolve);
-          } else {
-            resolve(false);
-          }
-        }
-      };
-      ws.onmessage = (ev) => {
-        if (
-          !settled &&
-          typeof ev.data === "string" &&
-          ev.data.startsWith("restricted:")
-        ) {
-          settled = true;
-          clearTimeout(timer);
-          ws.close();
-          resolve(false);
-        }
-      };
-    });
-
-  const maxAttempts = 3;
-  let delay = 1000;
-  for (let i = 0; i < maxAttempts; i++) {
-    if (await attemptOnce()) {
-      const res = { ts: now, ok: true };
-      pingCache.set(url, res);
-      if (ls) {
-        try {
-          ls.setItem(cacheKey, JSON.stringify(res));
-        } catch {}
-      }
-      return true;
-    }
-    if (i < maxAttempts - 1) {
-      await new Promise((r) => setTimeout(r, delay));
-      delay = Math.min(delay * 2, 32000);
-    }
-  }
-
-  if (!alreadyReported.has(url)) {
-    reportedFailures.set(url, (reportedFailures.get(url) ?? 0) + maxAttempts);
-    scheduleFailureLog();
-  }
-  const res = { ts: now, ok: false };
-  pingCache.set(url, res);
-  if (ls) {
-    try {
-      ls.setItem(cacheKey, JSON.stringify(res));
-    } catch {}
-  }
-  return false;
-}
+const cache = new Map<string, { ts: number; res: string[] }>();
 
 export async function filterHealthyRelays(relays: string[]): Promise<string[]> {
-  const key = relays.slice().sort().join("|");
-  const cached = filterCache.get(key);
+  const cleaned = sanitizeRelayUrls(relays);
+  const key = cleaned.slice().sort().join(",");
   const now = Date.now();
+  const cached = cache.get(key);
   if (cached && now - cached.ts < CACHE_TTL_MS) return cached.res;
 
-  const healthy: string[] = [];
-  // Process relays in small batches to avoid exhausting browser resources
-  const batchSize = 10;
+  const ndk = await getNdk();
+  const pool = ndk.pool;
 
-  for (let i = 0; i < relays.length; i += batchSize) {
-    const batch = relays.slice(i, i + batchSize);
-    const results = await Promise.all(
-      batch.map(async (u) => ((await pingRelay(u)) ? u : null)),
-    );
-    const batchHealthy = results.filter((u): u is string => !!u);
-    healthy.push(...batchHealthy);
+  for (const url of cleaned) {
+    ndk.addExplicitRelay(url);
   }
-  if (healthy.length === 0) {
-    if (!allFailedWarned) {
-      console.warn("No reachable relays; falling back to FREE_RELAYS");
-      allFailedWarned = true;
+
+  const connected: string[] = [];
+  await new Promise<void>((resolve) => {
+    const t = setTimeout(resolve, 1500);
+    function onConnect(relay: any) {
+      if (!connected.includes(relay.url)) connected.push(relay.url);
     }
-    filterCache.set(key, { ts: now, res: FREE_RELAYS });
-    return FREE_RELAYS;
-  }
+    pool.on("relay:connect", onConnect);
+    setTimeout(() => {
+      pool.off("relay:connect", onConnect);
+      clearTimeout(t);
+      resolve();
+    }, 1500);
+  });
 
-  const res = healthy.length >= 2 ? healthy : FREE_RELAYS;
-  filterCache.set(key, { ts: now, res });
+  const res = connected.length >= 2 ? connected : FREE_RELAYS;
+  cache.set(key, { ts: now, res });
   return res;
 }


### PR DESCRIPTION
## Summary
- refresh default and fallback relay lists with env overrides
- add bounded relay connectivity and publish flow with explicit ack handling
- surface publish failures via reusable NostrRelayErrorBanner

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68babc5b92b483309417ae3fb4d457b9