### PR TITLE
Implement Fundstr-first Nutzap profile workflow

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -6,6 +6,29 @@
     </div>
 
     <q-card class="q-pa-md">
+      <div class="text-subtitle1 q-mb-sm">Author</div>
+      <q-input
+        v-model="authorInput"
+        label="Author (npub or hex pubkey)"
+        dense
+        filled
+        autocomplete="off"
+      />
+      <div class="row items-center q-gutter-sm q-mt-sm">
+        <q-btn
+          color="primary"
+          label="Load Data"
+          :disable="!authorInput.trim() || loading"
+          :loading="loading"
+          @click="loadAll"
+        />
+      </div>
+      <div class="text-caption text-2 q-mt-sm">
+        Tier address preview: {{ tierAddressPreview }}
+      </div>
+    </q-card>
+
+    <q-card class="q-pa-md">
       <div class="text-subtitle1 q-mb-sm">Payment Profile (kind 10019)</div>
       <q-input v-model="displayName" label="Display Name" dense filled class="q-mb-sm" />
       <q-input v-model="pictureUrl" label="Picture URL" dense filled class="q-mb-sm" />
@@ -17,16 +40,48 @@
         dense
         filled
         autogrow
+        class="q-mb-sm"
       />
+      <q-input
+        v-model="relaysText"
+        type="textarea"
+        label="Relay Hints (optional, one per line)"
+        dense
+        filled
+        autogrow
+      />
+      <div class="row justify-end q-gutter-sm q-mt-md">
+        <q-btn
+          color="primary"
+          label="Publish Profile"
+          :disable="profilePublishDisabled"
+          :loading="publishingProfile"
+          @click="publishProfile"
+        />
+      </div>
+      <div class="text-caption q-mt-sm" v-if="lastProfilePublishInfo">
+        {{ lastProfilePublishInfo }}
+      </div>
     </q-card>
 
     <q-card class="q-pa-md">
       <div class="row items-center justify-between q-mb-sm">
-        <div class="text-subtitle1">Tiers ({{ tiers.length }}) — kind {{ tierKindLabel }}</div>
-        <q-btn dense color="primary" label="Add Tier" @click="openNewTier" />
-      </div>
-      <div class="text-caption text-2 q-mb-sm">
-        Each tier is published as parameterized replaceable event ["d","tiers"] on relay.fundstr.me.
+        <div>
+          <div class="text-subtitle1">Tiers ({{ tiers.length }})</div>
+          <div class="text-caption text-2">
+            Publishing as {{ tierKindLabel }} — parameterized replaceable ["d","tiers"].
+          </div>
+        </div>
+        <div class="row items-center q-gutter-sm">
+          <q-btn-toggle
+            v-model="tierKind"
+            :options="tierKindOptions"
+            dense
+            toggle-color="primary"
+            unelevated
+          />
+          <q-btn dense color="primary" label="Add Tier" @click="openNewTier" />
+        </div>
       </div>
       <q-list bordered separator v-if="tiers.length">
         <q-item v-for="tier in tiers" :key="tier.id">
@@ -36,8 +91,7 @@
             </div>
             <div class="text-caption" v-if="tier.description">{{ tier.description }}</div>
             <div class="text-caption" v-if="tier.media?.length">
-              Media:
-              {{ tier.media.map(m => m.url).join(', ') }}
+              Media: {{ tier.media.map(m => m.url).join(', ') }}
             </div>
           </q-item-section>
           <q-item-section side>
@@ -47,18 +101,17 @@
         </q-item>
       </q-list>
       <div v-else class="text-caption text-2">No tiers yet. Add at least one tier before publishing.</div>
-    </q-card>
-
-    <q-card class="q-pa-md">
-      <q-btn
-        color="primary"
-        :disable="publishDisabled"
-        :loading="publishing"
-        label="Publish Nutzap Profile"
-        @click="publishAll"
-      />
-      <div class="text-caption q-mt-sm" v-if="lastPublishInfo">
-        Last publish: {{ lastPublishInfo }}
+      <div class="row justify-end q-gutter-sm q-mt-md">
+        <q-btn
+          color="primary"
+          label="Publish Tiers"
+          :disable="tiersPublishDisabled"
+          :loading="publishingTiers"
+          @click="publishTiers"
+        />
+      </div>
+      <div class="text-caption q-mt-sm" v-if="lastTiersPublishInfo">
+        {{ lastTiersPublishInfo }}
       </div>
     </q-card>
 
@@ -111,31 +164,109 @@
 </template>
 
 <script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { v4 as uuidv4 } from 'uuid';
 import RelayStatusIndicator from 'src/nutzap/RelayStatusIndicator.vue';
-import { computed } from 'vue';
-import { useNutzapProfile } from 'src/nutzap/useNutzapProfile';
-import { NUTZAP_TIERS_KIND } from 'src/nutzap/relayConfig';
+import { notifyError, notifySuccess } from 'src/js/notify';
+import type { Tier } from 'src/nutzap/types';
+import { useActiveNutzapSigner } from 'src/nutzap/signer';
+import { getNutzapNdk } from 'src/nutzap/ndkInstance';
+import { NUTZAP_RELAY_WSS } from 'src/nutzap/relayConfig';
+import {
+  fundstrFirstQuery,
+  normalizeAuthor,
+  pickLatestParamReplaceable,
+  pickLatestReplaceable,
+  publishTierDefinitions,
+  publishNostrEvent,
+} from './nutzap-profile/nostrHelpers';
 
-const {
-  displayName,
-  pictureUrl,
-  p2pkPub,
-  mintsText,
-  tiers,
-  tierForm,
-  showTierDialog,
-  publishing,
-  lastPublishInfo,
-  publishDisabled,
-  tierFrequencies,
-  editTier,
-  removeTier,
-  saveTier,
-  resetTierForm,
-  publishAll,
-} = useNutzapProfile();
+type TierKind = 30019 | 30000;
 
-const tierKindLabel = computed(() => NUTZAP_TIERS_KIND);
+const tierFrequencies: Tier['frequency'][] = ['one_time', 'monthly', 'yearly'];
+
+type TierFormState = {
+  id: string;
+  title: string;
+  price: number;
+  frequency: Tier['frequency'];
+  description: string;
+  mediaCsv: string;
+};
+
+const authorInput = ref('');
+const displayName = ref('');
+const pictureUrl = ref('');
+const p2pkPub = ref('');
+const mintsText = ref('');
+const relaysText = ref(NUTZAP_RELAY_WSS);
+const tiers = ref<Tier[]>([]);
+const tierKind = ref<TierKind>(30019);
+const tierForm = ref<TierFormState>({
+  id: '',
+  title: '',
+  price: 0,
+  frequency: 'monthly',
+  description: '',
+  mediaCsv: '',
+});
+const showTierDialog = ref(false);
+const loading = ref(false);
+const publishingProfile = ref(false);
+const publishingTiers = ref(false);
+const lastProfilePublishInfo = ref('');
+const lastTiersPublishInfo = ref('');
+const hasAutoLoaded = ref(false);
+
+const { pubkey, signer } = useActiveNutzapSigner();
+
+const mintList = computed(() =>
+  mintsText.value
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean)
+);
+
+const relayList = computed(() => {
+  const entries = relaysText.value
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean);
+  const base = entries.length ? entries : [NUTZAP_RELAY_WSS];
+  return Array.from(new Set(base));
+});
+
+const tierKindOptions = [
+  { label: 'Canonical (30019)', value: 30019 },
+  { label: 'Legacy (30000)', value: 30000 },
+] as const;
+
+const tierKindLabel = computed(() =>
+  tierKind.value === 30019 ? 'Canonical (30019)' : 'Legacy (30000)'
+);
+
+const tierAddressPreview = computed(() => {
+  try {
+    const authorHex = normalizeAuthor(authorInput.value);
+    return `${tierKind.value}:${authorHex}:tiers`;
+  } catch {
+    return `${tierKind.value}:<author>:tiers`;
+  }
+});
+
+const profilePublishDisabled = computed(
+  () =>
+    publishingProfile.value ||
+    !authorInput.value.trim() ||
+    !p2pkPub.value.trim() ||
+    mintList.value.length === 0 ||
+    tiers.value.length === 0
+);
+
+const tiersPublishDisabled = computed(
+  () =>
+    publishingTiers.value || !authorInput.value.trim() || tiers.value.length === 0
+);
 
 const tierFrequencyOptions = computed(() =>
   tierFrequencies.map(value => ({
@@ -149,12 +280,397 @@ const tierFrequencyOptions = computed(() =>
   }))
 );
 
+function toMediaCsv(media?: { type: string; url: string }[]) {
+  if (!media) return '';
+  return media
+    .map(m => m?.url)
+    .filter((u): u is string => typeof u === 'string' && !!u)
+    .join(', ');
+}
+
+function resetTierForm() {
+  tierForm.value = {
+    id: '',
+    title: '',
+    price: 0,
+    frequency: 'monthly',
+    description: '',
+    mediaCsv: '',
+  };
+}
+
 function openNewTier() {
   resetTierForm();
   showTierDialog.value = true;
 }
 
-function frequencyLabel(value: (typeof tierFrequencies)[number]) {
+function editTier(tier: Tier) {
+  tierForm.value = {
+    id: tier.id,
+    title: tier.title,
+    price: tier.price,
+    frequency: tier.frequency,
+    description: tier.description ?? '',
+    mediaCsv: toMediaCsv(tier.media),
+  };
+  showTierDialog.value = true;
+}
+
+function removeTier(id: string) {
+  tiers.value = tiers.value.filter(t => t.id !== id);
+}
+
+function saveTier() {
+  const form = tierForm.value;
+  const media = form.mediaCsv
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+    .map(url => ({ type: 'link', url }));
+  const tier: Tier = {
+    id: form.id || uuidv4(),
+    title: form.title.trim(),
+    price: Number(form.price) || 0,
+    frequency: form.frequency,
+    description: form.description ? form.description.trim() : undefined,
+    media: media.length ? media : undefined,
+  };
+
+  if (form.id) {
+    tiers.value = tiers.value.map(t => (t.id === form.id ? tier : t));
+  } else {
+    tiers.value = [...tiers.value, tier];
+  }
+
+  resetTierForm();
+}
+
+function mapJsonTier(raw: any): Tier | null {
+  if (!raw) return null;
+  const id = typeof raw.id === 'string' && raw.id ? raw.id : uuidv4();
+  const title = typeof raw.title === 'string' ? raw.title : '';
+  const price = Number(raw.price ?? raw.price_sats ?? 0);
+  const frequency = tierFrequencies.includes(raw.frequency)
+    ? raw.frequency
+    : 'monthly';
+  const description = typeof raw.description === 'string' && raw.description ? raw.description : undefined;
+  let media: { type: string; url: string }[] | undefined;
+  if (Array.isArray(raw.media)) {
+    const normalized = raw.media
+      .map((entry: any) => {
+        if (!entry) return null;
+        if (typeof entry === 'string') {
+          return { type: 'link', url: entry };
+        }
+        const url = typeof entry.url === 'string' ? entry.url : '';
+        if (!url) return null;
+        const type = typeof entry.type === 'string' ? entry.type : 'link';
+        return { type, url };
+      })
+      .filter((entry): entry is { type: string; url: string } => !!entry && !!entry.url);
+    media = normalized.length ? normalized : undefined;
+  }
+  return {
+    id,
+    title,
+    price,
+    frequency,
+    description,
+    media,
+  };
+}
+
+async function loadTiers(authorHex: string) {
+  try {
+    let activeKind: TierKind | null = null;
+    let events = await fundstrFirstQuery([
+      { kinds: [30019], authors: [authorHex], '#d': ['tiers'], limit: 1 },
+    ]);
+    let latest = pickLatestParamReplaceable(events);
+    if (latest) {
+      activeKind = 30019;
+    } else {
+      events = await fundstrFirstQuery([
+        { kinds: [30000], authors: [authorHex], '#d': ['tiers'], limit: 1 },
+      ]);
+      latest = pickLatestReplaceable(events);
+      if (latest) {
+        activeKind = 30000;
+      }
+    }
+
+    if (!latest) {
+      tiers.value = [];
+      return;
+    }
+
+    if (activeKind) {
+      tierKind.value = activeKind;
+    }
+
+    try {
+      const parsed = latest.content ? JSON.parse(latest.content) : {};
+      const rawTiers = Array.isArray(parsed?.tiers) ? parsed.tiers : [];
+      tiers.value = rawTiers
+        .map(mapJsonTier)
+        .filter((tier): tier is Tier => !!tier);
+    } catch (err) {
+      console.warn('[nutzap] failed to parse tiers content', err);
+      tiers.value = [];
+    }
+  } catch (err) {
+    console.error('[nutzap] failed to load tiers', err);
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+}
+
+async function loadProfile(authorHex: string) {
+  let events;
+  try {
+    events = await fundstrFirstQuery([
+      { kinds: [10019], authors: [authorHex], limit: 1 },
+    ]);
+  } catch (err) {
+    console.error('[nutzap] failed to load profile', err);
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+
+  const latest = pickLatestReplaceable(events);
+  if (!latest) {
+    displayName.value = '';
+    pictureUrl.value = '';
+    p2pkPub.value = '';
+    mintsText.value = '';
+    relaysText.value = NUTZAP_RELAY_WSS;
+    return;
+  }
+
+  if (latest.pubkey) {
+    authorInput.value = latest.pubkey;
+  }
+
+  try {
+    const parsed = latest.content ? JSON.parse(latest.content) : {};
+    if (typeof parsed.p2pk === 'string') {
+      p2pkPub.value = parsed.p2pk;
+    }
+    if (Array.isArray(parsed.mints)) {
+      mintsText.value = parsed.mints.join('\n');
+    }
+    if (Array.isArray(parsed.relays) && parsed.relays.length > 0) {
+      relaysText.value = parsed.relays.join('\n');
+    } else {
+      relaysText.value = NUTZAP_RELAY_WSS;
+    }
+    if (typeof parsed.tierAddr === 'string') {
+      const [kindPart, , dPart] = parsed.tierAddr.split(':');
+      const maybeKind = Number(kindPart);
+      if ((maybeKind === 30019 || maybeKind === 30000) && dPart === 'tiers') {
+        tierKind.value = maybeKind as TierKind;
+      }
+    }
+  } catch (err) {
+    console.warn('[nutzap] failed to parse profile content', err);
+  }
+
+  const tags = Array.isArray(latest.tags) ? latest.tags : [];
+  const nameTag = tags.find((t: any) => Array.isArray(t) && t[0] === 'name' && t[1]);
+  if (nameTag) {
+    displayName.value = nameTag[1];
+  }
+  const pictureTag = tags.find((t: any) => Array.isArray(t) && t[0] === 'picture' && t[1]);
+  if (pictureTag) {
+    pictureUrl.value = pictureTag[1];
+  }
+  const mintTags = tags.filter((t: any) => Array.isArray(t) && t[0] === 'mint' && t[1]);
+  if (!mintsText.value && mintTags.length) {
+    mintsText.value = mintTags.map((t: any) => t[1]).join('\n');
+  }
+  const relayTags = tags.filter((t: any) => Array.isArray(t) && t[0] === 'relay' && t[1]);
+  if ((!relaysText.value || relaysText.value === NUTZAP_RELAY_WSS) && relayTags.length) {
+    relaysText.value = Array.from(new Set(relayTags.map((t: any) => t[1]))).join('\n');
+  }
+  if (!p2pkPub.value) {
+    const pkTag = tags.find((t: any) => Array.isArray(t) && t[0] === 'pubkey' && t[1]);
+    if (pkTag) {
+      p2pkPub.value = pkTag[1];
+    }
+  }
+}
+
+async function loadAll() {
+  let authorHex: string;
+  try {
+    authorHex = normalizeAuthor(authorInput.value);
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : String(err));
+    return;
+  }
+
+  loading.value = true;
+  try {
+    await Promise.all([loadTiers(authorHex), loadProfile(authorHex)]);
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : 'Failed to load Nutzap profile.');
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function publishTiers() {
+  let authorHex: string;
+  try {
+    authorHex = normalizeAuthor(authorInput.value);
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : String(err));
+    return;
+  }
+
+  if (tiers.value.length === 0) {
+    notifyError('Add at least one tier before publishing.');
+    return;
+  }
+
+  publishingTiers.value = true;
+  try {
+    const payload = tiers.value.map(tier => {
+      const mediaUrls = Array.isArray(tier.media)
+        ? tier.media.map(m => m.url).filter(Boolean)
+        : [];
+      const record: Record<string, unknown> = {
+        id: tier.id,
+        title: tier.title,
+        price: tier.price,
+        frequency: tier.frequency,
+      };
+      if (tier.description) {
+        record.description = tier.description;
+      }
+      if (mediaUrls.length) {
+        record.media = mediaUrls;
+      }
+      return record;
+    });
+
+    const ack = await publishTierDefinitions(payload, tierKind.value);
+    const signerPubkey = ack.event?.pubkey;
+    const reloadKey = typeof signerPubkey === 'string' && signerPubkey ? signerPubkey : authorHex;
+    if (signerPubkey && signerPubkey !== authorInput.value) {
+      authorInput.value = signerPubkey;
+    }
+    const eventId = ack.id ?? ack.event?.id;
+    lastTiersPublishInfo.value = eventId
+      ? `Tiers published (kind ${tierKind.value}) — id ${eventId}`
+      : `Tiers published (kind ${tierKind.value}).`;
+    notifySuccess('Subscription tiers published to relay.fundstr.me.');
+    await loadTiers(reloadKey);
+  } catch (err) {
+    console.error('[nutzap] publish tiers failed', err);
+    notifyError(err instanceof Error ? err.message : 'Unable to publish tiers.');
+  } finally {
+    publishingTiers.value = false;
+  }
+}
+
+async function publishProfile() {
+  let authorHex: string;
+  try {
+    authorHex = normalizeAuthor(authorInput.value);
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : String(err));
+    return;
+  }
+
+  if (!p2pkPub.value.trim()) {
+    notifyError('P2PK public key is required.');
+    return;
+  }
+  if (mintList.value.length === 0) {
+    notifyError('Add at least one trusted mint URL.');
+    return;
+  }
+  if (tiers.value.length === 0) {
+    notifyError('Add at least one tier before publishing.');
+    return;
+  }
+
+  publishingProfile.value = true;
+  try {
+    const relays = relayList.value;
+    const content = JSON.stringify({
+      v: 1,
+      p2pk: p2pkPub.value.trim(),
+      mints: mintList.value,
+      relays,
+      tierAddr: `${tierKind.value}:${authorHex}:tiers`,
+    });
+
+    const tags: string[][] = [
+      ['t', 'nutzap-profile'],
+      ['client', 'fundstr'],
+      ...mintList.value.map(mint => ['mint', mint, 'sat']),
+      ...relays.map(relay => ['relay', relay]),
+    ];
+    if (displayName.value.trim()) {
+      tags.push(['name', displayName.value.trim()]);
+    }
+    if (pictureUrl.value.trim()) {
+      tags.push(['picture', pictureUrl.value.trim()]);
+    }
+
+    const ack = await publishNostrEvent({ kind: 10019, tags, content });
+    const signerPubkey = ack.event?.pubkey;
+    const reloadKey = typeof signerPubkey === 'string' && signerPubkey ? signerPubkey : authorHex;
+    if (signerPubkey && signerPubkey !== authorInput.value) {
+      authorInput.value = signerPubkey;
+    }
+    const eventId = ack.id ?? ack.event?.id;
+    lastProfilePublishInfo.value = eventId
+      ? `Profile published — id ${eventId}`
+      : 'Profile published to relay.fundstr.me.';
+    notifySuccess('Nutzap profile published to relay.fundstr.me.');
+    await loadProfile(reloadKey);
+  } catch (err) {
+    console.error('[nutzap] publish profile failed', err);
+    notifyError(err instanceof Error ? err.message : 'Unable to publish Nutzap profile.');
+  } finally {
+    publishingProfile.value = false;
+  }
+}
+
+function frequencyLabel(value: Tier['frequency']) {
   return value === 'one_time' ? 'one-time' : value;
 }
+
+watch(
+  signer,
+  newSigner => {
+    const ndk = getNutzapNdk();
+    ndk.signer = newSigner ?? undefined;
+  },
+  { immediate: true }
+);
+
+watch(pubkey, newPubkey => {
+  if (newPubkey && !authorInput.value) {
+    authorInput.value = newPubkey;
+  }
+  if (newPubkey && !hasAutoLoaded.value) {
+    hasAutoLoaded.value = true;
+    void loadAll();
+  }
+});
+
+onMounted(() => {
+  if (!relaysText.value) {
+    relaysText.value = NUTZAP_RELAY_WSS;
+  }
+  if (pubkey.value && !authorInput.value) {
+    authorInput.value = pubkey.value;
+  }
+  if (authorInput.value && !hasAutoLoaded.value) {
+    hasAutoLoaded.value = true;
+    void loadAll();
+  }
+});
 </script>

--- a/src/pages/nutzap-profile/nostrHelpers.ts
+++ b/src/pages/nutzap-profile/nostrHelpers.ts
@@ -1,0 +1,246 @@
+import { nip19 } from 'nostr-tools';
+import { NDKEvent } from '@nostr-dev-kit/ndk';
+import { getNutzapNdk } from 'src/nutzap/ndkInstance';
+
+const HEX_64_REGEX = /^[0-9a-f]{64}$/i;
+const HEX_128_REGEX = /^[0-9a-f]{128}$/i;
+
+export type NostrEvent = {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: any[];
+  content: string;
+  sig: string;
+};
+
+export type NostrFilter = {
+  kinds: number[];
+  authors: string[];
+  '#d'?: string[];
+  limit?: number;
+};
+
+export function normalizeAuthor(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('Author is required.');
+  }
+
+  if (HEX_64_REGEX.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+
+  if (trimmed.toLowerCase().startsWith('npub')) {
+    const decoded = nip19.decode(trimmed);
+    if (decoded.type !== 'npub') {
+      throw new Error('Only npub identifiers are supported.');
+    }
+    const data = decoded.data;
+    if (typeof data !== 'string' || !HEX_64_REGEX.test(data)) {
+      throw new Error('Invalid npub payload.');
+    }
+    return data.toLowerCase();
+  }
+
+  throw new Error('Author must be a 64-char hex pubkey or npub.');
+}
+
+export function isNostrEvent(e: any): e is NostrEvent {
+  if (!e || typeof e !== 'object') return false;
+  if (!HEX_64_REGEX.test(e.id ?? '')) return false;
+  if (!HEX_64_REGEX.test(e.pubkey ?? '')) return false;
+  if (typeof e.created_at !== 'number' || !Number.isFinite(e.created_at)) return false;
+  if (typeof e.kind !== 'number') return false;
+  if (!Array.isArray(e.tags)) return false;
+  if (typeof e.content !== 'string') return false;
+  if (!HEX_128_REGEX.test(e.sig ?? '')) return false;
+  return true;
+}
+
+export function pickLatestReplaceable<T extends { created_at?: number }>(events: T[]): T | null {
+  let latest: T | null = null;
+  for (const event of events) {
+    if (!event || typeof (event as any).kind !== 'number' || typeof (event as any).pubkey !== 'string') {
+      continue;
+    }
+    if (!latest || (event.created_at ?? 0) > (latest.created_at ?? 0)) {
+      latest = event;
+    }
+  }
+  return latest;
+}
+
+export function pickLatestParamReplaceable<T extends { created_at?: number; tags?: any[] }>(events: T[]): T | null {
+  let latest: T | null = null;
+  let latestKey = '';
+  for (const event of events) {
+    if (!event || typeof (event as any).kind !== 'number' || typeof (event as any).pubkey !== 'string') {
+      continue;
+    }
+    const tags = Array.isArray((event as any).tags) ? (event as any).tags : [];
+    const dTag = tags.find((t: any) => Array.isArray(t) && t[0] === 'd' && typeof t[1] === 'string');
+    const key = `${(event as any).kind}:${(event as any).pubkey}:${dTag ? dTag[1] : ''}`;
+    if (!latest || key !== latestKey || (event.created_at ?? 0) > (latest.created_at ?? 0)) {
+      latest = event;
+      latestKey = key;
+    }
+  }
+  return latest;
+}
+
+export async function fundstrFirstQuery(filters: NostrFilter[], wsTimeoutMs = 1500): Promise<any[]> {
+  const wsUrl = 'wss://relay.fundstr.me';
+  let events: any[] = [];
+
+  try {
+    events = await new Promise<any[]>((resolve, reject) => {
+      const collected: any[] = [];
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const subId = Math.random().toString(36).slice(2);
+      let socket: WebSocket | null = null;
+
+      const finalize = (result: any[], error?: unknown) => {
+        if (settled) return;
+        settled = true;
+        if (timer) {
+          clearTimeout(timer);
+        }
+        if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
+          try {
+            socket.close();
+          } catch (closeErr) {
+            console.warn('[nutzap] ws close failed', closeErr);
+          }
+        }
+        if (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      };
+
+      try {
+        socket = new WebSocket(wsUrl);
+      } catch (err) {
+        finalize([], err);
+        return;
+      }
+
+      timer = setTimeout(() => finalize(collected), wsTimeoutMs);
+
+      socket.onopen = () => {
+        try {
+          socket?.send(JSON.stringify(['REQ', subId, ...filters]));
+        } catch (err) {
+          finalize(collected, err);
+        }
+      };
+
+      socket.onmessage = ev => {
+        try {
+          const data = JSON.parse(ev.data);
+          if (!Array.isArray(data)) return;
+          const [type, sub, payload] = data;
+          if (sub !== subId) return;
+          if (type === 'EVENT') {
+            collected.push(payload);
+          } else if (type === 'EOSE') {
+            finalize(collected);
+          }
+        } catch (err) {
+          console.warn('[nutzap] ws message parse failed', err);
+        }
+      };
+
+      socket.onerror = err => {
+        finalize(collected, err instanceof Error ? err : new Error('WebSocket error'));
+      };
+
+      socket.onclose = () => {
+        finalize(collected);
+      };
+    });
+  } catch (err) {
+    console.warn('[nutzap] ws query failed', err);
+  }
+
+  if (!Array.isArray(events) || events.length === 0) {
+    try {
+      const response = await fetch(
+        `https://relay.fundstr.me/req?filters=${encodeURIComponent(JSON.stringify(filters))}`
+      );
+      if (!response.ok) {
+        throw new Error(`HTTP query failed with status ${response.status}`);
+      }
+      const data = await response.json();
+      if (Array.isArray(data)) {
+        events = data;
+      } else if (Array.isArray(data?.events)) {
+        events = data.events;
+      } else {
+        events = [];
+      }
+    } catch (err) {
+      console.warn('[nutzap] http query failed', err);
+      if (!Array.isArray(events) || events.length === 0) {
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+    }
+  }
+
+  return Array.isArray(events) ? events : [];
+}
+
+export async function publishNostrEvent(template: {
+  kind: number;
+  tags: any[];
+  content: string;
+  created_at?: number;
+}) {
+  const created_at = template.created_at ?? Math.floor(Date.now() / 1000);
+  let signed: unknown;
+
+  if (typeof window !== 'undefined' && window.nostr?.signEvent) {
+    signed = await window.nostr.signEvent({ ...template, created_at });
+  } else {
+    const ndk = getNutzapNdk();
+    const ev = new NDKEvent(ndk, { ...template, created_at });
+    await ev.sign();
+    signed = await ev.toNostrEvent();
+  }
+
+  if (!isNostrEvent(signed)) {
+    throw new Error('Not a signed NIP-01 event');
+  }
+
+  const response = await fetch('https://relay.fundstr.me/event', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(signed),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Relay rejected with status ${response.status}`);
+  }
+
+  const ack = await response.json();
+  if (!ack?.accepted) {
+    throw new Error(ack?.message || 'Relay rejected');
+  }
+
+  return { ...ack, event: signed };
+}
+
+export async function publishTierDefinitions(tiers: any[], kind: number) {
+  const tags = [
+    ['d', 'tiers'],
+    ['t', 'nutzap-tiers'],
+    ['client', 'fundstr'],
+  ];
+  const content = JSON.stringify({ v: 1, tiers });
+  return publishNostrEvent({ kind, tags, content });
+}


### PR DESCRIPTION
## Summary
- add Fundstr-first nostr helpers for author normalization, event validation, replaceable selection, querying, and publishing (including tier wrapper)
- rebuild the Nutzap profile page to expose author/tier controls and use the helpers for load and publish flows

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cd04176b4083309362aba414b91f52