### PR TITLE
Creator Hub uses fallback relays with per-relay results

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,3 +9,4 @@
   "Manage" on a bucket to open the modal.
 - Bucket detail modal includes a History tab.
 - Documented iframe snippet support and Nostr event link embedding for media previews. These previews also show when viewing tiers from the find creators page.
+- Creator Hub: publish uses fallback relays on failure; per-relay results and connected count fixes; tier definitions included.

--- a/src/components/NostrRelayErrorBanner.vue
+++ b/src/components/NostrRelayErrorBanner.vue
@@ -1,19 +1,5 @@
 <template>
   <div>
-    <q-banner
-      v-if="fallbackUsed"
-      inline-actions
-      dense
-      class="bg-warning text-black q-mb-sm"
-    >
-      <div class="text-body2">
-        Your relays looked unhealthy. We temporarily used vetted open relays. Consider updating your relay list.
-      </div>
-      <template #action>
-        <q-btn flat dense label="Manage" @click="$emit('manage')" />
-      </template>
-    </q-banner>
-
     <q-banner v-if="error" inline-actions dense class="bg-negative text-white">
       <div class="text-body2">
         {{ error.message }}
@@ -33,6 +19,6 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{ error?: { message: string; details?: any }; fallbackUsed?: boolean }>();
+defineProps<{ error?: { message: string; details?: any } }>();
 defineEmits<{ 'retry': []; 'manage': [] }>();
 </script>

--- a/src/components/ProfilePanel.vue
+++ b/src/components/ProfilePanel.vue
@@ -60,7 +60,7 @@ async function publishProfile() {
   }
   publishing.value = true;
   try {
-    const { ids, failedRelays } = await publishDiscoveryProfile({
+    const { ids, byRelay } = await publishDiscoveryProfile({
       profile: {
         display_name: display_name.value,
         picture: picture.value,
@@ -70,6 +70,7 @@ async function publishProfile() {
       mints: profileMints.value,
       relays: profileRelays.value,
     });
+    const failedRelays = byRelay.filter((r) => !r.ok).map((r) => r.url);
     console.debug('Profile publish ok', {
       ids,
       relays: profileRelays.value,

--- a/src/components/PublishBar.vue
+++ b/src/components/PublishBar.vue
@@ -10,6 +10,13 @@
       >
         {{ $t("creatorHub.publish") }}
       </q-btn>
+      <q-banner
+        v-if="fallbackUsed.length"
+        dense
+        class="bg-warning text-black q-mt-sm"
+      >
+        Your relays were unhealthy; also used fallback: {{ fallbackUsed.join(', ') }}
+      </q-banner>
       <div v-if="table.length" class="q-mt-sm">
         <table class="text-caption">
           <thead>
@@ -41,9 +48,10 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-interface RelayRow { relay: string; status: string; latencyMs?: number; fromFallback?: boolean }
-const props = defineProps<{ publishing: boolean; results?: { kind: number; perRelay: RelayRow[] }[] }>();
+import type { PublishReport } from "src/nostr/publish";
+const props = defineProps<{ publishing: boolean; report?: PublishReport | null; fallbackUsed: string[] }>();
 const emit = defineEmits(["publish"]);
-const loading = computed(() => props.publishing && !(props.results && props.results.length));
-const table = computed(() => props.results?.[0]?.perRelay ?? []);
+const loading = computed(() => props.publishing && !props.report);
+const table = computed(() => props.report?.byRelay ?? []);
+const fallbackUsed = computed(() => props.fallbackUsed || []);
 </script>

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -2,20 +2,21 @@
   <q-page class="bg-surface-1 q-pa-md">
     <NostrRelayErrorBanner
       :error="publishErrors"
-      :fallback-used="fallbackUsed.length > 0"
       @retry="publishProfileBundle"
       @manage="openRelayManager"
     />
     <q-card class="q-pa-lg bg-surface-2 shadow-4 full-width">
-      <q-banner v-if="!ndkConnected" class="text-white bg-orange">
-        <template #avatar><q-spinner /></template>
-        Connecting to your Nostr relays ({{ connectedCount }} / {{ totalRelays }})...
+      <q-banner
+        v-if="connectedCount === 0"
+        class="text-white bg-warning"
+      >
+        Connected to 0 of {{ totalRelays }} relays. Publishing will still try vetted relays.
         <template #action>
           <q-btn flat label="Reconnect" @click="reconnectAll" />
         </template>
       </q-banner>
       <q-banner v-else class="text-white bg-positive">
-        Connected to {{ connectedCount }} of {{ totalRelays }} relays. Ready to publish.
+        Connected to {{ connectedCount }} of {{ totalRelays }} relays.
       </q-banner>
       <q-banner v-if="failedRelays.length" class="text-white bg-negative">
         <div>
@@ -196,7 +197,8 @@
       <PublishBar
         v-if="isDirty"
         :publishing="publishing"
-        :results="publishResults"
+        :report="publishReport"
+        :fallback-used="fallbackUsed"
         @publish="publishProfileBundle"
       />
       <RelayScannerDialog
@@ -249,7 +251,7 @@ const {
   performDelete,
   publishing,
   publishErrors,
-  publishResults,
+  publishReport,
   fallbackUsed,
   isDirty,
   profileRelays,
@@ -262,7 +264,6 @@ const {
 
 const profileStore = useCreatorProfileStore();
 const showRelayScanner = ref(false);
-const ndkConnected = computed(() => connectedCount.value > 0);
 const relayManagerDialogRef = ref<InstanceType<typeof RelayManagerDialog> | null>(null);
 function openRelayManager() {
   relayManagerDialogRef.value?.show();

--- a/test/publishDiscoveryProfile.spec.ts
+++ b/test/publishDiscoveryProfile.spec.ts
@@ -2,21 +2,28 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('@noble/ciphers/aes.js', () => ({}), { virtual: true });
 
 let createdEvents: any[] = [];
-class MockNDKEvent {
-  kind?: number;
-  tags: any[] = [];
-  content = '';
-  created_at?: number;
-  constructor() {
-    createdEvents.push(this);
-  }
-  sign = vi.fn();
-  publish = vi.fn();
-  rawEvent() { return {} as any; }
-}
 
 vi.mock('../src/composables/useNdk', () => ({
   useNdk: vi.fn().mockResolvedValue({})
+}));
+
+vi.mock('../src/nostr/publish', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    publishToRelaysWithAcks: vi.fn().mockImplementation((_ndk, _ev, relays: string[]) => {
+      return Promise.resolve({
+        perRelay: relays.map((url) => ({ relay: url, status: url.includes('good') ? 'ok' : 'timeout' })),
+        ok: relays.some((u) => u.includes('good')),
+        acks: relays.some((u) => u.includes('good')) ? 1 : 0,
+        requiredAcks: 1,
+      });
+    }),
+  };
+});
+
+vi.mock('../src/config/relays', () => ({
+  VETTED_OPEN_WRITE_RELAYS: ['wss://good'],
 }));
 
 const connectMock = vi.fn();
@@ -26,14 +33,23 @@ vi.mock('../src/stores/nostr', async (importOriginal) => {
   return {
     ...actual,
     useNostrStore: () => ({ signer: {}, connect: connectMock }),
-    publishWithTimeout: vi.fn().mockResolvedValue(undefined),
-    urlsToRelaySet: vi.fn().mockResolvedValue({ relays: [] } as any),
   };
 });
 
-vi.mock('@nostr-dev-kit/ndk', async () => {
-  const actual: any = await vi.importActual('@nostr-dev-kit/ndk');
-  return { ...actual, NDKEvent: MockNDKEvent };
+vi.mock('@nostr-dev-kit/ndk', () => {
+  class MockNDKEvent {
+    kind?: number;
+    tags: any[] = [];
+    content = '';
+    created_at?: number;
+    constructor() {
+      createdEvents.push(this);
+    }
+    sign = vi.fn();
+    publish = vi.fn();
+    rawEvent() { return {} as any; }
+  }
+  return { NDKEvent: MockNDKEvent };
 });
 
 import { publishDiscoveryProfile } from '../src/stores/nostr';
@@ -50,5 +66,18 @@ describe('publishDiscoveryProfile', () => {
     });
     const ev = createdEvents.find(e => e.kind === 10019);
     expect(ev.tags).toContainEqual(['a', '30000:pub:tiers']);
+  });
+
+  it('uses fallback relays when user relays fail', async () => {
+    createdEvents = [];
+    const report = await publishDiscoveryProfile({
+      profile: {},
+      p2pkPub: 'pub',
+      mints: [],
+      relays: ['wss://bad'],
+    });
+    expect(report.anySuccess).toBe(true);
+    expect(report.relaysTried).toBeGreaterThan(0);
+    expect(report.usedFallback.length).toBeGreaterThan(0);
   });
 });

--- a/test/vitest/__tests__/nostrConnection.spec.ts
+++ b/test/vitest/__tests__/nostrConnection.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { useNostrStore } from '../../../src/stores/nostr';
+
+describe('nostr store connection tracking', () => {
+  it('updates count on relay connect and disconnect', () => {
+    const store = useNostrStore();
+    store.connectedRelays.clear();
+    store.connected = false;
+    expect(store.numConnectedRelays).toBe(0);
+    store.connectedRelays.add('wss://one');
+    store.connected = store.connectedRelays.size > 0;
+    expect(store.numConnectedRelays).toBe(1);
+    store.connectedRelays.delete('wss://one');
+    store.connected = store.connectedRelays.size > 0;
+    expect(store.numConnectedRelays).toBe(0);
+  });
+});

--- a/test/vitest/__tests__/relaySelection.spec.ts
+++ b/test/vitest/__tests__/relaySelection.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach, expect, vi } from "vitest";
 import { selectPreferredRelays, resetRelaySelection } from "../../../src/stores/nostr";
+import { selectPublishRelays } from "../../../src/nostr/publish";
 import * as relayHealth from "../../../src/utils/relayHealth";
 
 const filterHealthyRelaysMock = vi.spyOn(relayHealth, "filterHealthyRelays");
@@ -28,5 +29,19 @@ describe("selectPreferredRelays", () => {
     filterHealthyRelaysMock.mockResolvedValue(["wss://good"]);
     const res = await selectPreferredRelays(["wss://bad", "wss://good"]);
     expect(res).toEqual(["wss://good"]);
+  });
+});
+
+describe("selectPublishRelays", () => {
+  it("uses vetted relays when preferred empty", () => {
+    const res = selectPublishRelays([], ["wss://a", "wss://b"], 2);
+    expect(res.targets).toEqual(["wss://a", "wss://b"]);
+    expect(res.usedFallback).toEqual(["wss://a", "wss://b"]);
+  });
+
+  it("appends fallback to reach minimum", () => {
+    const res = selectPublishRelays(["wss://user"], ["wss://a", "wss://b"], 2);
+    expect(res.targets).toEqual(["wss://user", "wss://a"]);
+    expect(res.usedFallback).toEqual(["wss://a"]);
   });
 });


### PR DESCRIPTION
## Summary
- ensure publish selects fallback relays and reports per-relay status
- fix Nostr connection count by tracking actual connected relays
- show relay results and fallback notice in Creator Hub publish bar

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm vitest run test/publishDiscoveryProfile.spec.ts test/publishCreatorBundle.spec.ts test/vitest/__tests__/relaySelection.spec.ts test/vitest/__tests__/nostrConnection.spec.ts` *(fails: mocking setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1d1a3f98833096e797eb26b61c90