### PR TITLE
Fix P2PK selection and relay handling

### DIFF
--- a/src/components/CreatorProfileForm.vue
+++ b/src/components/CreatorProfileForm.vue
@@ -30,9 +30,9 @@
       outlined
     />
     <div>
-      <q-select
-        v-if="hasP2PK"
-        v-model="profilePubLocal"
+    <q-select
+      v-if="hasP2PK"
+      v-model="profilePubLocal"
         :options="p2pkOptions"
         option-value="value"
         option-label="label"
@@ -129,7 +129,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { useI18n } from "vue-i18n";
 import InfoTooltip from "./InfoTooltip.vue";
@@ -168,8 +168,8 @@ const mintOptions = computed(() => mintsStore.mints.map((m) => m.url));
 
 async function generateP2PK() {
   await p2pkStore.createAndSelectNewKey();
-  if (p2pkStore.firstKey) {
-    profilePub.value = p2pkStore.firstKey.publicKey;
+  if (p2pkStore.selectedKey) {
+    profilePub.value = p2pkStore.selectedKey.publicKey;
   }
 }
 
@@ -186,8 +186,11 @@ const aboutLocal = computed({
   set: (val: string) => (about.value = val),
 });
 const profilePubLocal = computed({
-  get: () => profilePub.value,
-  set: (val: string | null) => (profilePub.value = val || ""),
+  get: () => p2pkStore.selectedKey?.publicKey || profilePub.value,
+  set: (val: string | null) => {
+    p2pkStore.selectKey(val);
+    profilePub.value = val || "";
+  },
 });
 const profileMintsLocal = computed({
   get: () => profileMints.value,
@@ -197,6 +200,12 @@ const profileRelaysLocal = computed({
   get: () => profileRelays.value,
   set: (val: string[]) => (profileRelays.value = sanitizeRelayUrls(val).slice(0, 8)),
 });
+
+watch(
+  () => profilePub.value,
+  (val) => p2pkStore.selectKey(val || null),
+  { immediate: true },
+);
 
 const validUrl = computed(() => /^https?:\/\/.+/.test(pictureLocal.value));
 const urlRule = (val: string) =>

--- a/src/components/PublishBar.vue
+++ b/src/components/PublishBar.vue
@@ -5,7 +5,7 @@
         color="primary"
         outline
         :loading="loading"
-        :disable="publishing"
+        :disable="publishing || disablePublish"
         @click="emit('publish')"
       >
         {{ $t("creatorHub.publish") }}
@@ -49,9 +49,10 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { PublishReport } from "src/nostr/publish";
-const props = defineProps<{ publishing: boolean; report?: PublishReport | null; fallbackUsed: string[] }>();
+const props = defineProps<{ publishing: boolean; report?: PublishReport | null; fallbackUsed: string[]; disablePublish?: boolean }>();
 const emit = defineEmits(["publish"]);
 const loading = computed(() => props.publishing && !props.report);
 const table = computed(() => props.report?.byRelay ?? []);
 const fallbackUsed = computed(() => props.fallbackUsed || []);
+const disablePublish = computed(() => props.disablePublish || false);
 </script>

--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -44,6 +44,7 @@ export const LOCAL_STORAGE_KEYS = {
   CASHU_NWC_RELAYS: "cashu.nwc.relays",
   CASHU_NWC_SEENCOMMANDSUNTIL: "cashu.nwc.seenCommandsUntil",
   CASHU_OLDMNEMONICCOUNTERS: "cashu.oldMnemonicCounters",
+  CASHU_P2PK_SELECTEDKEY: "cashu.p2pk.selectedKey",
   CASHU_P2PK_SHOWP2PKBUTTONINDRAWER: "cashu.p2pk.showP2PkButtonInDrawer",
   CASHU_PR_ENABLE: "cashu.pr.enable",
   CASHU_PR_RECEIVE: "cashu.pr.receive",

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -201,6 +201,7 @@
         :publishing="publishing"
         :report="publishReport"
         :fallback-used="fallbackUsed"
+        :disable-publish="publishDisabled"
         @publish="publishProfileBundle"
       />
       <RelayScannerDialog
@@ -255,6 +256,7 @@ const {
   publishErrors,
   publishReport,
   fallbackUsed,
+  publishDisabled,
   isDirty,
   profileRelays,
   connectedCount,

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -79,6 +79,10 @@ export async function buildTimedOutputs(
 export const useP2PKStore = defineStore("p2pk", {
   state: () => ({
     p2pkKeys: useLocalStorage<P2PKKey[]>(LOCAL_STORAGE_KEYS.CASHU_P2PKKEYS, []),
+    selectedKey: useLocalStorage<P2PKKey | null>(
+      LOCAL_STORAGE_KEYS.CASHU_P2PK_SELECTEDKEY,
+      null,
+    ),
     showP2PkButtonInDrawer: useLocalStorage<boolean>(
       LOCAL_STORAGE_KEYS.CASHU_P2PK_SHOWP2PKBUTTONINDRAWER,
       false,
@@ -165,12 +169,22 @@ export const useP2PKStore = defineStore("p2pk", {
     },
     async createAndSelectNewKey() {
       const { pub, priv } = generateP2pkKeyPair();
-      this.p2pkKeys.unshift({
+      const key = {
         publicKey: pub,
         privateKey: priv,
         used: false,
         usedCount: 0,
-      });
+      };
+      this.p2pkKeys.unshift(key);
+      this.selectedKey = key;
+    },
+    selectKey(pub: string | null) {
+      if (!pub) {
+        this.selectedKey = null;
+        return;
+      }
+      const key = this.p2pkKeys.find((k) => k.publicKey === pub) || null;
+      this.selectedKey = key;
     },
     getSecretP2PKInfo: function (secret: string): {
       pubkey: string;

--- a/test/vitest/__tests__/creatorHub-layout.spec.ts
+++ b/test/vitest/__tests__/creatorHub-layout.spec.ts
@@ -47,7 +47,11 @@ vi.mock("../../../src/stores/nostr", async (importOriginal) => {
 });
 
 vi.mock("../../../src/stores/p2pk", () => ({
-  useP2PKStore: () => ({ firstKey: null }),
+  useP2PKStore: () => ({
+    firstKey: null,
+    selectedKey: null,
+    isValidPubkey: () => false,
+  }),
 }));
 
 vi.mock("../../../src/stores/mints", () => ({


### PR DESCRIPTION
## Summary
- track a user-selected P2PK key and expose it in profile publishing
- publish Nutzap profile using the creator's relay list instead of fallback targets
- disable publish and guide users to manage keys when no valid P2PK is chosen

## Testing
- `pnpm lint`
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/publishDiscoveryProfile.spec.ts` *(fails: Signer required to publish a discoverable profile)*

------
https://chatgpt.com/codex/tasks/task_e_68bbce2b6aa48330b96c744f5d74e48d