### PR TITLE
feat: guard Nostr events against future timestamps

### DIFF
--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,43 @@
+import type NDK from "@nostr-dev-kit/ndk";
+
+/**
+ * Attempt to retrieve a trusted current time from either the NDK pool
+ * or via a simple HEAD request to one of the provided relay URLs.
+ *
+ * @param ndk - An NDK instance whose pool may expose a `now()` method.
+ * @param relays - Relay URLs used as fallback HTTP HEAD targets.
+ * @returns A timestamp in milliseconds, or null if none could be fetched.
+ */
+export async function getTrustedTime(
+  ndk: NDK | null,
+  relays: string[],
+): Promise<number | null> {
+  const pool: any = ndk?.pool as any;
+  if (pool && typeof pool.now === "function") {
+    try {
+      const t = await pool.now();
+      if (typeof t === "number" && !Number.isNaN(t)) {
+        return t < 1e12 ? t * 1000 : t; // handle seconds
+      }
+    } catch {
+      // ignore and fallback
+    }
+  }
+
+  for (const r of relays) {
+    try {
+      const httpUrl = r.replace(/^wss?:\/\//, "https://");
+      const res = await fetch(httpUrl, { method: "HEAD" });
+      const header = res.headers.get("date");
+      if (header) {
+        const ms = new Date(header).getTime();
+        if (!Number.isNaN(ms)) return ms;
+      }
+    } catch {
+      // try next relay
+    }
+  }
+
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- add helper to fetch trusted network time
- abort publish when local clock is >5m ahead with option to use network time
- allow discovery profile publisher to clamp timestamps

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build` *(fails: Rollup failed to resolve import "@noble/ciphers/aes.js")*

------
https://chatgpt.com/codex/tasks/task_e_68bb3482e5788330a29dafa89d761066