### PR TITLE
Add Fundstr relay status emitter

### DIFF
--- a/src/nutzap/FundstrRelaySocket.ts
+++ b/src/nutzap/FundstrRelaySocket.ts
@@ -1,0 +1,115 @@
+import { getCurrentScope, onScopeDispose, readonly, ref, type Ref } from 'vue';
+import { getNutzapNdk } from './ndkInstance';
+import { NUTZAP_RELAY_WSS } from './relayConfig';
+
+export type FundstrRelayStatus = 'connecting' | 'connected' | 'disconnected';
+
+function normalizeRelayUrl(url?: string): string {
+  return (url ?? '').replace(/\s+/g, '').replace(/\/+$/, '').toLowerCase();
+}
+
+type StatusListener = (status: FundstrRelayStatus) => void;
+
+class FundstrRelaySocket {
+  private readonly targetUrl = normalizeRelayUrl(this.relayUrl);
+  private listeners = new Set<StatusListener>();
+  private status: FundstrRelayStatus = 'connecting';
+  private attached = false;
+  private hasEverConnected = false;
+
+  constructor(private readonly relayUrl: string) {}
+
+  private matchesRelay(relay: any) {
+    const url = typeof relay?.url === 'string' ? relay.url : undefined;
+    return normalizeRelayUrl(url) === this.targetUrl;
+  }
+
+  private setStatus(next: FundstrRelayStatus) {
+    if (next === 'connected') {
+      this.hasEverConnected = true;
+    }
+    if (this.status === next) return;
+    this.status = next;
+    for (const listener of this.listeners) {
+      listener(next);
+    }
+  }
+
+  private refreshStatus() {
+    const ndk = getNutzapNdk();
+    const pool = ndk.pool as any;
+    const relays: any[] = Array.from(pool?.relays?.values?.() ?? []);
+    const relay = relays.find((r) => this.matchesRelay(r));
+    if (relay?.connected) {
+      this.setStatus('connected');
+    } else if (this.hasEverConnected) {
+      this.setStatus('disconnected');
+    } else {
+      this.setStatus('connecting');
+    }
+  }
+
+  private ensureAttached() {
+    if (this.attached) return;
+    this.attached = true;
+    const ndk = getNutzapNdk();
+    const pool = ndk.pool as any;
+
+    const handleConnect = (relay: any) => {
+      if (!this.matchesRelay(relay)) return;
+      this.setStatus('connected');
+    };
+
+    const handleDisconnect = (relay: any) => {
+      if (!this.matchesRelay(relay)) return;
+      this.setStatus(this.hasEverConnected ? 'disconnected' : 'connecting');
+    };
+
+    const handleHeartbeat = (relay: any) => {
+      if (!this.matchesRelay(relay)) return;
+      this.setStatus('connected');
+    };
+
+    pool.on?.('relay:connect', handleConnect);
+    pool.on?.('relay:disconnect', handleDisconnect);
+    (pool as any).on?.('relay:stalled', handleDisconnect);
+    (pool as any).on?.('relay:heartbeat', handleHeartbeat);
+
+    this.refreshStatus();
+  }
+
+  getStatus(): FundstrRelayStatus {
+    this.ensureAttached();
+    return this.status;
+  }
+
+  onStatusChange(listener: StatusListener): () => void {
+    this.ensureAttached();
+    this.listeners.add(listener);
+    listener(this.status);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  useStatus(): Readonly<Ref<FundstrRelayStatus>> {
+    const status = ref(this.getStatus());
+    const stop = this.onStatusChange((next) => {
+      status.value = next;
+    });
+
+    if (getCurrentScope()) {
+      onScopeDispose(() => {
+        stop();
+      });
+    }
+
+    return readonly(status);
+  }
+}
+
+export const fundstrRelaySocket = new FundstrRelaySocket(NUTZAP_RELAY_WSS);
+
+export function useFundstrRelayStatus(): Readonly<Ref<FundstrRelayStatus>> {
+  return fundstrRelaySocket.useStatus();
+}

--- a/src/nutzap/RelayStatusIndicator.vue
+++ b/src/nutzap/RelayStatusIndicator.vue
@@ -5,11 +5,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, computed } from 'vue';
-import { getNutzapNdk } from './ndkInstance';
-import { NUTZAP_RELAY_WSS } from './relayConfig';
+import { computed } from 'vue';
+import { useFundstrRelayStatus } from './FundstrRelaySocket';
 
-const status = ref<'connecting' | 'connected' | 'disconnected'>('connecting');
+const status = useFundstrRelayStatus();
 
 const label = computed(() => {
   switch (status.value) {
@@ -23,21 +22,6 @@ const label = computed(() => {
 });
 
 const statusClass = computed(() => `status-${status.value}`);
-
-let timer: any;
-onMounted(() => {
-  const ndk = getNutzapNdk();
-  timer = setInterval(() => {
-    const relay = (ndk as any).pool?.relays?.get?.(NUTZAP_RELAY_WSS);
-    const connected = relay?.connected || relay?.status === 1;
-    status.value = connected
-      ? 'connected'
-      : status.value === 'connected'
-        ? 'disconnected'
-        : 'connecting';
-  }, 1000);
-});
-onUnmounted(() => clearInterval(timer));
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- introduce a FundstrRelaySocket helper that listens to relay connection events and exposes a reusable status signal
- update the Nutzap relay status indicator to consume the socket status instead of polling the NDK relay pool

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d25074cfac83309e3852888c193eb7