### PR TITLE
Improve relay failure UX with vetted relay reset option

### DIFF
--- a/src/components/NostrRelayErrorBanner.vue
+++ b/src/components/NostrRelayErrorBanner.vue
@@ -3,22 +3,68 @@
     <q-banner v-if="error" inline-actions dense class="bg-negative text-white">
       <div class="text-body2">
         {{ error.message }}
-        <div v-if="error.details" class="q-mt-xs">
-          Tried: {{ error.details.urlsTried?.length || 0 }},
-          Connected: {{ error.details.urlsConnected?.length || 0 }},
-          OK: {{ error.details.okOn?.length || 0 }},
-          Failed: {{ error.details.failedOn?.length || 0 }},
-          No ACK: {{ error.details.missingAcks?.length || 0 }}
+        <div v-if="table.length" class="q-mt-xs">
+          <table class="text-caption">
+            <thead>
+              <tr>
+                <th class="q-pr-sm">Relay</th>
+                <th class="q-pr-sm">Status</th>
+                <th>Suggestion</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="r in table" :key="r.url">
+                <td class="q-pr-sm" style="word-break: break-all">{{ r.url }}</td>
+                <td class="q-pr-sm">{{ r.err || 'ok' }}</td>
+                <td>{{ suggestion(r.err) }}</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
       <template #action>
         <q-btn flat dense label="Retry" @click="$emit('retry')" />
+        <q-btn
+          v-if="props.allowReplace"
+          flat
+          dense
+          label="Replace with vetted relays"
+          @click="$emit('replace')"
+        />
+        <q-btn flat dense label="Manage" @click="$emit('manage')" />
       </template>
     </q-banner>
   </div>
 </template>
 
 <script setup lang="ts">
-defineProps<{ error?: { message: string; details?: any } }>();
-defineEmits<{ 'retry': []; 'manage': [] }>();
+import { computed } from 'vue';
+
+const props = defineProps<{
+  error?: { message: string; details?: any };
+  allowReplace?: boolean;
+}>();
+
+defineEmits<{
+  retry: [];
+  manage: [];
+  replace: [];
+}>();
+
+const table = computed(() => props.error?.details?.byRelay || []);
+
+function suggestion(status?: string) {
+  switch (status) {
+    case 'timeout':
+      return 'Relay timeout';
+    case 'notConnected':
+      return 'Check URL or connectivity';
+    case 'blocked':
+    case 'rejected':
+      return 'Relay rejected event';
+    default:
+      return '';
+  }
+}
+
 </script>

--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -641,7 +641,11 @@ export function useCreatorHub() {
         profileStore.markClean();
         notifySuccess("Profile and tiers updated");
       } else {
-        publishErrors.value = { message: "Unable to publish to all relays", details: publishReport.value };
+        console.table(publishReport.value.byRelay);
+        publishErrors.value = {
+          message: "Unable to publish to all relays",
+          details: publishReport.value,
+        };
       }
     } catch (e: any) {
       publishErrors.value = { message: e?.message || String(e) };
@@ -649,6 +653,25 @@ export function useCreatorHub() {
     } finally {
       publishing.value = false;
       debug("creatorHub:publishing:done");
+    }
+  }
+
+  async function replaceWithVettedRelays() {
+    const proceed = await new Promise<boolean>((resolve) => {
+      $q
+        .dialog({
+          title: "Replace relays?",
+          message: "Replace your relay list with vetted open relays?",
+          cancel: true,
+          persistent: true,
+          ok: { label: "Replace" },
+        })
+        .onOk(() => resolve(true))
+        .onCancel(() => resolve(false))
+        .onDismiss(() => resolve(false));
+    });
+    if (proceed) {
+      profileRelays.value = VETTED_OPEN_WRITE_RELAYS.slice(0, MAX_RELAYS);
     }
   }
 
@@ -694,6 +717,7 @@ export function useCreatorHub() {
     nextReconnectIn,
     reconnectAll,
     profileRelays,
+    replaceWithVettedRelays,
     nostr,
   };
 }

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -2,8 +2,10 @@
   <q-page class="bg-surface-1 q-pa-md">
     <NostrRelayErrorBanner
       :error="publishErrors"
+      :allow-replace="true"
       @retry="publishProfileBundle"
       @manage="openRelayManager"
+      @replace="replaceWithVettedRelays"
     />
     <q-card class="q-pa-lg bg-surface-2 shadow-4 full-width">
       <q-banner
@@ -260,6 +262,7 @@ const {
   failedRelays,
   reconnectAll,
   publishProfileBundle,
+  replaceWithVettedRelays,
 } = useCreatorHub();
 
 const profileStore = useCreatorProfileStore();


### PR DESCRIPTION
## Summary
- log per-relay publish results when no relay succeeds
- allow replacing profile relays with vetted defaults
- surface per-relay status with suggestions in relay error banner

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb39db8d08833095b0bd3cba7619e6