### PR TITLE
Implement Fundstr relay publishing for Nutzap profile

### DIFF
--- a/src/pages/nutzap-profile/README-NutzapProfile.md
+++ b/src/pages/nutzap-profile/README-NutzapProfile.md
@@ -1,0 +1,113 @@
+# Nutzap Profile + Tiers (Fundstr Relay)
+
+This page publishes a creator's Nutzap payment profile (kind **10019**) and the
+companion tier catalog (kinds **30019** canonical, **30000** legacy fallback)
+to the Fundstr relay at `relay.fundstr.me`. The helper module
+`src/pages/nutzap-profile/nostrHelpers.ts` centralises relay endpoints, signing,
+and read/write helpers so the page can provide production-grade UX around the
+Nostr primitives.
+
+## Event contracts
+
+### Nutzap Profile — kind 10019
+
+* **Tags**
+  * Required: `['t','nutzap-profile']`, `['client','fundstr']`
+  * For each mint: `['mint','<https-url>','sat']`
+  * Optional but encouraged: relay hints `['relay','wss://relay.fundstr.me']`,
+    canonical link to the tier PRE `['a','<kind>:<pubkey>:tiers']`,
+    `['name','…']`, `['picture','…']`
+* **Content** — JSON string:
+
+  ```json
+  {
+    "v": 1,
+    "p2pk": "<hex Cashu P2PK>",
+    "mints": ["https://mint.example", "https://mint2.example"],
+    "relays": ["wss://relay.fundstr.me", "wss://another.example"],
+    "tierAddr": "30019:<author_hex>:tiers"
+  }
+  ```
+
+  `tierAddr` switches to `30000:<author_hex>:tiers` when the UI toggle is set
+to legacy mode.
+
+### Nutzap Tiers — kinds 30019 / 30000
+
+* **Tags**
+  * Required PRE selector: `['d','tiers']`
+  * Optional: `['t','nutzap-tiers']`, `['client','fundstr']`
+* **Content** — JSON string (never a bare array):
+
+  ```json
+  {
+    "v": 1,
+    "tiers": [
+      {
+        "id": "alpha",
+        "title": "Supporter",
+        "price": 2100,
+        "frequency": "monthly",
+        "description": "2k sats per month",
+        "media": ["https://cdn.example/banner.png"]
+      }
+    ]
+  }
+  ```
+
+  The helpers coerce the local `Tier` model into this minimal wire format and
+  accept both string and object media entries when parsing events from the
+  relay.
+
+## Transport strategy
+
+1. **Reads** use `fundstrFirstQuery(filters)`.
+   * Open a WebSocket to `wss://relay.fundstr.me` and send
+     `['REQ', <subId>, ...filters]`.
+   * Collect `['EVENT', …]` frames until the relay replies with
+     `['EOSE', <subId>]` or a **3 second** timeout elapses (see
+     `WS_FIRST_TIMEOUT_MS`).
+   * If no events were received, fall back to
+     `GET https://relay.fundstr.me/req?filters=<urlencoded JSON>` and return the
+     JSON body (`{ ok: true, events:[…] }`).
+2. **Writes** call `publishNostrEvent(template)`.
+   * Sign the template either via `window.nostr.signEvent` or the NDK signer.
+   * Validate the signed event with `isNostrEvent` before sending.
+   * POST the event to `https://relay.fundstr.me/event` and only treat the
+     publish as successful when the relay acknowledges with `{"ok":true,
+     "accepted":true, ...}`.
+
+The Nutzap page keeps the author input (npub or hex) and the tier kind toggle
+visible so the user always knows which PRE coordinate will be written.
+
+## Verification snippets
+
+Replace `$AUTH` with the 64-char lowercase pubkey that signed the events.
+
+```bash
+# Latest Nutzap profile (kind 10019)
+curl -sS --get 'https://relay.fundstr.me/req' \
+  --data-urlencode 'filters=[{"kinds":[10019],"authors":["'$AUTH'"],"limit":1}]' | jq .
+
+# Latest Nutzap tiers (canonical 30019)
+curl -sS --get 'https://relay.fundstr.me/req' \
+  --data-urlencode 'filters=[{"kinds":[30019],"authors":["'$AUTH'"],"#d":["tiers"],"limit":1}]' | jq .
+```
+
+If canonical tiers are missing (legacy data only), change `30019` to `30000` in
+the second command.
+
+## Troubleshooting checklist
+
+* ✅ **Relay ack** — ensure the POST response contains `"accepted": true`.
+  Any other status bubbles up to the UI via `notifyError`.
+* ✅ **Author hygiene** — the helpers normalise npub input to 64-char lowercase
+  hex before building filters or tier addresses.
+* ✅ **Tier selector** — canonical reads always include `"#d":["tiers"]` so
+  legacy events with different PRE keys cannot pollute the results.
+* ✅ **Transport fallback** — watch the network panel for the initial WebSocket
+  subscription. If no events arrive before timeout you should see an HTTP
+  fallback request with identical filters.
+* ✅ **Content parity** — when reads return unexpected data, run the curl
+  commands above to compare the stored JSON against the UI expectations.
+

--- a/src/pages/nutzap-profile/__tests__/nostrHelpers.spec.ts
+++ b/src/pages/nutzap-profile/__tests__/nostrHelpers.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { nip19 } from 'nostr-tools';
+import {
+  normalizeAuthor,
+  isNostrEvent,
+  pickLatestReplaceable,
+  pickLatestParamReplaceable,
+} from '../nostrHelpers';
+
+describe('normalizeAuthor', () => {
+  const hexKey = '5015f8a13449bcc6e21b54de0dc6be037ce8e90c96582343c5c8f668c67515e8';
+
+  it('accepts 64-char hex keys', () => {
+    expect(normalizeAuthor(hexKey.toUpperCase())).toBe(hexKey);
+  });
+
+  it('decodes npub identifiers to hex', () => {
+    const npub = nip19.npubEncode(hexKey);
+    expect(normalizeAuthor(npub)).toBe(hexKey);
+  });
+
+  it('rejects invalid inputs', () => {
+    expect(() => normalizeAuthor('npub1invalid')).toThrow();
+    expect(() => normalizeAuthor('')).toThrow();
+    expect(() => normalizeAuthor('1234')).toThrow();
+  });
+});
+
+describe('isNostrEvent', () => {
+  const baseEvent = {
+    id: 'ab'.repeat(32),
+    pubkey: 'cd'.repeat(32),
+    created_at: Math.floor(Date.now() / 1000),
+    kind: 10019,
+    tags: [],
+    content: '{}',
+    sig: 'ef'.repeat(64),
+  };
+
+  it('recognizes valid NIP-01 events', () => {
+    expect(isNostrEvent(baseEvent)).toBe(true);
+  });
+
+  it('rejects events with invalid fields', () => {
+    expect(isNostrEvent({ ...baseEvent, sig: 'notvalid' })).toBe(false);
+    expect(isNostrEvent({ ...baseEvent, id: 'xyz' })).toBe(false);
+    expect(isNostrEvent({ ...baseEvent, created_at: 'not-a-number' })).toBe(false);
+  });
+});
+
+describe('replaceable selectors', () => {
+  const baseEvent = {
+    pubkey: 'aa'.repeat(32),
+    tags: [['d', 'tiers']],
+  };
+
+  it('pickLatestReplaceable returns the newest event for a key', () => {
+    const events = [
+      { ...baseEvent, kind: 10019, created_at: 10, id: '10'.repeat(32) },
+      { ...baseEvent, kind: 10019, created_at: 20, id: '20'.repeat(32) },
+      { ...baseEvent, kind: 10019, created_at: 15, id: '15'.repeat(32) },
+    ];
+    const latest = pickLatestReplaceable(events);
+    expect(latest?.created_at).toBe(20);
+  });
+
+  it('pickLatestParamReplaceable respects the first d tag', () => {
+    const events = [
+      {
+        ...baseEvent,
+        kind: 30019,
+        created_at: 5,
+        id: '05'.repeat(32),
+        tags: [['d', 'tiers'], ['d', 'other']],
+      },
+      {
+        ...baseEvent,
+        kind: 30019,
+        created_at: 10,
+        id: '10'.repeat(32),
+        tags: [['d', 'tiers']],
+      },
+    ];
+    const latest = pickLatestParamReplaceable(events);
+    expect(latest?.created_at).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- rework Nutzap profile page to publish and reload kind 10019 profiles and parameterized tier events from relay.fundstr.me
- add robust nostr helper utilities for author normalization, replaceable selection, Fundstr-first querying, and signed publishing acknowledgements
- document the integration and cover helper behaviour with unit tests

## Testing
- pnpm test
- pnpm exec vitest run src/pages/nutzap-profile/__tests__/nostrHelpers.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd1791c21883308a50a69e07711436