### PR TITLE
Support legacy tier events alongside modern format

### DIFF
--- a/src/nostr/tiers.ts
+++ b/src/nostr/tiers.ts
@@ -2,6 +2,15 @@ import type { Event as NostrEvent } from "nostr-tools";
 import type { Tier } from "src/stores/types";
 import { filterValidMedia } from "src/utils/validateMedia";
 
+function firstDTag(event: NostrEvent): string | undefined {
+  for (const tag of event.tags || []) {
+    if (tag[0] === "d" && typeof tag[1] === "string") {
+      return tag[1];
+    }
+  }
+  return undefined;
+}
+
 export function parseTierDefinitionEvent(event: NostrEvent): Tier[] {
   let raw: any[] = [];
   try {
@@ -27,10 +36,32 @@ export function parseTierDefinitionEvent(event: NostrEvent): Tier[] {
 
 export function pickTierDefinitionEvent(events: NostrEvent[]): NostrEvent | null {
   if (!events.length) return null;
-  return events
-    .filter((e) => e.kind === 30019 || e.kind === 30000)
-    .sort((a, b) => {
+  const candidates = new Map<string, NostrEvent>();
+  for (const event of events) {
+    if (event.kind !== 30019 && event.kind !== 30000) continue;
+    const d = firstDTag(event) ?? "tiers";
+    const key = `${event.kind}:${event.pubkey}:${d}`;
+    const prev = candidates.get(key);
+    if (!prev) {
+      candidates.set(key, event);
+      continue;
+    }
+    if (event.created_at > prev.created_at) {
+      candidates.set(key, event);
+      continue;
+    }
+    if (event.created_at === prev.created_at && (event.id ?? "") > (prev.id ?? "")) {
+      candidates.set(key, event);
+    }
+  }
+
+  const deduped = Array.from(candidates.values());
+  if (!deduped.length) return null;
+  return (
+    deduped.sort((a, b) => {
+      if (b.created_at !== a.created_at) return b.created_at - a.created_at;
       if (a.kind !== b.kind) return a.kind === 30019 ? -1 : 1;
-      return b.created_at - a.created_at;
-    })[0] || null;
+      return (b.id ?? "") > (a.id ?? "") ? 1 : -1;
+    })[0] || null
+  );
 }

--- a/test/tiers.spec.ts
+++ b/test/tiers.spec.ts
@@ -1,35 +1,50 @@
 import { describe, it, expect } from 'vitest';
 import { parseTierDefinitionEvent, pickTierDefinitionEvent } from '../src/nostr/tiers';
 
-const legacyEvent = {
+const baseLegacyEvent = {
   kind: 30000,
-  content: JSON.stringify({ tiers: [
-    { id: 'b', price: 2 },
-    { id: 'a', price: 1 }
-  ] }),
-  created_at: 1,
+  pubkey: 'pk',
+  tags: [['d', 'tiers']],
+  content: JSON.stringify({
+    tiers: [
+      { id: 'b', price: 200, perks: 'Legacy Perk' },
+      { id: 'a', price: 100 },
+    ],
+  }),
 } as any;
 
-const newEvent = {
+const baseModernEvent = {
   kind: 30019,
+  pubkey: 'pk',
+  tags: [['d', 'tiers']],
   content: JSON.stringify([
-    { id: 'b', price_sats: 2 },
-    { id: 'a', price_sats: 1 }
+    { id: 'b', price_sats: 200, media: [{ url: 'https://ok' }] },
+    { id: 'a', price_sats: 100, perks: 'Modern perk' },
   ]),
-  created_at: 2,
 } as any;
 
 describe('tier definition readers', () => {
-  it('parses legacy kind 30000', () => {
+  it('normalizes legacy kind 30000 payloads', () => {
+    const legacyEvent = { ...baseLegacyEvent, created_at: 1 };
     const tiers = parseTierDefinitionEvent(legacyEvent);
-    expect(tiers.map(t => t.id)).toEqual(['a','b']);
+    expect(tiers.map((t) => t.id)).toEqual(['a', 'b']);
+    expect(tiers[0].price_sats).toBe(100);
+    expect(tiers[1].benefits).toEqual(['Legacy Perk']);
   });
-  it('parses new kind 30019', () => {
-    const tiers = parseTierDefinitionEvent(newEvent);
-    expect(tiers.map(t => t.id)).toEqual(['a','b']);
+
+  it('normalizes modern kind 30019 payloads', () => {
+    const modernEvent = { ...baseModernEvent, created_at: 2 };
+    const tiers = parseTierDefinitionEvent(modernEvent);
+    expect(tiers.map((t) => t.id)).toEqual(['a', 'b']);
+    expect(tiers[0].benefits).toEqual(['Modern perk']);
+    expect(tiers[1].media).toEqual([{ url: 'https://ok' }]);
   });
-  it('prefers kind 30019 over 30000', () => {
-    const chosen = pickTierDefinitionEvent([legacyEvent, newEvent]);
-    expect(chosen?.kind).toBe(30019);
+
+  it('selects the newest tier definition regardless of kind', () => {
+    const modernEvent = { ...baseModernEvent, id: 'modern', created_at: 10 };
+    const newerLegacy = { ...baseLegacyEvent, id: 'legacy', created_at: 20 };
+    const chosen = pickTierDefinitionEvent([modernEvent, newerLegacy]);
+    expect(chosen?.kind).toBe(30000);
+    expect(chosen?.id).toBe('legacy');
   });
 });

--- a/test/vitest/__tests__/publish.spec.ts
+++ b/test/vitest/__tests__/publish.spec.ts
@@ -180,6 +180,13 @@ describe("replaceable semantics", () => {
       created_at: 80,
       tags: [["d", "tiers"]],
     });
+    const tiersLegacy = makeEvent({
+      id: "tiers-legacy",
+      kind: 30000,
+      pubkey: "alice",
+      created_at: 90,
+      tags: [["d", "tiers"]],
+    });
 
     const events: NostrEvent[] = [
       duplicate,
@@ -188,6 +195,7 @@ describe("replaceable semantics", () => {
       profileNew,
       tiersOld,
       tiersNew,
+      tiersLegacy,
     ];
 
     const deduped = dedup(events);
@@ -199,12 +207,12 @@ describe("replaceable semantics", () => {
       pubkey: "alice",
     });
     const latestTiers = pickLatestAddrReplaceable(normalized, {
-      kind: 30019,
+      kind: [30019, 30000],
       pubkey: "alice",
       d: "tiers",
     });
 
     expect(latestProfile?.id).toBe("profile-new");
-    expect(latestTiers?.id).toBe("tiers-new");
+    expect(latestTiers?.id).toBe("tiers-legacy");
   });
 });

--- a/test/vitest/__tests__/relayClient.spec.ts
+++ b/test/vitest/__tests__/relayClient.spec.ts
@@ -76,6 +76,13 @@ describe("relayClient dedup & replaceable handling", () => {
         created_at: 80,
         tags: [["d", "tiers"]],
       }),
+      makeEvent({
+        id: "tiers-legacy",
+        kind: 30000,
+        pubkey: "alice",
+        created_at: 85,
+        tags: [["d", "tiers"]],
+      }),
     ];
 
     const deduped = dedup(events);
@@ -98,11 +105,11 @@ describe("relayClient dedup & replaceable handling", () => {
     expect(latestProfile?.id).toBe("profile-new");
 
     const latestTiers = pickLatestAddrReplaceable(normalized, {
-      kind: 30019,
+      kind: [30019, 30000],
       pubkey: "alice",
       d: "tiers",
     });
-    expect(latestTiers?.id).toBe("tiers-new");
+    expect(latestTiers?.id).toBe("tiers-legacy");
   });
 });
 


### PR DESCRIPTION
## Summary
- allow `queryNutzapTiers` to read both kind 30019 and 30000 tier events and adjust replacement helper to handle multiple kinds
- ensure tier selection utilities dedupe by {kind,pubkey,d} and continue normalizing data across legacy and modern formats
- refresh tier-related tests to cover both event kinds and creators store behaviour

## Testing
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/tiers.spec.ts test/vitest/__tests__/relayClient.spec.ts test/vitest/__tests__/publish.spec.ts test/vitest/__tests__/creators-tiers.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68cd328dec7c833096e1ddbdd2400470