### PR TITLE
Rework Nutzap profile page for Fundstr relay helpers

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -6,9 +6,48 @@
     </div>
 
     <q-card class="q-pa-md">
+      <div class="text-subtitle1 q-mb-sm">Author &amp; Tier Kind</div>
+      <q-input
+        v-model="authorInput"
+        label="Author (npub or 64-hex pubkey)"
+        dense
+        filled
+        :error="!!authorError"
+        :error-message="authorError"
+        class="q-mb-sm"
+      />
+      <div class="row items-center justify-between q-mb-sm">
+        <q-option-group
+          v-model="tierKind"
+          :options="tierKindOptions"
+          type="radio"
+          color="primary"
+          inline
+        />
+        <div class="row items-center q-gutter-sm">
+          <div class="text-caption text-2" v-if="authorHex">Author hex: {{ authorHex }}</div>
+          <q-btn
+            color="primary"
+            label="Load from Relay"
+            dense
+            :loading="loading"
+            @click="loadAll"
+          />
+        </div>
+      </div>
+      <div class="text-caption text-2">
+        Canonical kind 30019 is recommended. Legacy 30000 is available for backward compatibility.
+      </div>
+      <q-banner v-if="loadError" class="bg-negative text-white q-mt-sm">
+        {{ loadError }}
+      </q-banner>
+      <q-banner v-else-if="lastLoadedInfo" class="bg-positive text-white q-mt-sm">
+        {{ lastLoadedInfo }}
+      </q-banner>
+    </q-card>
+
+    <q-card class="q-pa-md">
       <div class="text-subtitle1 q-mb-sm">Payment Profile (kind 10019)</div>
-      <q-input v-model="displayName" label="Display Name" dense filled class="q-mb-sm" />
-      <q-input v-model="pictureUrl" label="Picture URL" dense filled class="q-mb-sm" />
       <q-input v-model="p2pkPub" label="P2PK Public Key" dense filled class="q-mb-sm" />
       <q-input
         v-model="mintsText"
@@ -17,16 +56,28 @@
         dense
         filled
         autogrow
+        class="q-mb-sm"
       />
+      <q-input
+        v-model="relaysText"
+        type="textarea"
+        label="Relay Hints (optional, one per line)"
+        dense
+        filled
+        autogrow
+      />
+      <div class="text-caption text-2 q-mt-sm" v-if="tierAddress">
+        Tier address: {{ tierAddress }}
+      </div>
     </q-card>
 
     <q-card class="q-pa-md">
       <div class="row items-center justify-between q-mb-sm">
-        <div class="text-subtitle1">Tiers ({{ tiers.length }}) — kind {{ tierKindLabel }}</div>
+        <div class="text-subtitle1">Tiers ({{ tiers.length }}) — kind {{ tierKind }}</div>
         <q-btn dense color="primary" label="Add Tier" @click="openNewTier" />
       </div>
       <div class="text-caption text-2 q-mb-sm">
-        Each tier is published as parameterized replaceable event ["d","tiers"] on relay.fundstr.me.
+        Each tier publishes as a replaceable event with tag ["d","tiers"] on relay.fundstr.me.
       </div>
       <q-list bordered separator v-if="tiers.length">
         <q-item v-for="tier in tiers" :key="tier.id">
@@ -49,17 +100,29 @@
       <div v-else class="text-caption text-2">No tiers yet. Add at least one tier before publishing.</div>
     </q-card>
 
-    <q-card class="q-pa-md">
-      <q-btn
-        color="primary"
-        :disable="publishDisabled"
-        :loading="publishing"
-        label="Publish Nutzap Profile"
-        @click="publishAll"
-      />
-      <div class="text-caption q-mt-sm" v-if="lastPublishInfo">
-        Last publish: {{ lastPublishInfo }}
+    <q-card class="q-pa-md column q-gutter-sm">
+      <div class="row q-gutter-sm">
+        <q-btn
+          color="primary"
+          :disable="publishTiersDisabled"
+          :loading="publishingTiers"
+          label="Publish Tiers"
+          @click="publishTiers"
+        />
+        <q-btn
+          color="primary"
+          :disable="publishProfileDisabled"
+          :loading="publishingProfile"
+          label="Publish Profile"
+          @click="publishProfile"
+        />
       </div>
+      <q-banner v-if="tiersAck" class="bg-positive text-white">
+        Published tiers to relay.fundstr.me (id: {{ tiersAck.id }})
+      </q-banner>
+      <q-banner v-if="profileAck" class="bg-positive text-white">
+        Published profile to relay.fundstr.me (id: {{ profileAck.id }})
+      </q-banner>
     </q-card>
 
     <q-dialog v-model="showTierDialog" @hide="resetTierForm">
@@ -111,31 +174,63 @@
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { v4 as uuidv4 } from 'uuid';
 import RelayStatusIndicator from 'src/nutzap/RelayStatusIndicator.vue';
-import { computed } from 'vue';
-import { useNutzapProfile } from 'src/nutzap/useNutzapProfile';
-import { NUTZAP_TIERS_KIND } from 'src/nutzap/relayConfig';
+import { notifyError, notifySuccess } from 'src/js/notify';
+import type { Tier } from 'src/nutzap/types';
+import {
+  normalizeAuthor,
+  fundstrFirstQuery,
+  pickLatestParamReplaceable,
+  pickLatestReplaceable,
+  publishNostrEvent,
+  type NostrFilter,
+} from './nutzap-profile/nostrHelpers';
+import { NUTZAP_RELAY_WSS } from 'src/nutzap/relayConfig';
 
-const {
-  displayName,
-  pictureUrl,
-  p2pkPub,
-  mintsText,
-  tiers,
-  tierForm,
-  showTierDialog,
-  publishing,
-  lastPublishInfo,
-  publishDisabled,
-  tierFrequencies,
-  editTier,
-  removeTier,
-  saveTier,
-  resetTierForm,
-  publishAll,
-} = useNutzapProfile();
+const tierFrequencies: Tier['frequency'][] = ['one_time', 'monthly', 'yearly'];
 
-const tierKindLabel = computed(() => NUTZAP_TIERS_KIND);
+type TierFormState = {
+  id: string;
+  title: string;
+  price: number;
+  frequency: Tier['frequency'];
+  description: string;
+  mediaCsv: string;
+};
+
+const authorInput = ref('');
+const authorHex = ref('');
+const authorError = ref('');
+const tierKind = ref<30019 | 30000>(30019);
+
+const p2pkPub = ref('');
+const mintsText = ref('');
+const relaysText = ref(NUTZAP_RELAY_WSS);
+const tiers = ref<Tier[]>([]);
+const tierForm = ref<TierFormState>({
+  id: '',
+  title: '',
+  price: 0,
+  frequency: 'monthly',
+  description: '',
+  mediaCsv: '',
+});
+const showTierDialog = ref(false);
+
+const loading = ref(false);
+const loadError = ref('');
+const lastLoadedInfo = ref('');
+const publishingProfile = ref(false);
+const publishingTiers = ref(false);
+const profileAck = ref<{ id?: string } | null>(null);
+const tiersAck = ref<{ id?: string } | null>(null);
+
+const tierKindOptions = [
+  { label: 'Canonical 30019', value: 30019 },
+  { label: 'Legacy 30000', value: 30000 },
+];
 
 const tierFrequencyOptions = computed(() =>
   tierFrequencies.map(value => ({
@@ -149,12 +244,384 @@ const tierFrequencyOptions = computed(() =>
   }))
 );
 
+const mintList = computed(() =>
+  mintsText.value
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean)
+);
+
+const relayList = computed(() =>
+  relaysText.value
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean)
+);
+
+const tierAddress = computed(() => {
+  if (!authorHex.value) return '';
+  return `${tierKind.value}:${authorHex.value}:tiers`;
+});
+
+const publishProfileDisabled = computed(
+  () =>
+    publishingProfile.value ||
+    !authorHex.value ||
+    !p2pkPub.value.trim() ||
+    mintList.value.length === 0
+);
+
+const publishTiersDisabled = computed(
+  () => publishingTiers.value || !authorHex.value || tiers.value.length === 0
+);
+
+watch(authorInput, value => {
+  profileAck.value = null;
+  tiersAck.value = null;
+  if (!value.trim()) {
+    authorHex.value = '';
+    authorError.value = '';
+    return;
+  }
+  try {
+    authorHex.value = normalizeAuthor(value);
+    authorError.value = '';
+  } catch (e: any) {
+    authorHex.value = '';
+    authorError.value = e?.message ?? 'Invalid author input';
+  }
+});
+
+function toMediaCsv(media?: { type: string; url: string }[]) {
+  if (!media) return '';
+  return media
+    .map(item => item?.url)
+    .filter((url): url is string => typeof url === 'string' && !!url)
+    .join(', ');
+}
+
+function mapJsonTier(raw: any): Tier | null {
+  if (!raw) return null;
+  const id = typeof raw.id === 'string' && raw.id ? raw.id : uuidv4();
+  const title = typeof raw.title === 'string' ? raw.title : '';
+  const price = Number(raw.price ?? raw.price_sats ?? 0);
+  const validFrequency = tierFrequencies.includes(raw.frequency)
+    ? raw.frequency
+    : 'monthly';
+  const description = typeof raw.description === 'string' ? raw.description : undefined;
+  let media: { type: string; url: string }[] | undefined;
+  if (Array.isArray(raw.media)) {
+    media = raw.media
+      .map((item: any) => {
+        if (!item) return null;
+        if (typeof item === 'string') {
+          return { type: 'link', url: item };
+        }
+        const url = typeof item.url === 'string' ? item.url : '';
+        if (!url) return null;
+        const type = typeof item.type === 'string' ? item.type : 'link';
+        return { type, url };
+      })
+      .filter((entry): entry is { type: string; url: string } => !!entry);
+  }
+  return {
+    id,
+    title,
+    price,
+    frequency: validFrequency,
+    description,
+    media,
+  };
+}
+
+function resetTierForm() {
+  tierForm.value = {
+    id: '',
+    title: '',
+    price: 0,
+    frequency: 'monthly',
+    description: '',
+    mediaCsv: '',
+  };
+}
+
 function openNewTier() {
   resetTierForm();
   showTierDialog.value = true;
 }
 
-function frequencyLabel(value: (typeof tierFrequencies)[number]) {
+function editTier(tier: Tier) {
+  tierForm.value = {
+    id: tier.id,
+    title: tier.title,
+    price: tier.price,
+    frequency: tier.frequency,
+    description: tier.description ?? '',
+    mediaCsv: toMediaCsv(tier.media),
+  };
+  showTierDialog.value = true;
+}
+
+function removeTier(id: string) {
+  tiers.value = tiers.value.filter(t => t.id !== id);
+}
+
+function saveTier() {
+  const form = tierForm.value;
+  const media = form.mediaCsv
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+    .map(url => ({ type: 'link', url }));
+  const tier: Tier = {
+    id: form.id || uuidv4(),
+    title: form.title.trim(),
+    price: Number(form.price) || 0,
+    frequency: form.frequency,
+    description: form.description ? form.description.trim() : undefined,
+    media: media.length ? media : undefined,
+  };
+
+  if (form.id) {
+    tiers.value = tiers.value.map(t => (t.id === form.id ? tier : t));
+  } else {
+    tiers.value = [...tiers.value, tier];
+  }
+
+  resetTierForm();
+}
+
+function frequencyLabel(value: Tier['frequency']) {
   return value === 'one_time' ? 'one-time' : value;
 }
+
+function buildProfileContent(params: {
+  p2pk: string;
+  mints: string[];
+  relays: string[];
+  authorHex: string;
+  tiersKind: number;
+}) {
+  return JSON.stringify({
+    v: 1,
+    p2pk: params.p2pk,
+    mints: params.mints,
+    relays: params.relays,
+    tierAddr: `${params.tiersKind}:${params.authorHex}:tiers`,
+  });
+}
+
+async function loadProfile(author: string) {
+  const filters: NostrFilter[] = [
+    {
+      kinds: [10019],
+      authors: [author],
+      limit: 1,
+    },
+  ];
+  const events = await fundstrFirstQuery(filters);
+  const event = pickLatestReplaceable(events);
+  if (!event) {
+    p2pkPub.value = '';
+    if (!mintsText.value) mintsText.value = '';
+    return;
+  }
+  try {
+    const content = event.content ? JSON.parse(event.content) : {};
+    if (typeof content.p2pk === 'string') {
+      p2pkPub.value = content.p2pk;
+    }
+    if (Array.isArray(content.mints)) {
+      mintsText.value = content.mints.join('\n');
+    }
+    if (Array.isArray(content.relays) && content.relays.length > 0) {
+      relaysText.value = content.relays.join('\n');
+    }
+    if (typeof content.tierAddr === 'string') {
+      const [kindPart, authorPart] = content.tierAddr.split(':');
+      const parsedKind = Number(kindPart);
+      if ((parsedKind === 30019 || parsedKind === 30000) && authorPart?.toLowerCase() === author) {
+        tierKind.value = parsedKind;
+      }
+    }
+  } catch (e) {
+    console.warn('[nutzap-profile] failed to parse profile content', e);
+  }
+  lastLoadedInfo.value = `Loaded profile event ${event.id}`;
+}
+
+async function loadTiers(author: string) {
+  const canonicalFilters: NostrFilter[] = [
+    {
+      kinds: [30019],
+      authors: [author],
+      '#d': ['tiers'],
+      limit: 1,
+    },
+  ];
+  const canonicalEvents = await fundstrFirstQuery(canonicalFilters);
+  let selected = pickLatestParamReplaceable(canonicalEvents);
+  let selectedKind: 30019 | 30000 = 30019;
+  if (!selected) {
+    const legacyFilters: NostrFilter[] = [
+      {
+        kinds: [30000],
+        authors: [author],
+        '#d': ['tiers'],
+        limit: 1,
+      },
+    ];
+    const legacyEvents = await fundstrFirstQuery(legacyFilters);
+    selected = pickLatestReplaceable(legacyEvents);
+    selectedKind = 30000;
+  }
+  if (!selected) {
+    tiers.value = [];
+    return;
+  }
+  try {
+    const parsed = selected.content ? JSON.parse(selected.content) : {};
+    const tierArray = Array.isArray(parsed?.tiers)
+      ? parsed.tiers
+      : Array.isArray(parsed)
+        ? parsed
+        : [];
+    tiers.value = tierArray
+      .map(mapJsonTier)
+      .filter((t): t is Tier => !!t);
+    tierKind.value = selectedKind;
+  } catch (e) {
+    console.warn('[nutzap-profile] failed to parse tier content', e);
+  }
+  lastLoadedInfo.value = `Loaded tiers event ${selected.id}`;
+}
+
+async function loadAll() {
+  if (!authorInput.value.trim()) {
+    notifyError('Enter an author npub or hex pubkey.');
+    return;
+  }
+  try {
+    const normalized = normalizeAuthor(authorInput.value);
+    authorHex.value = normalized;
+    authorError.value = '';
+  } catch (e: any) {
+    authorHex.value = '';
+    authorError.value = e?.message ?? 'Invalid author input';
+    notifyError(authorError.value);
+    return;
+  }
+
+  loading.value = true;
+  loadError.value = '';
+  lastLoadedInfo.value = '';
+  try {
+    await loadProfile(authorHex.value);
+    await loadTiers(authorHex.value);
+  } catch (e: any) {
+    console.error('[nutzap-profile] load failed', e);
+    loadError.value = e?.message ?? 'Failed to load from relay.';
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function publishTiers() {
+  if (!authorHex.value) {
+    notifyError('Author must be a valid npub or hex pubkey.');
+    return;
+  }
+  if (tiers.value.length === 0) {
+    notifyError('Add at least one tier before publishing.');
+    return;
+  }
+  publishingTiers.value = true;
+  tiersAck.value = null;
+  try {
+    const content = JSON.stringify({
+      v: 1,
+      tiers: tiers.value.map(t => ({
+        id: t.id,
+        title: t.title,
+        price: t.price,
+        frequency: t.frequency,
+        description: t.description,
+        media: t.media,
+      })),
+    });
+    const tags = [
+      ['d', 'tiers'],
+      ['t', 'nutzap-tiers'],
+      ['client', 'fundstr'],
+    ];
+    const ack = await publishNostrEvent({
+      kind: tierKind.value,
+      tags,
+      content,
+    });
+    tiersAck.value = ack;
+    notifySuccess(`Tiers published to relay.fundstr.me (id: ${ack?.id})`);
+    await loadTiers(authorHex.value);
+  } catch (e: any) {
+    console.error('[nutzap-profile] publish tiers failed', e);
+    notifyError(e?.message ?? 'Unable to publish tiers.');
+  } finally {
+    publishingTiers.value = false;
+  }
+}
+
+async function publishProfile() {
+  if (!authorHex.value) {
+    notifyError('Author must be a valid npub or hex pubkey.');
+    return;
+  }
+  if (!p2pkPub.value.trim()) {
+    notifyError('P2PK public key is required.');
+    return;
+  }
+  if (mintList.value.length === 0) {
+    notifyError('Add at least one trusted mint URL.');
+    return;
+  }
+  publishingProfile.value = true;
+  profileAck.value = null;
+  try {
+    const content = buildProfileContent({
+      p2pk: p2pkPub.value.trim(),
+      mints: mintList.value,
+      relays: relayList.value,
+      authorHex: authorHex.value,
+      tiersKind: tierKind.value,
+    });
+    const tags: any[] = [
+      ['t', 'nutzap-profile'],
+      ['client', 'fundstr'],
+    ];
+    mintList.value.forEach(mint => {
+      tags.push(['mint', mint, 'sat']);
+    });
+    relayList.value.forEach(relay => {
+      tags.push(['relay', relay]);
+    });
+    const ack = await publishNostrEvent({
+      kind: 10019,
+      tags,
+      content,
+    });
+    profileAck.value = ack;
+    notifySuccess(`Profile published to relay.fundstr.me (id: ${ack?.id})`);
+    await loadProfile(authorHex.value);
+  } catch (e: any) {
+    console.error('[nutzap-profile] publish profile failed', e);
+    notifyError(e?.message ?? 'Unable to publish Nutzap profile.');
+  } finally {
+    publishingProfile.value = false;
+  }
+}
+
+onMounted(() => {
+  if (authorInput.value.trim()) {
+    void loadAll();
+  }
+});
 </script>

--- a/src/pages/nutzap-profile/nostrHelpers.ts
+++ b/src/pages/nutzap-profile/nostrHelpers.ts
@@ -1,0 +1,230 @@
+import { nip19 } from 'nostr-tools';
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import { getNutzapNdk } from 'src/nutzap/ndkInstance';
+
+export type NostrEvent = {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: any[];
+  content: string;
+  sig: string;
+};
+
+export type NostrFilter = {
+  kinds: number[];
+  authors: string[];
+  '#d'?: string[];
+  limit?: number;
+};
+
+const HEX_64_REGEX = /^[0-9a-f]{64}$/i;
+const HEX_128_REGEX = /^[0-9a-f]{128}$/i;
+
+export function normalizeAuthor(input: string): string {
+  if (typeof input !== 'string') {
+    throw new Error('Author must be a string.');
+  }
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('Author is required.');
+  }
+  if (HEX_64_REGEX.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  if (/^npub[0-9a-z]+$/i.test(trimmed)) {
+    const decoded = nip19.decode(trimmed);
+    if (decoded.type !== 'npub' || typeof decoded.data !== 'string') {
+      throw new Error('Invalid npub.');
+    }
+    if (!HEX_64_REGEX.test(decoded.data)) {
+      throw new Error('npub does not decode to 64-hex.');
+    }
+    return decoded.data.toLowerCase();
+  }
+  throw new Error('Author must be npub or 64-hex.');
+}
+
+export function isNostrEvent(e: any): e is NostrEvent {
+  if (!e || typeof e !== 'object') return false;
+  if (typeof e.id !== 'string' || !HEX_64_REGEX.test(e.id)) return false;
+  if (typeof e.pubkey !== 'string' || !HEX_64_REGEX.test(e.pubkey)) return false;
+  if (typeof e.created_at !== 'number' || !Number.isInteger(e.created_at)) return false;
+  if (typeof e.kind !== 'number' || !Number.isInteger(e.kind)) return false;
+  if (!Array.isArray(e.tags)) return false;
+  if (typeof e.content !== 'string') return false;
+  if (typeof e.sig !== 'string' || !HEX_128_REGEX.test(e.sig)) return false;
+  return true;
+}
+
+function extractDTag(event: any): string | undefined {
+  if (!event || !Array.isArray(event.tags)) return undefined;
+  for (const tag of event.tags) {
+    if (Array.isArray(tag) && tag[0] === 'd' && typeof tag[1] === 'string') {
+      return tag[1];
+    }
+  }
+  return undefined;
+}
+
+export function pickLatestReplaceable(events: any[]): any | null {
+  if (!Array.isArray(events) || events.length === 0) return null;
+  const latestByKey = new Map<string, any>();
+  for (const event of events) {
+    if (!event || typeof event.kind !== 'number' || typeof event.pubkey !== 'string') continue;
+    const key = `${event.kind}:${event.pubkey}`;
+    const current = latestByKey.get(key);
+    if (!current || (event.created_at ?? 0) > (current.created_at ?? 0)) {
+      latestByKey.set(key, event);
+    }
+  }
+  const candidates = Array.from(latestByKey.values());
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0));
+  return candidates[0] ?? null;
+}
+
+export function pickLatestParamReplaceable(events: any[]): any | null {
+  if (!Array.isArray(events) || events.length === 0) return null;
+  const latestByKey = new Map<string, any>();
+  for (const event of events) {
+    if (!event || typeof event.kind !== 'number' || typeof event.pubkey !== 'string') continue;
+    const d = extractDTag(event);
+    if (!d) continue;
+    const key = `${event.kind}:${event.pubkey}:${d}`;
+    const current = latestByKey.get(key);
+    if (!current || (event.created_at ?? 0) > (current.created_at ?? 0)) {
+      latestByKey.set(key, event);
+    }
+  }
+  const candidates = Array.from(latestByKey.values());
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0));
+  return candidates[0] ?? null;
+}
+
+export async function fundstrFirstQuery(filters: NostrFilter[], wsTimeoutMs = 1500): Promise<any[]> {
+  const wsEvents = await queryViaWebSocket(filters, wsTimeoutMs);
+  if (wsEvents.length > 0) {
+    return wsEvents;
+  }
+  return queryViaHttp(filters);
+}
+
+async function queryViaWebSocket(filters: NostrFilter[], wsTimeoutMs: number): Promise<any[]> {
+  if (typeof WebSocket === 'undefined') {
+    return [];
+  }
+  return new Promise(resolve => {
+    const events: any[] = [];
+    let settled = false;
+    const subId = `fundstr-${Math.random().toString(36).slice(2, 10)}`;
+    const ws = new WebSocket('wss://relay.fundstr.me');
+    const finalize = () => {
+      if (settled) return;
+      settled = true;
+      try {
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+          ws.close();
+        }
+      } catch (e) {
+        console.warn('[fundstrFirstQuery] failed to close websocket', e);
+      }
+      resolve(events);
+    };
+    const timer = setTimeout(finalize, wsTimeoutMs);
+
+    ws.onopen = () => {
+      try {
+        ws.send(JSON.stringify(['REQ', subId, ...filters]));
+      } catch (e) {
+        console.warn('[fundstrFirstQuery] failed to send ws request', e);
+        finalize();
+      }
+    };
+
+    ws.onmessage = raw => {
+      try {
+        const msg = JSON.parse(raw.data);
+        if (!Array.isArray(msg)) return;
+        const [type, incomingSubId, payload] = msg;
+        if (type === 'EVENT' && incomingSubId === subId && payload) {
+          events.push(payload);
+        }
+        if (type === 'EOSE' && incomingSubId === subId) {
+          clearTimeout(timer);
+          finalize();
+        }
+      } catch (e) {
+        console.warn('[fundstrFirstQuery] failed to parse ws message', e);
+      }
+    };
+
+    ws.onerror = () => {
+      clearTimeout(timer);
+      finalize();
+    };
+
+    ws.onclose = () => {
+      clearTimeout(timer);
+      finalize();
+    };
+  });
+}
+
+async function queryViaHttp(filters: NostrFilter[]): Promise<any[]> {
+  try {
+    const encoded = encodeURIComponent(JSON.stringify(filters));
+    const response = await fetch(`https://relay.fundstr.me/req?filters=${encoded}`);
+    if (!response.ok) {
+      console.warn('[fundstrFirstQuery] HTTP query failed', response.status, response.statusText);
+      return [];
+    }
+    const data = await response.json();
+    return Array.isArray(data) ? data : [];
+  } catch (e) {
+    console.warn('[fundstrFirstQuery] HTTP query error', e);
+    return [];
+  }
+}
+
+export async function publishNostrEvent(template: {
+  kind: number;
+  tags: any[];
+  content: string;
+  created_at?: number;
+}): Promise<{ ok?: boolean; accepted?: boolean; id?: string; message?: string }> {
+  const created_at = template.created_at ?? Math.floor(Date.now() / 1000);
+  const payload = { ...template, created_at };
+  let signed: any;
+  const nostr = (globalThis as any)?.nostr;
+  if (nostr?.signEvent) {
+    signed = await nostr.signEvent(payload);
+  } else {
+    const ndk = getNutzapNdk();
+    const ev = new NDKEvent(ndk, payload);
+    await ev.sign();
+    signed = await ev.toNostrEvent();
+  }
+
+  if (!isNostrEvent(signed)) {
+    throw new Error('Not a signed NIP-01 event');
+  }
+
+  const response = await fetch('https://relay.fundstr.me/event', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(signed),
+  });
+  let ack: any = null;
+  try {
+    ack = await response.json();
+  } catch (e) {
+    console.warn('[publishNostrEvent] failed to parse relay response', e);
+  }
+  if (!ack?.accepted) {
+    throw new Error(ack?.message || 'Relay rejected');
+  }
+  return ack;
+}


### PR DESCRIPTION
## Summary
- add Fundstr-specific Nostr helper utilities for the Nutzap profile page
- rebuild the Nutzap profile page around explicit author input, tier kind toggle, and Fundstr-first relay queries
- publish tiers/profile with the required payload schema, tags, and acknowledgment handling

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cd04176b4083309362aba414b91f52