### PR TITLE
feat: add HTTP relay publish fallback

### DIFF
--- a/src/composables/useNutzapProfile.ts
+++ b/src/composables/useNutzapProfile.ts
@@ -739,8 +739,9 @@ export function useNutzapProfile() {
       currentStep.value = 'PUB_TIERS'
       try {
         if (proxyMode.value && hasHttpProxy()) {
-          const signedEvent = evTiers.toNostrEvent() as Event
-          await publishWithFallback(signedEvent, { proxyMode: true })
+          const signedTier = evTiers.toNostrEvent() as Event
+          const res = await publishWithFallback(signedTier, { proxyMode: true })
+          if (!res.ok) throw new Error('PUB_FAIL')
         } else {
           await publishToWritableWithAck(
             ndk,


### PR DESCRIPTION
## Summary
- add environment-driven proxy helpers and HTTP publishing fallback
- probe NIP-11 via proxy and enable proxy-mode publishing when WS is blocked

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run build` *(fails: Rollup failed to resolve import `@noble/ciphers/aes.js`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd8c50f8c833096f67930099fa7fd