### PR TITLE
refactor: centralize relay client for nutzap data flows

### DIFF
--- a/src-pwa/custom-service-worker.js
+++ b/src-pwa/custom-service-worker.js
@@ -38,5 +38,13 @@ registerRoute(
   ({ url }) =>
     url.origin === "https://relay.fundstr.me" &&
     (url.pathname.startsWith("/req") || url.pathname.startsWith("/event")),
-  new NetworkOnly({ cacheName: "fundstr-relay" }),
+  new NetworkOnly({
+    fetchOptions: {
+      cache: "no-store",
+      headers: {
+        "cache-control": "no-cache",
+        pragma: "no-cache",
+      },
+    },
+  }),
 );

--- a/src/nostr/discovery.ts
+++ b/src/nostr/discovery.ts
@@ -1,18 +1,29 @@
 import type { Filter } from "./relayClient";
-import { queryNostr } from "./relayClient";
+import { queryNostr, toHex } from "./relayClient";
 
 export async function fallbackDiscoverRelays(pubkey: string): Promise<string[]> {
+  let hex: string;
+  try {
+    hex = toHex(pubkey);
+  } catch {
+    return [];
+  }
+
   const filters: Filter[] = [
-    { kinds: [10002], authors: [pubkey], limit: 1 },
+    { kinds: [10002], authors: [hex], limit: 1 },
   ];
   const events = await queryNostr(filters, {
     preferFundstr: false,
     fanout: [],
   });
   if (!events.length) return [];
-  const latest = events.sort((a, b) => b.created_at - a.created_at)[0];
+  const latest = events[0];
   if (!latest) return [];
-  return latest.tags
-    .filter((tag) => tag[0] === "r" && typeof tag[1] === "string")
-    .map((tag) => tag[1]!);
+  const urls = new Set<string>();
+  for (const tag of latest.tags || []) {
+    if (tag[0] === "r" && typeof tag[1] === "string" && tag[1]) {
+      urls.add(tag[1]);
+    }
+  }
+  return Array.from(urls);
 }

--- a/src/nutzap/publish.ts
+++ b/src/nutzap/publish.ts
@@ -16,6 +16,9 @@ export async function publishNutzapProfile(
   ev.tags = tags;
   await ev.sign(); // must have signer configured globally or via NDK signer
   const ack = await publishNostr(ev.toNostrEvent());
+  if (!ack.accepted) {
+    throw new Error(ack.message || "Relay rejected Nutzap profile");
+  }
   return { ...ack, via: 'http' as const };
 }
 
@@ -31,5 +34,8 @@ export async function publishTierDefinitions(tiers: Tier[]) {
   ev.content = JSON.stringify(tiers);
   await ev.sign();
   const ack = await publishNostr(ev.toNostrEvent());
+  if (!ack.accepted) {
+    throw new Error(ack.message || "Relay rejected tier definitions");
+  }
   return { ...ack, via: 'http' as const };
 }

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -468,7 +468,7 @@ async function decryptNip04(
 // --- Nutzap helpers (NIP-61) ----------------------------------------------
 
 import type { NostrEvent } from "@nostr-dev-kit/ndk";
-import { queryNutzapProfile } from "@/nostr/relayClient";
+import { queryNutzapProfile, toHex } from "@/nostr/relayClient";
 import { fallbackDiscoverRelays } from "@/nostr/discovery";
 import type { NostrEvent as RelayEvent } from "@/nostr/relayClient";
 
@@ -786,8 +786,12 @@ export async function anyRelayReachable(relays: string[]): Promise<boolean> {
 export async function fetchNutzapProfile(
   npubOrHex: string,
 ): Promise<NutzapProfile | null> {
-  const hex = npubOrHex.startsWith("npub") ? npubToHex(npubOrHex) : npubOrHex;
-  if (!hex) throw new Error("Invalid npub");
+  let hex: string;
+  try {
+    hex = toHex(npubOrHex);
+  } catch (e) {
+    throw new Error("Invalid npub");
+  }
 
   if (nutzapProfileCache.has(hex)) {
     return nutzapProfileCache.get(hex) || null;

--- a/test/vitest/__tests__/relayClient.spec.ts
+++ b/test/vitest/__tests__/relayClient.spec.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nip19 } from "nostr-tools";
 import {
   dedup,
   normalizeEvents,
   pickLatestAddrReplaceable,
   pickLatestReplaceable,
   queryNostr,
+  queryNutzapProfile,
   type NostrEvent,
 } from "@/nostr/relayClient";
 
@@ -21,6 +23,15 @@ function makeEvent(partial: Partial<NostrEvent>): NostrEvent {
   };
 }
 
+function toUrlString(input: any): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  if (input && typeof input === "object" && "url" in input) {
+    return (input as { url: string }).url;
+  }
+  throw new Error("Unsupported fetch input");
+}
+
 describe("relayClient dedup & replaceable handling", () => {
   it("deduplicates events and keeps the latest replaceable versions", () => {
     const duplicate = makeEvent({ id: "dup", created_at: 100, kind: 1 });
@@ -34,10 +45,22 @@ describe("relayClient dedup & replaceable handling", () => {
         created_at: 50,
       }),
       makeEvent({
+        id: "profile-10019-old",
+        kind: 10019,
+        pubkey: "alice",
+        created_at: 55,
+      }),
+      makeEvent({
         id: "profile-new",
         kind: 0,
         pubkey: "alice",
         created_at: 60,
+      }),
+      makeEvent({
+        id: "profile-10019-new",
+        kind: 10019,
+        pubkey: "alice",
+        created_at: 65,
       }),
       makeEvent({
         id: "tiers-old",
@@ -62,6 +85,8 @@ describe("relayClient dedup & replaceable handling", () => {
 
     expect(normalized.find((ev) => ev.id === "profile-new")).toBeTruthy();
     expect(normalized.find((ev) => ev.id === "profile-old")).toBeUndefined();
+    expect(normalized.find((ev) => ev.id === "profile-10019-new")).toBeTruthy();
+    expect(normalized.find((ev) => ev.id === "profile-10019-old")).toBeUndefined();
 
     expect(normalized.find((ev) => ev.id === "tiers-new")).toBeTruthy();
     expect(normalized.find((ev) => ev.id === "tiers-old")).toBeUndefined();
@@ -95,8 +120,9 @@ describe("relayClient transport", () => {
   });
 
   it("falls back to HTTP when websocket connection fails", async () => {
+    const pubkeyHex = "c".repeat(64);
     const responseEvents = [
-      makeEvent({ id: "http-event", kind: 10019, pubkey: "alice" }),
+      makeEvent({ id: "http-event", kind: 10019, pubkey: pubkeyHex }),
     ];
 
     const fetchMock = vi.fn(async () =>
@@ -115,11 +141,112 @@ describe("relayClient transport", () => {
 
     (globalThis as any).WebSocket = ThrowingWebSocket as any;
 
-    const filters = [{ kinds: [10019], authors: ["alice"] }];
+    const filters = [{ kinds: [10019], authors: [pubkeyHex] }];
     const events = await queryNostr(filters, { preferFundstr: true, wsTimeoutMs: 10 });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(events).toHaveLength(1);
     expect(events[0].id).toBe("http-event");
+  });
+
+  it("normalises npub authors to hex when querying profiles", async () => {
+    const pubkeyHex = "f".repeat(64);
+    const npub = nip19.npubEncode(pubkeyHex);
+    const responseEvents = [
+      makeEvent({ id: "profile", kind: 10019, pubkey: pubkeyHex }),
+    ];
+
+    const fetchMock = vi.fn(async (input: any) => {
+      const url = new URL(toUrlString(input));
+      const filtersParam = url.searchParams.get("filters");
+      expect(filtersParam).toBeTruthy();
+      const parsed = JSON.parse(decodeURIComponent(filtersParam!));
+      expect(parsed[0].authors[0]).toBe(pubkeyHex);
+      return new Response(JSON.stringify(responseEvents), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    class ThrowingWebSocket {
+      constructor() {
+        throw new Error("connect failed");
+      }
+    }
+
+    (globalThis as any).WebSocket = ThrowingWebSocket as any;
+
+    const npubResult = await queryNutzapProfile(npub);
+    expect(npubResult?.pubkey).toBe(pubkeyHex);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockClear();
+    const hexResult = await queryNutzapProfile(pubkeyHex);
+    expect(hexResult?.id).toBe("profile");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const lastUrl = new URL(toUrlString(fetchMock.mock.calls[0][0]));
+    const filtersParam = lastUrl.searchParams.get("filters");
+    expect(filtersParam).toBeTruthy();
+    const parsed = JSON.parse(decodeURIComponent(filtersParam!));
+    expect(parsed[0].authors[0]).toBe(pubkeyHex);
+  });
+
+  it("falls back to HTTP when websocket returns no events", async () => {
+    const pubkeyHex = "a".repeat(64);
+    const responseEvents = [
+      makeEvent({ id: "http-event-empty", kind: 10019, pubkey: pubkeyHex }),
+    ];
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify(responseEvents), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    class EmptyWebSocket {
+      CONNECTING = 0;
+      OPEN = 1;
+      CLOSING = 2;
+      CLOSED = 3;
+      readyState = this.CONNECTING;
+      onopen?: () => void;
+      onmessage?: (event: { data: string }) => void;
+      onerror?: () => void;
+      onclose?: () => void;
+
+      constructor() {
+        setTimeout(() => {
+          this.readyState = this.OPEN;
+          this.onopen?.();
+        }, 0);
+      }
+
+      send() {
+        setTimeout(() => {
+          this.onmessage?.({ data: JSON.stringify(["EOSE", "sub"]) });
+          this.readyState = this.CLOSED;
+          this.onclose?.();
+        }, 0);
+      }
+
+      close() {
+        this.readyState = this.CLOSED;
+      }
+    }
+
+    (globalThis as any).WebSocket = EmptyWebSocket as any;
+
+    const filters = [{ kinds: [10019], authors: [pubkeyHex] }];
+    const events = await queryNostr(filters, {
+      preferFundstr: true,
+      wsTimeoutMs: 50,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe("http-event-empty");
   });
 });


### PR DESCRIPTION
## Summary
- expand the relay client with npub-to-hex normalization, Fundstr-first WS/HTTP fallback, and helpers for Nutzap profile & tier queries
- update Find Creators workflows, creator stores, and Nutzap profile publishing to use the centralized relay client and relay hints
- harden service-worker and documentation around relay access and add targeted vitest coverage for relay fallback behaviour

## Testing
- pnpm test
- pnpm vitest run test/vitest/__tests__/relayClient.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cba3293fe8833098c753502849eccb