### PR TITLE
feat: add worker proxy and robust nutzap profile networking

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -4,6 +4,7 @@
       <div class="text-subtitle1 q-mb-sm">Relay Status</div>
       <q-banner :class="bannerClass" class="text-white">
         Connected: {{ connectedCount }}/{{ totalRelays }} • {{ writableConnectedCount }} writable
+        <span v-if="bannerHint">• {{ bannerHint }}</span>
         <template v-slot:action>
           <q-toggle v-model="proxyMode" label="Proxy" dense class="q-mr-sm" />
           <q-icon name="help_outline" size="16px" class="q-mr-sm">
@@ -14,6 +15,7 @@
           </q-icon>
           <q-btn flat label="Reconnect" @click="reconnectAll" />
           <q-btn flat label="Use vetted" @click="useVetted" />
+          <q-btn flat label="Single-connection mode" @click="singleConnectionMode" />
         </template>
       </q-banner>
       <q-expansion-item label="Diagnostics" dense class="q-mt-sm">
@@ -158,6 +160,7 @@ const {
   totalRelays,
   publishDisabled,
   bannerClass,
+  bannerHint,
   // actions
   editTier,
   removeTier,
@@ -165,6 +168,7 @@ const {
   publishAll,
   reconnectAll,
   useVetted,
+  singleConnectionMode,
   copyDebug,
 } = useNutzapProfile()
 </script>

--- a/workers/fundstr-proxy/.env.example
+++ b/workers/fundstr-proxy/.env.example
@@ -1,0 +1,1 @@
+PROXY_BASE=https://staging.fundstr.me

--- a/workers/fundstr-proxy/src/index.ts
+++ b/workers/fundstr-proxy/src/index.ts
@@ -1,0 +1,55 @@
+export default { fetch: handle };
+
+async function handle(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+
+  // WS bridge: browser -> (your domain) -> relay
+  if (url.pathname === '/ws' && req.headers.get('Upgrade') === 'websocket') {
+    const target = url.searchParams.get('target');
+    if (!target || !target.startsWith('wss://')) {
+      return new Response('bad target', { status: 400 });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+
+    server.accept();
+
+    // Dial upstream relay and accept
+    const upstreamResp = await fetch(target, {
+      headers: { Upgrade: 'websocket', Connection: 'Upgrade' }
+    });
+    const upstream = (upstreamResp as any).webSocket as WebSocket;
+    if (!upstream) return new Response('upstream failed', { status: 502 });
+    upstream.accept();
+
+    // Pipe frames both ways
+    server.addEventListener('message', (e: MessageEvent) => upstream.send(e.data));
+    upstream.addEventListener('message', (e: MessageEvent) => server.send(e.data));
+    server.addEventListener('close', () => upstream.close());
+    upstream.addEventListener('close', () => server.close());
+
+    // **Return 101 with the client end**
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  if (url.pathname === '/http') {
+    const target = url.searchParams.get('target');
+    if (!target || !/^https:\/\/[^?]+$/.test(target)) return new Response('bad target', { status: 400 });
+
+    const resp = await fetch(target, { headers: { Accept: 'application/nostr+json' }});
+    const body = await resp.text();
+    return new Response(body, {
+      status: resp.status,
+      headers: {
+        'Content-Type': resp.headers.get('Content-Type') ?? 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': '*',
+        'Access-Control-Allow-Methods': 'GET,HEAD,OPTIONS'
+      }
+    });
+  }
+
+  // Health check / default
+  return new Response('ok');
+}


### PR DESCRIPTION
## Summary
- add Cloudflare worker WebSocket/HTTP proxy
- improve Nutzap profile diagnostics, preflights, and relay handling
- expose single-connection and proxy toggles in Nutzap profile UI

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc62a6f1e88330b429dade38003e78