### PR TITLE
Handle HTML responses from Fundstr relay

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -479,7 +479,9 @@ async function loadTiers(authorHex: string) {
     applyTiersEvent(latest, activeKind);
   } catch (err) {
     console.error('[nutzap] failed to load tiers', err);
-    throw err instanceof Error ? err : new Error(String(err));
+    const message = err instanceof Error ? err.message : String(err);
+    notifyError(message);
+    throw err instanceof Error ? err : new Error(message);
   }
 }
 
@@ -491,7 +493,9 @@ async function loadProfile(authorHex: string) {
     ]);
   } catch (err) {
     console.error('[nutzap] failed to load profile', err);
-    throw err instanceof Error ? err : new Error(String(err));
+    const message = err instanceof Error ? err.message : String(err);
+    notifyError(message);
+    throw err instanceof Error ? err : new Error(message);
   }
 
   const latest = pickLatestReplaceable(events);
@@ -663,7 +667,10 @@ async function loadAll() {
   try {
     await Promise.all([loadTiers(authorHex), loadProfile(authorHex)]);
   } catch (err) {
-    notifyError(err instanceof Error ? err.message : 'Failed to load Nutzap profile.');
+    console.error('[nutzap] failed to load Nutzap profile', err);
+    if (!(err instanceof Error)) {
+      notifyError('Failed to load Nutzap profile.');
+    }
   } finally {
     loading.value = false;
   }


### PR DESCRIPTION
## Summary
- guard the HTTP fallback in `fundstrFirstQuery` by inspecting the response body/content-type and surfacing a helpful snippet when JSON parsing fails
- surface relay errors from `loadProfile` / `loadTiers` through `notifyError` while avoiding duplicate generic notifications

## Testing
- pnpm test *(fails: missing `vitest` dependency in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d26cfce1488330b716555bdb84acb0