### PR TITLE
Ensure Nutzap publishes send valid events

### DIFF
--- a/docs/relay-access.md
+++ b/docs/relay-access.md
@@ -9,7 +9,7 @@ point for issuing queries and publishing Nutzap events.
 1. The client always **prefers the isolated Fundstr relay**
    (`wss://relay.fundstr.me`).
 2. Every query begins with a WebSocket REQ/EOSE round-trip. Connections are
-   bounded by an 8–12&nbsp;s timeout.
+   bounded by a ~1.5&nbsp;s timeout to keep the UI responsive.
 3. If the socket cannot be opened or returns no events, the client
    automatically performs the same query over HTTP:
    `https://relay.fundstr.me/req?filters=…`.
@@ -27,6 +27,15 @@ Publishing Nutzap events uses a direct HTTP POST to
 like `{ ok, id, accepted, message }`. Callers must treat a publish as successful
 **only** when `accepted === true`. When `accepted` is false the provided relay
 `message` should be surfaced to the user verbatim.
+
+**Important:** before publishing, always convert signed `NDKEvent` instances to
+plain NIP-01 events (`{id,pubkey,created_at,kind,tags,content,sig}`) and let the
+client-side guard reject malformed payloads. Fundstr continues to prefer the
+first-party websocket with the short timeout above and transparently falls back
+to `GET /req` when it cannot return data. Deep links such as
+`/creator/:npubOrHex` immediately open the tiers dialog, showing a spinner until
+profile/tier data resolves and surfacing the relay error banner + retry control
+if the lookup fails.
 
 ## Key normalisation
 

--- a/src/nostr/eventUtils.ts
+++ b/src/nostr/eventUtils.ts
@@ -1,0 +1,30 @@
+export type NostrEvent = {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: string[][];
+  content: string;
+  sig: string;
+};
+
+export function toPlainNostrEvent(ev: any): NostrEvent {
+  // Prefer toNostrEvent() (NDK >= 0.8), fallback rawEvent() (older NDK), else assume plain.
+  const e = typeof ev?.toNostrEvent === 'function'
+    ? ev.toNostrEvent()
+    : (typeof ev?.rawEvent === 'function' ? ev.rawEvent() : ev);
+
+  const ok = e &&
+    typeof e.id === 'string' &&
+    typeof e.pubkey === 'string' &&
+    typeof e.created_at === 'number' &&
+    typeof e.kind === 'number' &&
+    Array.isArray(e.tags) &&
+    typeof e.content === 'string' &&
+    typeof e.sig === 'string';
+
+  if (!ok) {
+    throw new Error('client: bad event (missing id/pubkey/created_at/kind/tags/content/sig)');
+  }
+  return e as NostrEvent;
+}

--- a/src/nostr/relayClient.ts
+++ b/src/nostr/relayClient.ts
@@ -1,5 +1,7 @@
 import { nip19 } from "nostr-tools";
 import { bytesToHex } from "@noble/hashes/utils";
+import type { NostrEvent } from "./eventUtils";
+export type { NostrEvent } from "./eventUtils";
 
 export type Filter = {
   ids?: string[];
@@ -9,16 +11,6 @@ export type Filter = {
   until?: number;
   limit?: number;
   [key: `#${string}`]: string[] | number[] | undefined;
-};
-
-export type NostrEvent = {
-  id: string;
-  pubkey: string;
-  created_at: number;
-  kind: number;
-  tags: string[][];
-  content: string;
-  sig: string;
 };
 
 export type QueryOptions = {
@@ -434,6 +426,18 @@ export async function publishNostr(
   accepted?: boolean;
   message?: string;
 }> {
+  const valid =
+    !!evt &&
+    typeof evt.id === "string" &&
+    typeof evt.pubkey === "string" &&
+    typeof evt.created_at === "number" &&
+    typeof evt.kind === "number" &&
+    Array.isArray(evt.tags) &&
+    typeof evt.content === "string" &&
+    typeof evt.sig === "string";
+  if (!valid) {
+    return { ok: true, accepted: false, message: "client: bad event (missing fields)" };
+  }
   const res = await fetch(`${FUNDSTR.http}/event`, {
     method: "POST",
     headers: {

--- a/src/nutzap/publish.ts
+++ b/src/nutzap/publish.ts
@@ -3,6 +3,7 @@ import { NUTZAP_PROFILE_KIND, NUTZAP_TIERS_KIND } from './relayConfig';
 import { getNutzapNdk } from './ndkInstance';
 import type { Tier, NutzapProfileContent } from './types';
 import { publishNostr } from '@/nostr/relayClient';
+import { toPlainNostrEvent } from '@/nostr/eventUtils';
 
 /** Publish kind:10019 Nutzap profile; WS first (if allowed), else HTTP. */
 export async function publishNutzapProfile(
@@ -15,7 +16,8 @@ export async function publishNutzapProfile(
   ev.content = JSON.stringify(content);
   ev.tags = tags;
   await ev.sign(); // must have signer configured globally or via NDK signer
-  const ack = await publishNostr(ev.toNostrEvent());
+  const nostrEvent = toPlainNostrEvent(ev);
+  const ack = await publishNostr(nostrEvent);
   if (!ack.accepted) {
     throw new Error(ack.message || "Relay rejected Nutzap profile");
   }
@@ -33,7 +35,8 @@ export async function publishTierDefinitions(tiers: Tier[]) {
   ];
   ev.content = JSON.stringify(tiers);
   await ev.sign();
-  const ack = await publishNostr(ev.toNostrEvent());
+  const nostrEvent = toPlainNostrEvent(ev);
+  const ack = await publishNostr(nostrEvent);
   if (!ack.accepted) {
     throw new Error(ack.message || "Relay rejected tier definitions");
   }

--- a/test/vitest/__tests__/publish.spec.ts
+++ b/test/vitest/__tests__/publish.spec.ts
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  dedup,
+  normalizeEvents,
+  pickLatestAddrReplaceable,
+  pickLatestReplaceable,
+  publishNostr,
+  queryNostr,
+  type NostrEvent,
+} from "@/nostr/relayClient";
+import { publishNutzapProfile } from "@/nutzap/publish";
+
+vi.mock("@/nutzap/ndkInstance", () => ({
+  getNutzapNdk: vi.fn(() => ({})),
+}));
+
+let mockIdCounter = 0;
+
+vi.mock("@nostr-dev-kit/ndk", () => {
+  class MockNDKEvent {
+    kind = 0;
+    content = "";
+    tags: string[][] = [];
+    id = "";
+    pubkey = "f".repeat(64);
+    created_at = 0;
+    sig = "";
+
+    constructor(public ndk: unknown) {
+      void ndk;
+    }
+
+    async sign() {
+      mockIdCounter += 1;
+      this.id = `mock-id-${mockIdCounter}`;
+      this.created_at = 1_700_000_000 + mockIdCounter;
+      this.sig = `sig-${mockIdCounter}`;
+    }
+
+    toNostrEvent() {
+      return {
+        id: this.id || `mock-id-${mockIdCounter}`,
+        pubkey: this.pubkey,
+        created_at: this.created_at || 1_700_000_000,
+        kind: this.kind,
+        tags: Array.isArray(this.tags) ? this.tags : [],
+        content: typeof this.content === "string" ? this.content : "",
+        sig: this.sig || `sig-${mockIdCounter}`,
+      } satisfies NostrEvent;
+    }
+  }
+
+  return { NDKEvent: MockNDKEvent };
+});
+
+const originalFetch = globalThis.fetch;
+const originalWebSocket = (globalThis as any).WebSocket;
+
+beforeEach(() => {
+  mockIdCounter = 0;
+  globalThis.fetch = originalFetch;
+  (globalThis as any).WebSocket = originalWebSocket;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  (globalThis as any).WebSocket = originalWebSocket;
+});
+
+function makeEvent(partial: Partial<NostrEvent>): NostrEvent {
+  return {
+    id: "evt" + Math.random().toString(36).slice(2),
+    pubkey: "p".repeat(64),
+    created_at: Math.floor(Date.now() / 1000),
+    kind: 1,
+    tags: [],
+    content: "",
+    sig: "sig",
+    ...partial,
+  };
+}
+
+describe("publish safeguards", () => {
+  it("rejects malformed events before posting", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await publishNostr({} as any);
+
+    expect(result).toEqual({
+      ok: true,
+      accepted: false,
+      message: "client: bad event (missing fields)",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces relay errors when publish is rejected", async () => {
+    const ack = { ok: true, accepted: false, message: "AUTH required" };
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify(ack), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(
+      publishNutzapProfile(
+        { p2pkPubkey: "p".repeat(64), relays: [], trustedMints: [] },
+        [],
+      ),
+    ).rejects.toThrow("AUTH required");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("transport fallbacks", () => {
+  it("falls back to HTTP when Fundstr websocket cannot connect", async () => {
+    const pubkeyHex = "a".repeat(64);
+    const responseEvents = [
+      makeEvent({ id: "http-event", kind: 10019, pubkey: pubkeyHex }),
+    ];
+
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify(responseEvents), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    class ThrowingWebSocket {
+      constructor() {
+        throw new Error("connect failed");
+      }
+    }
+
+    (globalThis as any).WebSocket = ThrowingWebSocket as any;
+
+    const filters = [{ kinds: [10019], authors: [pubkeyHex] }];
+    const events = await queryNostr(filters, { preferFundstr: true, wsTimeoutMs: 5 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe("http-event");
+  });
+});
+
+describe("replaceable semantics", () => {
+  it("keeps only the latest profile and tier definitions", () => {
+    const duplicate = makeEvent({ id: "dup", created_at: 100, kind: 1 });
+    const profileOld = makeEvent({
+      id: "profile-old",
+      kind: 10019,
+      pubkey: "alice",
+      created_at: 50,
+    });
+    const profileNew = makeEvent({
+      id: "profile-new",
+      kind: 10019,
+      pubkey: "alice",
+      created_at: 60,
+    });
+    const tiersOld = makeEvent({
+      id: "tiers-old",
+      kind: 30019,
+      pubkey: "alice",
+      created_at: 70,
+      tags: [["d", "tiers"]],
+    });
+    const tiersNew = makeEvent({
+      id: "tiers-new",
+      kind: 30019,
+      pubkey: "alice",
+      created_at: 80,
+      tags: [["d", "tiers"]],
+    });
+
+    const events: NostrEvent[] = [
+      duplicate,
+      { ...duplicate },
+      profileOld,
+      profileNew,
+      tiersOld,
+      tiersNew,
+    ];
+
+    const deduped = dedup(events);
+    expect(deduped.filter((ev) => ev.id === "dup")).toHaveLength(1);
+
+    const normalized = normalizeEvents(events);
+    const latestProfile = pickLatestReplaceable(normalized, {
+      kind: 10019,
+      pubkey: "alice",
+    });
+    const latestTiers = pickLatestAddrReplaceable(normalized, {
+      kind: 30019,
+      pubkey: "alice",
+      d: "tiers",
+    });
+
+    expect(latestProfile?.id).toBe("profile-new");
+    expect(latestTiers?.id).toBe("tiers-new");
+  });
+});


### PR DESCRIPTION
## Summary
- add a nostr event utility to coerce and validate signed events before publishing
- harden Nutzap publish helpers and relay client guard to surface relay rejections
- document the publish/fallback expectations and add regression tests around publish safety

## Testing
- pnpm test
- pnpm vitest run test/vitest/__tests__/publish.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cbd73c72548330b1db917cc61e43a8