### PR TITLE
feat: unify signer path and add relay health checks

### DIFF
--- a/src/creatorHub/publishGuards.ts
+++ b/src/creatorHub/publishGuards.ts
@@ -1,0 +1,51 @@
+import { nip19 } from "nostr-tools";
+import { bytesToHex } from "@noble/hashes/utils";
+import type { NormalizedSigner } from "src/nostr/signer";
+import { getNormalizedSigner } from "src/nostr/signer";
+
+export class SignerGuardError extends Error {
+  code: "NO_SIGNER" | "PUBKEY_MISMATCH";
+  constructor(code: SignerGuardError["code"], message: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+export async function ensureSignerMatchesLoggedInNpub(opts: {
+  getLoggedInNpub: () => string | null;
+}): Promise<NormalizedSigner> {
+  const signer = await getNormalizedSigner();
+  if (!signer) {
+    throw new SignerGuardError(
+      "NO_SIGNER",
+      "Connect your Nostr key to publish.",
+    );
+  }
+  const logged = opts.getLoggedInNpub?.();
+  let hex: string | null = null;
+  if (logged) {
+    const trimmed = logged.trim();
+    if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+      hex = trimmed.toLowerCase();
+    } else {
+      try {
+        const decoded = nip19.decode(trimmed);
+        if (decoded.type === "npub") {
+          hex =
+            typeof decoded.data === "string"
+              ? decoded.data.toLowerCase()
+              : bytesToHex(decoded.data as Uint8Array).toLowerCase();
+        }
+      } catch {
+        hex = null;
+      }
+    }
+  }
+  if (!hex || hex !== signer.pubkeyHex) {
+    throw new SignerGuardError(
+      "PUBKEY_MISMATCH",
+      "Connect your Nostr key to publish.",
+    );
+  }
+  return signer;
+}

--- a/src/creatorHub/publishOrchestrator.ts
+++ b/src/creatorHub/publishOrchestrator.ts
@@ -1,0 +1,72 @@
+import type NDK from "@nostr-dev-kit/ndk";
+import { NDKEvent } from "@nostr-dev-kit/ndk";
+import { probeWriteRelays, selectHealthyWriteRelays, type RelayProbeResult } from "src/nostr/relayHealth";
+import { publishWithAcks, type RelayAck } from "src/nostr/publishWithAcks";
+import { verifyReadBack } from "src/nostr/readBack";
+import type { NormalizedSigner } from "src/nostr/signer";
+
+export async function publishOrchestrator(opts: {
+  ndk: NDK;
+  event10019: NDKEvent;
+  event30019: NDKEvent;
+  userRelays: string[];
+  vettedOpenRelays: string[];
+  fallbackAllowed: boolean;
+  signer: NormalizedSigner;
+}): Promise<{
+  probe: RelayProbeResult[];
+  acks10019: RelayAck[];
+  acks30019: RelayAck[];
+  readback10019: boolean;
+  readback30019: boolean;
+}> {
+  const candidate = Array.from(new Set(opts.userRelays));
+  const probe = await probeWriteRelays({ ndk: opts.ndk, relayUrls: candidate, timeoutMs: 2500 });
+  let healthy = selectHealthyWriteRelays(probe);
+
+  if (healthy.length === 0) {
+    if (!opts.fallbackAllowed) {
+      throw new Error("No write relays reachable");
+    }
+    const fallbackProbe = await probeWriteRelays({ ndk: opts.ndk, relayUrls: opts.vettedOpenRelays, timeoutMs: 2500 });
+    healthy = selectHealthyWriteRelays(fallbackProbe);
+    if (healthy.length === 0) {
+      throw new Error("No write relays reachable (even after fallback)");
+    }
+  }
+
+  await opts.event10019.sign(opts.signer.ndkSigner);
+  const a1 = await publishWithAcks({ ndk: opts.ndk, event: opts.event10019, relayUrls: healthy });
+  if (!a1.firstOkUrl) {
+    throw new Error("Publish of 10019 received no OK from any relay");
+  }
+  const rb1 = await verifyReadBack({
+    ndk: opts.ndk,
+    relayUrl: a1.firstOkUrl,
+    authorHex: opts.signer.pubkeyHex,
+    kind: 10019,
+    timeoutMs: 2000,
+  });
+
+  await opts.event30019.sign(opts.signer.ndkSigner);
+  const a2 = await publishWithAcks({ ndk: opts.ndk, event: opts.event30019, relayUrls: healthy });
+  if (!a2.firstOkUrl) {
+    throw new Error("Publish of 30019 received no OK from any relay");
+  }
+  const rb2 = await verifyReadBack({
+    ndk: opts.ndk,
+    relayUrl: a2.firstOkUrl,
+    authorHex: opts.signer.pubkeyHex,
+    kind: 30019,
+    dTag: "tiers",
+    timeoutMs: 2000,
+  });
+
+  return {
+    probe,
+    acks10019: a1.acks,
+    acks30019: a2.acks,
+    readback10019: rb1,
+    readback30019: rb2,
+  };
+}

--- a/src/nostr/publishWithAcks.ts
+++ b/src/nostr/publishWithAcks.ts
@@ -1,0 +1,79 @@
+import type NDK from "@nostr-dev-kit/ndk";
+import { NDKEvent } from "@nostr-dev-kit/ndk";
+
+export type RelayAck = {
+  url: string;
+  ok: boolean;
+  id?: string;
+  error?: string;
+  elapsedMs: number;
+};
+
+export async function publishWithAcks(opts: {
+  ndk: NDK;
+  event: NDKEvent;
+  relayUrls: string[];
+  timeoutMs?: number;
+}): Promise<{ acks: RelayAck[]; firstOkUrl?: string }> {
+  const timeoutMs = opts.timeoutMs ?? 6000;
+  const acks: RelayAck[] = [];
+  let firstOkUrl: string | undefined;
+
+  await Promise.all(
+    opts.relayUrls.map(async (url) => {
+      const start = Date.now();
+      try {
+        const relay = opts.ndk.pool.getRelay(url, true);
+        await relay.connect({ timeoutMs }).catch(() => {});
+        const pub = relay.publish(opts.event);
+        const ack = await new Promise<RelayAck>((resolve) => {
+          let done = false;
+          const to = setTimeout(() => {
+            if (!done) {
+              done = true;
+              resolve({
+                url,
+                ok: false,
+                elapsedMs: Date.now() - start,
+              });
+            }
+          }, timeoutMs);
+          pub.on("ok", (id?: string) => {
+            if (!done) {
+              done = true;
+              clearTimeout(to);
+              resolve({
+                url,
+                ok: true,
+                id,
+                elapsedMs: Date.now() - start,
+              });
+            }
+          });
+          pub.on("failed", (reason: string) => {
+            if (!done) {
+              done = true;
+              clearTimeout(to);
+              resolve({
+                url,
+                ok: false,
+                error: reason,
+                elapsedMs: Date.now() - start,
+              });
+            }
+          });
+        });
+        acks.push(ack);
+        if (ack.ok && !firstOkUrl) firstOkUrl = url;
+      } catch (e: any) {
+        acks.push({
+          url,
+          ok: false,
+          error: String(e?.message ?? e),
+          elapsedMs: Date.now() - start,
+        });
+      }
+    }),
+  );
+  return { acks, firstOkUrl };
+}

--- a/src/nostr/readBack.ts
+++ b/src/nostr/readBack.ts
@@ -1,0 +1,51 @@
+import type NDK from "@nostr-dev-kit/ndk";
+import { NDKSubscription } from "@nostr-dev-kit/ndk";
+
+export async function verifyReadBack(opts: {
+  ndk: NDK;
+  relayUrl: string;
+  authorHex: string;
+  kind: number;
+  dTag?: string;
+  timeoutMs?: number;
+}): Promise<boolean> {
+  const timeoutMs = opts.timeoutMs ?? 2000;
+  try {
+    const relay = opts.ndk.pool.getRelay(opts.relayUrl, true);
+    await relay.connect({ timeoutMs }).catch(() => {});
+    const filter: any = { kinds: [opts.kind], authors: [opts.authorHex], limit: 1 };
+    if (opts.dTag) filter["#d"] = [opts.dTag];
+    const sub: NDKSubscription = opts.ndk.subscribe(filter, {
+      closeOnEose: true,
+      relays: [relay],
+    });
+    return await new Promise<boolean>((resolve) => {
+      let done = false;
+      const to = setTimeout(() => {
+        if (!done) {
+          done = true;
+          sub.stop();
+          resolve(false);
+        }
+      }, timeoutMs);
+      sub.on("event", () => {
+        if (!done) {
+          done = true;
+          clearTimeout(to);
+          sub.stop();
+          resolve(true);
+        }
+      });
+      sub.on("eose", () => {
+        if (!done) {
+          done = true;
+          clearTimeout(to);
+          sub.stop();
+          resolve(false);
+        }
+      });
+    });
+  } catch {
+    return false;
+  }
+}

--- a/src/nostr/relayHealth.ts
+++ b/src/nostr/relayHealth.ts
@@ -1,0 +1,82 @@
+import type NDK from "@nostr-dev-kit/ndk";
+import { NDKEvent } from "@nostr-dev-kit/ndk";
+
+export type RelayProbeResult = {
+  url: string;
+  connected: boolean;
+  writeOk: boolean;
+  elapsedMs: number;
+  error?: string;
+};
+
+export async function probeWriteRelays(opts: {
+  ndk: NDK;
+  relayUrls: string[];
+  timeoutMs?: number;
+}): Promise<RelayProbeResult[]> {
+  const timeoutMs = opts.timeoutMs ?? 2500;
+  const ndk = opts.ndk;
+  const results = await Promise.all(
+    opts.relayUrls.map(async (url) => {
+      const start = Date.now();
+      const res: RelayProbeResult = {
+        url,
+        connected: false,
+        writeOk: false,
+        elapsedMs: 0,
+      };
+      try {
+        const relay = ndk.pool.getRelay(url, true);
+        await relay.connect({ timeoutMs }).catch(() => {});
+        res.connected = relay.status === 1 || relay.connected;
+        if (!res.connected) {
+          res.elapsedMs = Date.now() - start;
+          return res;
+        }
+        const ev = new NDKEvent(ndk);
+        ev.kind = 20000;
+        ev.content = "";
+        ev.tags = [];
+        await ev.sign();
+        const pub = relay.publish(ev);
+        const ok = await new Promise<boolean>((resolve) => {
+          let done = false;
+          const to = setTimeout(() => {
+            if (!done) {
+              done = true;
+              resolve(false);
+            }
+          }, timeoutMs);
+          pub.on("ok", () => {
+            if (!done) {
+              done = true;
+              clearTimeout(to);
+              resolve(true);
+            }
+          });
+          pub.on("failed", (reason: string) => {
+            if (!done) {
+              done = true;
+              clearTimeout(to);
+              res.error = reason;
+              resolve(false);
+            }
+          });
+        });
+        res.writeOk = ok;
+        res.elapsedMs = Date.now() - start;
+      } catch (e: any) {
+        res.error = String(e?.message ?? e);
+        res.elapsedMs = Date.now() - start;
+      }
+      return res;
+    }),
+  );
+  return results;
+}
+
+export function selectHealthyWriteRelays(results: RelayProbeResult[]): string[] {
+  return results
+    .filter((r) => r.connected && r.writeOk)
+    .map((r) => r.url);
+}

--- a/src/nostr/signer.ts
+++ b/src/nostr/signer.ts
@@ -1,0 +1,35 @@
+import type { NDKSigner } from "@nostr-dev-kit/ndk";
+import { useNostrStore, SignerType } from "src/stores/nostr";
+
+export type NormalizedSigner = {
+  kind: "nip07" | "nip46" | "local";
+  ndkSigner: NDKSigner;
+  pubkeyHex: string;
+};
+
+export async function getNormalizedSigner(): Promise<NormalizedSigner | null> {
+  const nostr = useNostrStore();
+  try {
+    await nostr.initSignerIfNotSet?.();
+  } catch {
+    // ignore
+  }
+  const signer = nostr.signer as NDKSigner | undefined;
+  if (!signer) return null;
+  const user = await signer.user();
+  const pubkeyHex = user?.pubkey;
+  if (!pubkeyHex) return null;
+
+  let kind: NormalizedSigner["kind"] = "local";
+  switch (nostr.signerType) {
+    case SignerType.NIP07:
+      kind = "nip07";
+      break;
+    case SignerType.NIP46:
+      kind = "nip46";
+      break;
+    default:
+      kind = "local";
+  }
+  return { kind, ndkSigner: signer, pubkeyHex: pubkeyHex.toLowerCase() };
+}

--- a/test/vitest/__tests__/creatorHub.spec.ts
+++ b/test/vitest/__tests__/creatorHub.spec.ts
@@ -7,13 +7,14 @@ import { useP2PKStore } from "../../../src/stores/p2pk";
 import { useMintsStore } from "../../../src/stores/mints";
 import { useCreatorProfileStore } from "../../../src/stores/creatorProfile";
 
-const notifySuccess = vi.fn();
-const notifyError = vi.fn();
+let notifySuccess: any;
+let notifyError: any;
 
-vi.mock("../../../src/js/notify", () => ({
-  notifySuccess,
-  notifyError,
-}));
+vi.mock("../../../src/js/notify", () => {
+  notifySuccess = vi.fn();
+  notifyError = vi.fn();
+  return { notifySuccess, notifyError };
+});
 
 let createdEvents: any[] = [];
 const signMock = vi.fn();
@@ -21,6 +22,7 @@ const publishMock = vi.fn();
 let fetchNutzapProfileMock: any;
 let publishNutzapProfileMock: any;
 let ensureRelayConnectivityMock: any;
+let ensureSignerMatchesLoggedInNpubMock: any;
 
 let ndkStub: any = {};
 
@@ -71,6 +73,11 @@ vi.mock("../../../src/stores/nostr", async (importOriginal) => {
   };
 });
 
+vi.mock("../../../src/creatorHub/publishGuards", () => ({
+  ensureSignerMatchesLoggedInNpub: (...args: any[]) =>
+    ensureSignerMatchesLoggedInNpubMock(...args),
+}));
+
 beforeEach(() => {
   createdEvents = [];
   signMock.mockClear();
@@ -79,6 +86,11 @@ beforeEach(() => {
   fetchNutzapProfileMock = vi.fn(async () => null);
   publishNutzapProfileMock = vi.fn();
   ensureRelayConnectivityMock = vi.fn();
+  ensureSignerMatchesLoggedInNpubMock = vi.fn(async () => ({
+    kind: "nip07",
+    ndkSigner: nostrStoreMock.signer,
+    pubkeyHex: nostrStoreMock.pubkey,
+  }));
   localStorage.clear();
 });
 


### PR DESCRIPTION
## Summary
- add `getNormalizedSigner` to wrap NDK signer sources
- implement signer guard and relay probing/publish helpers
- update Creator Hub publish to use NDK signer and structured relay flow

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbeceed9748330bc9894d86246458b