### PR TITLE
Limit Nutzap Profile relays to vetted targets

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -6,6 +6,7 @@
         Connected: {{ connectedCount }}/{{ totalRelays }} • {{ writableConnectedCount }} writable
         <template v-slot:action>
           <q-btn flat label="Reconnect" @click="reconnectAll" />
+          <q-btn flat label="Use vetted" @click="useVetted" />
         </template>
       </q-banner>
     </q-card>
@@ -135,5 +136,6 @@ const {
   saveTier,
   publishAll,
   reconnectAll,
+  useVetted,
 } = useNutzapProfile()
 </script>


### PR DESCRIPTION
## Summary
- Cap Nutzap Profile's relay connections to a small sanitized set of vetted write relays
- Only connect/publish to these targets and expose a helper to switch to the vetted list
- Show relay totals based on selected targets and add a "Use vetted" UI button

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc11ec36bc833095f8513e11b3e643