### PR TITLE
Implement Fundstr-first Nutzap profile workflow

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -6,6 +6,32 @@
     </div>
 
     <q-card class="q-pa-md">
+      <div class="text-subtitle1 q-mb-sm">Author</div>
+      <div class="row items-start q-col-gutter-sm">
+        <div class="col">
+          <q-input
+            v-model="authorInput"
+            label="Author (npub or 64-hex pubkey)"
+            dense
+            filled
+            @keyup.enter="applyAuthor"
+          />
+        </div>
+        <div class="col-auto">
+          <q-btn
+            color="primary"
+            label="Load"
+            :loading="loadingProfile || loadingTiers"
+            @click="applyAuthor"
+          />
+        </div>
+      </div>
+      <div class="text-negative text-caption q-mt-sm" v-if="authorError">{{ authorError }}</div>
+      <div class="text-caption text-2 q-mt-sm" v-else-if="authorHex">Author pubkey: {{ authorHex }}</div>
+      <div class="text-caption text-2 q-mt-sm" v-if="lastLoadInfo">{{ lastLoadInfo }}</div>
+    </q-card>
+
+    <q-card class="q-pa-md">
       <div class="text-subtitle1 q-mb-sm">Payment Profile (kind 10019)</div>
       <q-input v-model="displayName" label="Display Name" dense filled class="q-mb-sm" />
       <q-input v-model="pictureUrl" label="Picture URL" dense filled class="q-mb-sm" />
@@ -17,14 +43,32 @@
         dense
         filled
         autogrow
+        class="q-mb-sm"
       />
+      <q-input
+        v-model="relayText"
+        type="textarea"
+        label="Relay Hints (one per line)"
+        dense
+        filled
+        autogrow
+      />
+      <div class="text-caption text-2 q-mt-sm">tierAddr will publish as {{ tierAddress }}</div>
     </q-card>
 
     <q-card class="q-pa-md">
       <div class="row items-center justify-between q-mb-sm">
-        <div class="text-subtitle1">Tiers ({{ tiers.length }}) — kind {{ tierKindLabel }}</div>
+        <div class="text-subtitle1">Tiers ({{ tiers.length }}) — kind {{ selectedTierKind }}</div>
         <q-btn dense color="primary" label="Add Tier" @click="openNewTier" />
       </div>
+      <q-option-group
+        v-model="selectedTierKind"
+        :options="tierKindOptions"
+        type="toggle"
+        color="primary"
+        inline
+        class="q-mb-md"
+      />
       <div class="text-caption text-2 q-mb-sm">
         Each tier is published as parameterized replaceable event ["d","tiers"] on relay.fundstr.me.
       </div>
@@ -50,15 +94,23 @@
     </q-card>
 
     <q-card class="q-pa-md">
-      <q-btn
-        color="primary"
-        :disable="publishDisabled"
-        :loading="publishing"
-        label="Publish Nutzap Profile"
-        @click="publishAll"
-      />
-      <div class="text-caption q-mt-sm" v-if="lastPublishInfo">
-        Last publish: {{ lastPublishInfo }}
+      <div class="column q-gutter-sm">
+        <q-btn
+          color="primary"
+          label="Publish Subscription Tiers"
+          :disable="tiersPublishDisabled"
+          :loading="publishingTiers"
+          @click="publishTiers"
+        />
+        <q-btn
+          color="primary"
+          label="Publish Nutzap Profile"
+          :disable="profilePublishDisabled"
+          :loading="publishingProfile"
+          @click="publishProfile"
+        />
+        <div class="text-caption" v-if="lastTiersPublishInfo">Last tiers publish: {{ lastTiersPublishInfo }}</div>
+        <div class="text-caption" v-if="lastProfilePublishInfo">Last profile publish: {{ lastProfilePublishInfo }}</div>
       </div>
     </q-card>
 
@@ -111,50 +163,425 @@
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { v4 as uuidv4 } from 'uuid';
 import RelayStatusIndicator from 'src/nutzap/RelayStatusIndicator.vue';
-import { computed } from 'vue';
-import { useNutzapProfile } from 'src/nutzap/useNutzapProfile';
-import { NUTZAP_TIERS_KIND } from 'src/nutzap/relayConfig';
+import { notifyError, notifySuccess } from 'src/js/notify';
+import { NUTZAP_RELAY_WSS } from 'src/nutzap/relayConfig';
+import type { Tier } from 'src/nutzap/types';
+import {
+  fundstrFirstQuery,
+  normalizeAuthor,
+  pickLatestParamReplaceable,
+  pickLatestReplaceable,
+  publishNostrEvent,
+} from './nutzap-profile/nostrHelpers';
 
-const {
-  displayName,
-  pictureUrl,
-  p2pkPub,
-  mintsText,
-  tiers,
-  tierForm,
-  showTierDialog,
-  publishing,
-  lastPublishInfo,
-  publishDisabled,
-  tierFrequencies,
-  editTier,
-  removeTier,
-  saveTier,
-  resetTierForm,
-  publishAll,
-} = useNutzapProfile();
+const tierFrequencies: Tier['frequency'][] = ['one_time', 'monthly', 'yearly'];
 
-const tierKindLabel = computed(() => NUTZAP_TIERS_KIND);
+type TierFormState = {
+  id: string;
+  title: string;
+  price: number;
+  frequency: Tier['frequency'];
+  description: string;
+  mediaCsv: string;
+};
+
+function toMediaCsv(media?: { type: string; url: string }[]) {
+  if (!media) return '';
+  return media
+    .map(m => m?.url)
+    .filter((u): u is string => typeof u === 'string' && !!u)
+    .join(', ');
+}
+
+function mapJsonTier(raw: any): Tier | null {
+  if (!raw) return null;
+  const id = typeof raw.id === 'string' && raw.id ? raw.id : uuidv4();
+  const title = typeof raw.title === 'string' ? raw.title : '';
+  const price = Number(raw.price ?? raw.price_sats ?? 0);
+  const frequency = tierFrequencies.includes(raw.frequency) ? raw.frequency : 'monthly';
+  const description = typeof raw.description === 'string' ? raw.description : undefined;
+  const media = Array.isArray(raw.media)
+    ? raw.media
+        .map((m: any) => {
+          if (!m) return null;
+          const url = typeof m.url === 'string' ? m.url : typeof m === 'string' ? m : '';
+          if (!url) return null;
+          const type = typeof m.type === 'string' ? m.type : 'link';
+          return { type, url };
+        })
+        .filter(Boolean) as { type: string; url: string }[]
+    : undefined;
+  return {
+    id,
+    title,
+    price,
+    frequency,
+    description,
+    media,
+  };
+}
+
+const authorInput = ref('');
+const authorHex = ref('');
+const authorError = ref('');
+const lastLoadInfo = ref('');
+const loadingProfile = ref(false);
+const loadingTiers = ref(false);
+
+const displayName = ref('');
+const pictureUrl = ref('');
+const p2pkPub = ref('');
+const mintsText = ref('');
+const relayText = ref(NUTZAP_RELAY_WSS);
+const tiers = ref<Tier[]>([]);
+const tierForm = ref<TierFormState>({
+  id: '',
+  title: '',
+  price: 0,
+  frequency: 'monthly',
+  description: '',
+  mediaCsv: '',
+});
+const showTierDialog = ref(false);
+const publishingProfile = ref(false);
+const publishingTiers = ref(false);
+const lastProfilePublishInfo = ref('');
+const lastTiersPublishInfo = ref('');
+const selectedTierKind = ref<30019 | 30000>(30019);
+
+const tierKindOptions = computed(() => [
+  { label: '30019 (Recommended)', value: 30019 },
+  { label: '30000 (Legacy)', value: 30000 },
+]);
+
+const tierAddress = computed(() => {
+  const author = authorHex.value || 'author-hex';
+  return `${selectedTierKind.value}:${author}:tiers`;
+});
+
+const mintList = computed(() =>
+  mintsText.value
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean)
+);
+
+const relayList = computed(() =>
+  relayText.value
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean)
+);
 
 const tierFrequencyOptions = computed(() =>
   tierFrequencies.map(value => ({
     value,
-    label:
-      value === 'one_time'
-        ? 'One-time'
-        : value === 'monthly'
-          ? 'Monthly'
-          : 'Yearly',
+    label: value === 'one_time' ? 'One-time' : value === 'monthly' ? 'Monthly' : 'Yearly',
   }))
 );
+
+const profilePublishDisabled = computed(
+  () =>
+    publishingProfile.value ||
+    !authorInput.value.trim() ||
+    !p2pkPub.value.trim() ||
+    mintList.value.length === 0
+);
+
+const tiersPublishDisabled = computed(
+  () =>
+    publishingTiers.value ||
+    !authorInput.value.trim() ||
+    tiers.value.length === 0
+);
+
+function resetTierForm() {
+  tierForm.value = {
+    id: '',
+    title: '',
+    price: 0,
+    frequency: 'monthly',
+    description: '',
+    mediaCsv: '',
+  };
+}
 
 function openNewTier() {
   resetTierForm();
   showTierDialog.value = true;
 }
 
+function editTier(tier: Tier) {
+  tierForm.value = {
+    id: tier.id,
+    title: tier.title,
+    price: tier.price,
+    frequency: tier.frequency,
+    description: tier.description ?? '',
+    mediaCsv: toMediaCsv(tier.media),
+  };
+  showTierDialog.value = true;
+}
+
+function removeTier(id: string) {
+  tiers.value = tiers.value.filter(t => t.id !== id);
+}
+
+function saveTier() {
+  const form = tierForm.value;
+  const media = form.mediaCsv
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+    .map(url => ({ type: 'link', url }));
+  const tier: Tier = {
+    id: form.id || uuidv4(),
+    title: form.title.trim(),
+    price: Number(form.price) || 0,
+    frequency: form.frequency,
+    description: form.description ? form.description.trim() : undefined,
+    media: media.length ? media : undefined,
+  };
+
+  if (form.id) {
+    tiers.value = tiers.value.map(t => (t.id === form.id ? tier : t));
+  } else {
+    tiers.value = [...tiers.value, tier];
+  }
+
+  resetTierForm();
+}
+
 function frequencyLabel(value: (typeof tierFrequencies)[number]) {
   return value === 'one_time' ? 'one-time' : value;
 }
+
+function ensureAuthorHex(): string {
+  try {
+    const hex = normalizeAuthor(authorInput.value);
+    authorHex.value = hex;
+    authorError.value = '';
+    return hex;
+  } catch (err: any) {
+    authorError.value = err?.message ?? 'Invalid author';
+    throw err;
+  }
+}
+
+async function loadAuthorData(hex: string) {
+  loadingProfile.value = true;
+  loadingTiers.value = true;
+  try {
+    displayName.value = '';
+    pictureUrl.value = '';
+    p2pkPub.value = '';
+    mintsText.value = '';
+    relayText.value = NUTZAP_RELAY_WSS;
+    tiers.value = [];
+    selectedTierKind.value = 30019;
+
+    const profileFilters = [{ kinds: [10019], authors: [hex], limit: 1 }];
+    const profileEvents = await fundstrFirstQuery(profileFilters);
+    const profileEvent = pickLatestReplaceable(profileEvents);
+
+    if (profileEvent) {
+      try {
+        const content = profileEvent.content ? JSON.parse(profileEvent.content) : {};
+        if (typeof content.p2pk === 'string') {
+          p2pkPub.value = content.p2pk;
+        }
+        if (Array.isArray(content.mints)) {
+          mintsText.value = content.mints.join('\n');
+        }
+        if (Array.isArray(content.relays)) {
+          relayText.value = content.relays.join('\n');
+        }
+        if (typeof content.tierAddr === 'string') {
+          const [kindStr] = content.tierAddr.split(':');
+          const parsedKind = Number(kindStr);
+          if (parsedKind === 30019 || parsedKind === 30000) {
+            selectedTierKind.value = parsedKind;
+          }
+        }
+      } catch (err) {
+        console.warn('[nutzap] failed to parse profile content', err);
+      }
+      const tags = Array.isArray(profileEvent.tags) ? profileEvent.tags : [];
+      const nameTag = tags.find((t: any) => Array.isArray(t) && t[0] === 'name' && t[1]);
+      const pictureTag = tags.find((t: any) => Array.isArray(t) && t[0] === 'picture' && t[1]);
+      if (nameTag) displayName.value = nameTag[1];
+      if (pictureTag) pictureUrl.value = pictureTag[1];
+    }
+
+    const canonicalFilters = [{ kinds: [30019], authors: [hex], '#d': ['tiers'], limit: 1 }];
+    const canonicalEvents = await fundstrFirstQuery(canonicalFilters);
+    let tierEvent = pickLatestParamReplaceable(canonicalEvents);
+    let tierKindForContent: 30019 | 30000 | null = tierEvent ? 30019 : null;
+
+    if (!tierEvent) {
+      const legacyFilters = [{ kinds: [30000], authors: [hex], '#d': ['tiers'], limit: 1 }];
+      const legacyEvents = await fundstrFirstQuery(legacyFilters);
+      tierEvent = pickLatestReplaceable(legacyEvents);
+      tierKindForContent = tierEvent ? 30000 : null;
+    }
+
+    if (tierKindForContent) {
+      selectedTierKind.value = tierKindForContent;
+    }
+
+    if (tierEvent?.content) {
+      try {
+        const parsed = JSON.parse(tierEvent.content);
+        const list = Array.isArray(parsed?.tiers) ? parsed.tiers : Array.isArray(parsed) ? parsed : [];
+        tiers.value = list
+          .map(mapJsonTier)
+          .filter((t): t is Tier => !!t);
+      } catch (err) {
+        console.warn('[nutzap] failed to parse tiers', err);
+      }
+
+
+    lastLoadInfo.value = `Loaded from relay.fundstr.me at ${new Date().toLocaleTimeString()}`;
+  } catch (err) {
+    console.warn('[nutzap] failed to load author data', err);
+    notifyError('Failed to load Nutzap profile for this author.');
+  } finally {
+    loadingProfile.value = false;
+    loadingTiers.value = false;
+  }
+}
+
+async function applyAuthor() {
+  try {
+    const hex = ensureAuthorHex();
+    await loadAuthorData(hex);
+  } catch {
+    // handled in ensureAuthorHex / loadAuthorData
+  }
+}
+
+async function publishTiers() {
+  let hex: string;
+  try {
+    hex = ensureAuthorHex();
+  } catch {
+    return;
+  }
+
+  if (tiers.value.length === 0) {
+    notifyError('Add at least one tier before publishing.');
+    return;
+  }
+
+  publishingTiers.value = true;
+  try {
+    const payload = {
+      v: 1,
+      tiers: tiers.value.map(t => ({
+        id: t.id,
+        title: t.title,
+        price: t.price,
+        frequency: t.frequency,
+        description: t.description,
+        media: t.media,
+      })),
+    };
+
+    const tags = [
+      ['d', 'tiers'],
+      ['t', 'nutzap-tiers'],
+      ['client', 'fundstr'],
+    ];
+
+    const ack = await publishNostrEvent({
+      kind: selectedTierKind.value,
+      tags,
+      content: JSON.stringify(payload),
+    });
+
+    lastTiersPublishInfo.value = `relay.fundstr.me → ${ack.id}`;
+    notifySuccess(`Subscription tiers published to relay.fundstr.me (id ${ack.id}).`);
+    await loadAuthorData(hex);
+  } catch (err: any) {
+    console.error('[nutzap] failed to publish tiers', err);
+    notifyError(err?.message ?? 'Unable to publish subscription tiers.');
+  } finally {
+    publishingTiers.value = false;
+  }
+}
+
+async function publishProfile() {
+  let hex: string;
+  try {
+    hex = ensureAuthorHex();
+  } catch {
+    return;
+  }
+
+  if (!p2pkPub.value.trim()) {
+    notifyError('P2PK public key is required.');
+    return;
+  }
+  if (mintList.value.length === 0) {
+    notifyError('Add at least one trusted mint URL.');
+    return;
+  }
+
+  const relays = relayList.value.length ? relayList.value : [NUTZAP_RELAY_WSS];
+
+  publishingProfile.value = true;
+  try {
+    const content = {
+      v: 1,
+      p2pk: p2pkPub.value.trim(),
+      mints: mintList.value,
+      relays,
+      tierAddr: `${selectedTierKind.value}:${hex}:tiers`,
+    };
+
+    const tags: string[][] = [
+      ['t', 'nutzap-profile'],
+      ['client', 'fundstr'],
+    ];
+
+    mintList.value.forEach(mint => {
+      tags.push(['mint', mint, 'sat']);
+    });
+
+    relays.forEach(relay => {
+      tags.push(['relay', relay]);
+    });
+
+    if (displayName.value.trim()) {
+      tags.push(['name', displayName.value.trim()]);
+    }
+    if (pictureUrl.value.trim()) {
+      tags.push(['picture', pictureUrl.value.trim()]);
+    }
+
+    const ack = await publishNostrEvent({
+      kind: 10019,
+      tags,
+      content: JSON.stringify(content),
+    });
+
+    lastProfilePublishInfo.value = `relay.fundstr.me → ${ack.id}`;
+    notifySuccess(`Nutzap profile published to relay.fundstr.me (id ${ack.id}).`);
+    await loadAuthorData(hex);
+  } catch (err: any) {
+    console.error('[nutzap] failed to publish profile', err);
+    notifyError(err?.message ?? 'Unable to publish Nutzap profile.');
+  } finally {
+    publishingProfile.value = false;
+  }
+}
+
+onMounted(() => {
+  if (authorInput.value.trim()) {
+    void applyAuthor();
+  }
+});
 </script>

--- a/src/pages/nutzap-profile/nostrHelpers.ts
+++ b/src/pages/nutzap-profile/nostrHelpers.ts
@@ -1,0 +1,241 @@
+import { nip19 } from 'nostr-tools';
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import { getNutzapNdk } from 'src/nutzap/ndkInstance';
+
+const FUNDSTR_RELAY_WSS = 'wss://relay.fundstr.me';
+const FUNDSTR_HTTP_REQ = 'https://relay.fundstr.me/req';
+const FUNDSTR_HTTP_EVENT = 'https://relay.fundstr.me/event';
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export function normalizeAuthor(input: string): string {
+  const value = input.trim();
+  if (!value) {
+    throw new Error('Author is required.');
+  }
+  if (/^[0-9a-fA-F]{64}$/.test(value)) {
+    return value.toLowerCase();
+  }
+  if (value.toLowerCase().startsWith('npub')) {
+    const decoded = nip19.decode(value);
+    if (decoded.type !== 'npub') {
+      throw new Error('Invalid npub identifier.');
+    }
+    const data = decoded.data;
+    if (typeof data === 'string') {
+      if (!/^[0-9a-fA-F]{64}$/.test(data)) {
+        throw new Error('Invalid decoded npub value.');
+      }
+      return data.toLowerCase();
+    }
+    if (data instanceof Uint8Array) {
+      return bytesToHex(data);
+    }
+  }
+  throw new Error('Author must be a hex pubkey or npub.');
+}
+
+export function isNostrEvent(
+  e: any
+): e is {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: any[];
+  content: string;
+  sig: string;
+} {
+  if (!e || typeof e !== 'object') return false;
+  const hex64 = /^[0-9a-f]{64}$/;
+  const hexSig = /^[0-9a-f]{128}$/;
+  return (
+    typeof e.id === 'string' &&
+    hex64.test(e.id) &&
+    typeof e.pubkey === 'string' &&
+    hex64.test(e.pubkey) &&
+    Number.isInteger(e.created_at) &&
+    typeof e.kind === 'number' &&
+    Array.isArray(e.tags) &&
+    typeof e.content === 'string' &&
+    typeof e.sig === 'string' &&
+    hexSig.test(e.sig)
+  );
+}
+
+export function pickLatestReplaceable<T extends { kind?: number; pubkey?: string; created_at?: number }>(
+  events: T[]
+): T | null {
+  if (!Array.isArray(events) || events.length === 0) return null;
+  const map = new Map<string, T>();
+  for (const ev of events) {
+    if (!ev || typeof ev.kind !== 'number' || typeof ev.pubkey !== 'string') continue;
+    const key = `${ev.kind}:${ev.pubkey}`;
+    const existing = map.get(key);
+    if (!existing || (ev.created_at ?? 0) > (existing.created_at ?? 0)) {
+      map.set(key, ev);
+    }
+  }
+  if (map.size === 0) return null;
+  let latest: T | null = null;
+  for (const item of map.values()) {
+    if (!latest || (item.created_at ?? 0) > (latest.created_at ?? 0)) {
+      latest = item;
+    }
+  }
+  return latest;
+}
+
+function getDTag(ev: any): string | undefined {
+  if (!ev || !Array.isArray(ev.tags)) return undefined;
+  const tag = ev.tags.find((t: any) => Array.isArray(t) && t[0] === 'd' && typeof t[1] === 'string');
+  return tag?.[1];
+}
+
+export function pickLatestParamReplaceable<T extends { kind?: number; pubkey?: string; created_at?: number; tags?: any[] }>(
+  events: T[]
+): T | null {
+  if (!Array.isArray(events) || events.length === 0) return null;
+  const map = new Map<string, T>();
+  for (const ev of events) {
+    if (!ev || typeof ev.kind !== 'number' || typeof ev.pubkey !== 'string') continue;
+    const d = getDTag(ev);
+    if (typeof d !== 'string') continue;
+    const key = `${ev.kind}:${ev.pubkey}:${d}`;
+    const existing = map.get(key);
+    if (!existing || (ev.created_at ?? 0) > (existing.created_at ?? 0)) {
+      map.set(key, ev);
+    }
+  }
+  if (map.size === 0) return null;
+  let latest: T | null = null;
+  for (const item of map.values()) {
+    if (!latest || (item.created_at ?? 0) > (latest.created_at ?? 0)) {
+      latest = item;
+    }
+  }
+  return latest;
+}
+
+export type NostrFilter = { kinds: number[]; authors: string[]; '#d'?: string[]; limit?: number };
+
+export async function fundstrFirstQuery(filters: NostrFilter[], wsTimeoutMs = 1500): Promise<any[]> {
+  const events: any[] = [];
+  const useWebSocket = typeof WebSocket !== 'undefined';
+
+  if (useWebSocket) {
+    const subId = `fundstr-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const wsEvents = await new Promise<any[]>(resolve => {
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const ws = new WebSocket(FUNDSTR_RELAY_WSS);
+
+      const finalize = () => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        try {
+          if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+            ws.close();
+          }
+        } catch (err) {
+          console.warn('[fundstrFirstQuery] failed closing ws', err);
+        }
+        resolve([...events]);
+      };
+
+      timeout = setTimeout(() => {
+        finalize();
+      }, wsTimeoutMs);
+
+      ws.addEventListener('open', () => {
+        ws.send(JSON.stringify(['REQ', subId, ...filters]));
+      });
+
+      ws.addEventListener('message', ev => {
+        try {
+          const data = JSON.parse(ev.data as string);
+          if (!Array.isArray(data)) return;
+          if (data[0] === 'EVENT' && data[1] === subId && data[2]) {
+            events.push(data[2]);
+          } else if (data[0] === 'EOSE' && data[1] === subId) {
+            finalize();
+          }
+        } catch (err) {
+          console.warn('[fundstrFirstQuery] failed to parse ws message', err);
+        }
+      });
+
+      ws.addEventListener('error', () => {
+        finalize();
+      });
+
+      ws.addEventListener('close', () => {
+        finalize();
+      });
+    });
+
+    if (wsEvents.length > 0) {
+      return wsEvents;
+    }
+  }
+
+  try {
+    const url = new URL(FUNDSTR_HTTP_REQ);
+    url.searchParams.set('filters', JSON.stringify(filters));
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const data = await response.json();
+    if (Array.isArray(data)) {
+      return data;
+    }
+  } catch (err) {
+    console.warn('[fundstrFirstQuery] HTTP fallback failed', err);
+  }
+
+  return [];
+}
+
+export async function publishNostrEvent(template: {
+  kind: number;
+  tags: any[];
+  content: string;
+  created_at?: number;
+}) {
+  const created_at = template.created_at ?? Math.floor(Date.now() / 1000);
+  let signed: any;
+
+  if (typeof window !== 'undefined' && (window as any).nostr?.signEvent) {
+    signed = await (window as any).nostr.signEvent({
+      ...template,
+      created_at,
+    });
+  } else {
+    const ndk = getNutzapNdk();
+    const ev = new NDKEvent(ndk, { ...template, created_at });
+    await ev.sign();
+    signed = await ev.toNostrEvent();
+  }
+
+  if (!isNostrEvent(signed)) {
+    throw new Error('Not a signed NIP-01 event');
+  }
+
+  const ack = await fetch(FUNDSTR_HTTP_EVENT, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(signed),
+  }).then(r => r.json());
+
+  if (!ack?.accepted) {
+    throw new Error(ack?.message || 'Relay rejected');
+  }
+
+  return ack;
+}


### PR DESCRIPTION
## Summary
- add a /nutzap-profile helper module with author normalization, replaceable selection, and Fundstr relay query/publish utilities
- rebuild NutzapProfilePage to accept manual author input, toggle tier kind, and publish profile/tiers using the new schema and relay contract

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd04176b4083309362aba414b91f52