### PR TITLE
feat: omit publishStatus from tier events

### DIFF
--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -597,9 +597,13 @@ export function useCreatorHub() {
 
       const events: any[] = [kind0, kind10002, kind10019];
       if (tiers.length) {
+        const pureTiers = tiers.map((t) => {
+          const { publishStatus, ...pureTier } = t as any;
+          return pureTier;
+        });
         const kind30000 = new NDKEvent(
           ndkConn,
-          buildKind30000Tiers(nostr.pubkey, tiers, "tiers"),
+          buildKind30000Tiers(nostr.pubkey, pureTiers, "tiers"),
         );
         kind30000.created_at = createdAt;
         events.push(kind30000);

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -278,11 +278,14 @@ export const useCreatorHubStore = defineStore("creatorHub", {
     },
 
     async publishTierDefinitions() {
-      const tiersArray = this.getTierArray().map((t) => ({
-        ...toRaw(t),
-        price: t.price_sats,
-        media: t.media ? filterValidMedia(t.media) : [],
-      }));
+      const tiersArray = this.getTierArray().map((t) => {
+        const { publishStatus, ...pureTier } = toRaw(t) as any;
+        return {
+          ...pureTier,
+          price: t.price_sats,
+          media: t.media ? filterValidMedia(t.media) : [],
+        };
+      });
       const nostr = useNostrStore();
 
       if (!nostr.signer) {

--- a/test/publishCreatorBundle.spec.ts
+++ b/test/publishCreatorBundle.spec.ts
@@ -2,9 +2,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@noble/ciphers/aes.js', () => ({}), { virtual: true });
 
 const hubStore = {
-  getTierArray: () => [{ id: 't1', name: 'Tier', price_sats: 1 }],
-  publishTierDefinitions: vi.fn(),
-  lastPublishedTiersHash: ''
+  getTierArray: () => [
+    { id: 't1', name: 'Tier', price_sats: 1, publishStatus: 'pending' },
+  ],
+  publishTierDefinitions: vi.fn(async () => {
+    const json = JSON.stringify(
+      hubStore.getTierArray().map(({ publishStatus, ...pure }) => pure),
+    );
+    expect(json).not.toContain('publishStatus');
+  }),
+  lastPublishedTiersHash: '',
 };
 
 vi.mock('../src/stores/creatorHub', () => ({

--- a/test/vitest/__tests__/creatorHub.spec.ts
+++ b/test/vitest/__tests__/creatorHub.spec.ts
@@ -131,6 +131,7 @@ describe("publishTierDefinitions", () => {
         description: "",
         welcomeMessage: "",
         media: [],
+        publishStatus: "pending",
       },
     } as any;
     store.tierOrder = ["t1"];
@@ -156,6 +157,7 @@ describe("publishTierDefinitions", () => {
         },
       ]),
     );
+    expect(JSON.parse(ev.content)[0].publishStatus).toBeUndefined();
     expect(signMock).toHaveBeenCalledWith(nostrStoreMock.signer);
     expect(publishMock).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- strip `publishStatus` before serializing tier definitions
- add regression tests ensuring `publishStatus` is absent

## Testing
- `pnpm lint` *(fails: command not found)*
- `pnpm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3665ee948330981275d37e994421