### PR TITLE
Add heartbeat watchdog for stalled Nostr relays

### DIFF
--- a/src/js/nostr-runtime.ts
+++ b/src/js/nostr-runtime.ts
@@ -1,24 +1,62 @@
 import type NDK from "@nostr-dev-kit/ndk";
-import { NDKKind, type NDKEvent, type NDKFilter } from "@nostr-dev-kit/ndk";
+import {
+  NDKKind,
+  NDKRelaySet,
+  type NDKEvent,
+  type NDKFilter,
+} from "@nostr-dev-kit/ndk";
 import { useNdk } from "src/composables/useNdk";
 
 export class RelayWatchdog {
   private ndk: NDK;
   private timer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private ndkReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingHeartbeats = new Map<string, PendingHeartbeat>();
+  private reconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private minConnected = 0;
+  private fallbackRelays: string[] = [];
+  private running = false;
+  private readonly options: Required<RelayWatchdogOptions>;
+  private readonly poolDisconnectHandler = (relay: any) => {
+    const url = relay?.url;
+    if (url) this.cleanupHeartbeat(url);
+  };
 
-  constructor(ndk: NDK) {
+  constructor(ndk: NDK, options: RelayWatchdogOptions = {}) {
     this.ndk = ndk;
+    this.options = {
+      heartbeatIntervalMs: options.heartbeatIntervalMs ?? 15000,
+      heartbeatAckTimeoutMs: options.heartbeatAckTimeoutMs ?? 6000,
+      reconnectDelayMs: options.reconnectDelayMs ?? 2500,
+    };
+  }
+
+  updateNdk(ndk: NDK) {
+    if (this.ndk === ndk) return;
+    this.detachPoolListeners();
+    this.ndk = ndk;
+    if (this.running) {
+      this.attachPoolListeners();
+    }
   }
 
   start(minConnected: number, fallbackRelays: string[]) {
+    this.stop();
+    this.running = true;
+    this.minConnected = minConnected;
+    this.fallbackRelays = fallbackRelays;
+
+    this.attachPoolListeners();
+
     const check = async () => {
       try {
         const pool = this.ndk.pool;
         const connected = [...pool.relays.values()].filter(
           (r: any) => r.connected,
         ).length;
-        if (connected >= minConnected) return;
-        for (const url of fallbackRelays) {
+        if (connected >= this.minConnected) return;
+        for (const url of this.fallbackRelays) {
           if (!pool.relays.has(url)) {
             this.ndk.addExplicitRelay(url);
           }
@@ -28,18 +66,190 @@ export class RelayWatchdog {
         console.error("[RelayWatchdog]", e);
       }
     };
-    // run immediately and then periodically
+
+    const heartbeat = () => {
+      void this.pingRelays();
+    };
+
     void check();
+    heartbeat();
+
     this.timer = setInterval(() => {
       void check();
     }, 5000);
+
+    this.heartbeatTimer = setInterval(heartbeat, this.options.heartbeatIntervalMs);
   }
 
   stop() {
     if (this.timer) clearInterval(this.timer);
     this.timer = null;
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+    if (this.ndkReconnectTimer) clearTimeout(this.ndkReconnectTimer);
+    this.ndkReconnectTimer = null;
+    for (const { timeout, sub } of this.pendingHeartbeats.values()) {
+      clearTimeout(timeout);
+      try {
+        sub.stop?.();
+      } catch (err) {
+        console.debug("[RelayWatchdog] failed to stop heartbeat subscription", err);
+      }
+    }
+    this.pendingHeartbeats.clear();
+    for (const timer of this.reconnectTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.reconnectTimers.clear();
+    this.detachPoolListeners();
+    this.running = false;
+  }
+
+  private attachPoolListeners() {
+    (this.ndk.pool as any).on?.("relay:disconnect", this.poolDisconnectHandler);
+  }
+
+  private detachPoolListeners() {
+    (this.ndk.pool as any).off?.("relay:disconnect", this.poolDisconnectHandler);
+  }
+
+  private async pingRelays() {
+    const relays = [...this.ndk.pool.relays.values()];
+    for (const relay of relays) {
+      const url = relay?.url;
+      if (!url || !relay?.connected) continue;
+      if (this.pendingHeartbeats.has(url)) continue;
+      this.sendHeartbeat(relay).catch((err) => {
+        console.debug("[RelayWatchdog] heartbeat send failed", err);
+      });
+    }
+  }
+
+  private async sendHeartbeat(relay: any) {
+    const url: string | undefined = relay?.url;
+    if (!url) return;
+
+    const relaySet = new NDKRelaySet(new Set([relay]), this.ndk, this.ndk.pool);
+    const filter: NDKFilter = {
+      kinds: [NDKKind.Metadata],
+      authors: ["0".repeat(64)],
+      limit: 1,
+      since: Math.floor(Date.now() / 1000),
+    };
+
+    const sub = this.ndk.subscribe([filter], {
+      closeOnEose: true,
+      groupable: false,
+      relaySet,
+    }, false as any);
+
+    const cleanup = () => {
+      if (this.pendingHeartbeats.get(url)?.sub === sub) {
+        this.pendingHeartbeats.delete(url);
+      }
+      try {
+        sub.stop?.();
+      } catch (err) {
+        console.debug("[RelayWatchdog] cleanup failed", err);
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      cleanup();
+      this.handleHeartbeatTimeout(relay);
+    }, this.options.heartbeatAckTimeoutMs);
+
+    this.pendingHeartbeats.set(url, { timeout, sub });
+
+    const ack = () => {
+      clearTimeout(timeout);
+      cleanup();
+      this.handleHeartbeatAck(relay);
+    };
+
+    sub.on?.("eose", ack);
+    sub.on?.("event", ack);
+    sub.on?.("close", () => {
+      clearTimeout(timeout);
+      cleanup();
+    });
+
+    sub.start?.();
+  }
+
+  private handleHeartbeatAck(relay: any) {
+    const url: string | undefined = relay?.url;
+    if (!url) return;
+    const timer = this.reconnectTimers.get(url);
+    if (timer) {
+      clearTimeout(timer);
+      this.reconnectTimers.delete(url);
+    }
+    (this.ndk.pool as any).emit?.("relay:heartbeat", relay);
+  }
+
+  private handleHeartbeatTimeout(relay: any) {
+    const url: string | undefined = relay?.url;
+    if (!url) return;
+
+    console.warn(`[RelayWatchdog] heartbeat timeout on ${url}`);
+
+    (this.ndk.pool as any).emit?.("relay:stalled", relay);
+
+    try {
+      relay.disconnect?.();
+    } catch (err) {
+      console.debug("[RelayWatchdog] failed to disconnect stalled relay", err);
+    }
+
+    if (!this.reconnectTimers.has(url)) {
+      const timer = setTimeout(() => {
+        this.reconnectTimers.delete(url);
+        try {
+          if (typeof relay.connect === "function") {
+            void relay.connect().catch?.(() => {});
+          } else {
+            void this.ndk.connect().catch(() => {});
+          }
+        } catch (err) {
+          console.debug("[RelayWatchdog] reconnect attempt failed", err);
+        }
+      }, this.options.reconnectDelayMs);
+      this.reconnectTimers.set(url, timer);
+    }
+
+    this.scheduleNdkReconnect();
+  }
+
+  private scheduleNdkReconnect() {
+    if (this.ndkReconnectTimer) return;
+    this.ndkReconnectTimer = setTimeout(() => {
+      this.ndkReconnectTimer = null;
+      void this.ndk.connect().catch(() => {});
+    }, this.options.reconnectDelayMs);
+  }
+
+  private cleanupHeartbeat(url: string) {
+    const pending = this.pendingHeartbeats.get(url);
+    if (!pending) return;
+    clearTimeout(pending.timeout);
+    try {
+      pending.sub.stop?.();
+    } catch {}
+    this.pendingHeartbeats.delete(url);
   }
 }
+
+type PendingHeartbeat = {
+  timeout: ReturnType<typeof setTimeout>;
+  sub: any;
+};
+
+type RelayWatchdogOptions = {
+  heartbeatIntervalMs?: number;
+  heartbeatAckTimeoutMs?: number;
+  reconnectDelayMs?: number;
+};
 
 export async function stickyDmSubscription(
   pubkey: string,

--- a/test/relay-watchdog.heartbeat.spec.ts
+++ b/test/relay-watchdog.heartbeat.spec.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+
+vi.mock("@noble/ciphers/aes.js", () => ({}), { virtual: true });
+vi.mock("../src/composables/useNdk", () => ({
+  useNdk: vi.fn(),
+  rebuildNdk: vi.fn(),
+}));
+
+vi.mock("@nostr-dev-kit/ndk", () => {
+  class RelaySet {
+    relays: Set<any>;
+    constructor(relays: Set<any>) {
+      this.relays = relays;
+    }
+  }
+  return {
+    __esModule: true,
+    default: class {},
+    NDKKind: {
+      Metadata: 0,
+      EncryptedDirectMessage: 4,
+    },
+    NDKRelaySet: RelaySet,
+  };
+});
+
+import { RelayWatchdog } from "../src/js/nostr-runtime";
+
+class FakeSubscription extends EventEmitter {
+  private readonly onStart?: (sub: FakeSubscription) => void;
+
+  constructor(onStart?: (sub: FakeSubscription) => void) {
+    super();
+    this.onStart = onStart;
+  }
+
+  start() {
+    this.onStart?.(this);
+  }
+
+  stop() {
+    this.removeAllListeners();
+  }
+}
+
+class FakeRelay {
+  url: string;
+  connected = true;
+  connect = vi.fn(async () => {
+    this.connected = true;
+  });
+  disconnect = vi.fn(() => {
+    this.connected = false;
+  });
+  private heartbeatDelay: number | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  setHeartbeatResponse(delay: number | null) {
+    this.heartbeatDelay = delay;
+  }
+
+  handleHeartbeat(sub: FakeSubscription) {
+    if (this.heartbeatDelay == null) return;
+    setTimeout(() => {
+      sub.emit("eose");
+    }, this.heartbeatDelay);
+  }
+}
+
+class FakePool extends EventEmitter {
+  relays: Map<string, FakeRelay>;
+
+  constructor(relays: FakeRelay[]) {
+    super();
+    this.relays = new Map(relays.map((relay) => [relay.url, relay]));
+  }
+}
+
+class FakeNdk {
+  pool: FakePool;
+  connect = vi.fn(async () => {});
+  addExplicitRelay = vi.fn();
+
+  constructor(relays: FakeRelay[]) {
+    this.pool = new FakePool(relays);
+  }
+
+  subscribe(_filters: any, opts: any) {
+    const relaySet: { relays: Set<any> } | undefined = opts?.relaySet;
+    const relay = relaySet ? Array.from(relaySet.relays)[0] : undefined;
+    const sub = new FakeSubscription((subscription) => {
+      (relay as FakeRelay | undefined)?.handleHeartbeat(subscription);
+    });
+    return sub;
+  }
+}
+
+describe("RelayWatchdog heartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("disconnects and reconnects stalled relays", async () => {
+    const relay = new FakeRelay("wss://stall");
+    relay.setHeartbeatResponse(null);
+    const ndk = new FakeNdk([relay]);
+
+    const watchdog = new RelayWatchdog(ndk as any, {
+      heartbeatIntervalMs: 50,
+      heartbeatAckTimeoutMs: 100,
+      reconnectDelayMs: 150,
+    });
+
+    watchdog.start(1, []);
+
+    await vi.runOnlyPendingTimersAsync();
+
+    vi.advanceTimersByTime(50);
+    await vi.runOnlyPendingTimersAsync();
+
+    vi.advanceTimersByTime(100);
+    expect(relay.disconnect).toHaveBeenCalled();
+
+    vi.advanceTimersByTime(150);
+    expect(relay.connect).toHaveBeenCalled();
+
+    watchdog.stop();
+  });
+
+  it("keeps responsive relays connected", async () => {
+    const relay = new FakeRelay("wss://alive");
+    relay.setHeartbeatResponse(30);
+    const ndk = new FakeNdk([relay]);
+
+    const watchdog = new RelayWatchdog(ndk as any, {
+      heartbeatIntervalMs: 40,
+      heartbeatAckTimeoutMs: 100,
+      reconnectDelayMs: 120,
+    });
+
+    watchdog.start(1, []);
+
+    await vi.runOnlyPendingTimersAsync();
+    vi.advanceTimersByTime(40);
+    await vi.runOnlyPendingTimersAsync();
+    vi.advanceTimersByTime(30);
+    await vi.runOnlyPendingTimersAsync();
+
+    vi.advanceTimersByTime(120);
+
+    expect(relay.disconnect).not.toHaveBeenCalled();
+    expect(relay.connect).not.toHaveBeenCalled();
+
+    watchdog.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- add heartbeat monitoring to the RelayWatchdog so relays emit stalled/heartbeat events and reconnect automatically
- hook the watchdog into the shared NDK boot logic and nostr store to surface stalled relays and keep UI state in sync
- cover stalled and responsive relays with a dedicated vitest suite

## Testing
- pnpm test
- pnpm vitest run test/relay-watchdog.heartbeat.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68cd2e56403c833091f7cfb5307d7cba