### PR TITLE
Sign events before publishing to primary relay

### DIFF
--- a/src/composables/useNutzapProfile.ts
+++ b/src/composables/useNutzapProfile.ts
@@ -647,6 +647,13 @@ export function useNutzapProfile() {
       }
     }
 
+    try {
+      await event.sign(nostrStore.signer)
+    } catch (signError) {
+      console.error('Nutzap-Publisher: Event signing failed.', signError)
+      return { ok: false, error: 'Event signing was rejected or failed.' }
+    }
+
     const tempNdk = new NDK({
       explicitRelayUrls: [FUNDSTR_PRIMARY_RELAY],
       signer: nostrStore.signer


### PR DESCRIPTION
## Summary
- Sign events using the active signer before publishing to the primary relay
- Handle signing errors explicitly

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bea8053f2c8330895f7fc77859277e