### PR TITLE
Add Fundstr relay to default lists

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -308,6 +308,7 @@
     <script type="module" defer>
       import { filterHealthyRelays } from "./relayHealth.js";
       const DEFAULT_RELAYS = [
+        "wss://relay.fundstr.me",
         "wss://relay.damus.io",
         "wss://relay.primal.net",
         "wss://relay.snort.social",

--- a/scripts/update-featured-creators.js
+++ b/scripts/update-featured-creators.js
@@ -12,6 +12,7 @@ function NostrWebSocket(url, opts) {
 useWebSocketImplementation(NostrWebSocket);
 
 const DEFAULT_RELAYS = [
+  'wss://relay.fundstr.me',
   'wss://relay.damus.io',
   'wss://relay.primal.net',
   'wss://relay.snort.social',

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -9,6 +9,7 @@ export const FALLBACK_RELAYS: string[] = [
 
 // Curated default read relays – these are added at boot for read operations only.
 export const DEFAULT_RELAYS = [
+  "wss://relay.fundstr.me",
   "wss://relay.damus.io",
   "wss://relay.snort.social",
   "wss://relay.primal.net",


### PR DESCRIPTION
## Summary
- include wss://relay.fundstr.me in the DEFAULT_RELAYS configuration
- propagate the updated relay defaults to supporting scripts/assets that mirror the list

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cd2c5f5e6c8330b3a3c4f6a865c83c