### PR TITLE
Refactor Nutzap profile composable and signer access

### DIFF
--- a/src/nutzap/signer.ts
+++ b/src/nutzap/signer.ts
@@ -1,0 +1,15 @@
+import { computed } from 'vue';
+import type { NDKSigner } from '@nostr-dev-kit/ndk';
+import { useNostrStore } from 'src/stores/nostr';
+
+export function useActiveNutzapSigner() {
+  const nostr = useNostrStore();
+
+  const pubkey = computed(() => nostr.pubkey || '');
+  const signer = computed<NDKSigner | null>(() => (nostr.signer as NDKSigner | undefined) ?? null);
+
+  return {
+    pubkey,
+    signer,
+  };
+}

--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -113,7 +113,7 @@
 <script setup lang="ts">
 import RelayStatusIndicator from 'src/nutzap/RelayStatusIndicator.vue';
 import { computed } from 'vue';
-import { useNutzapProfile } from 'src/composables/useNutzapProfile';
+import { useNutzapProfile } from 'src/nutzap/useNutzapProfile';
 import { NUTZAP_TIERS_KIND } from 'src/nutzap/relayConfig';
 
 const {


### PR DESCRIPTION
## Summary
- move the Nutzap profile composable into the nutzap module and rely on a dedicated signer helper
- add a nutzap-specific signer accessor so publishing uses the isolated NDK without invoking global relay setup
- update the Nutzap profile page to consume the relocated composable

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ca81e49fa48330bb1815dee8a9af96