### PR TITLE
chore(settings): clean up nostr relay defaults

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,9 +1,60 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
 import { DEFAULT_RELAYS } from "src/config/relays";
+import { sanitizeRelayUrls } from "src/utils/relay";
+
+const RELAY_DENYLIST = new Set(
+  ["relay.nostr.bg", "nostr.zebedee.cloud", "relay.plebstr.com"].map((host) =>
+    host.toLowerCase(),
+  ),
+);
 
 export const useSettingsStore = defineStore("settings", {
   state: () => {
+    const defaultNostrRelays = useLocalStorage<string[]>(
+      "cashu.settings.defaultNostrRelays",
+      DEFAULT_RELAYS,
+    );
+
+    const existing = Array.isArray(defaultNostrRelays.value)
+      ? [...defaultNostrRelays.value]
+      : [];
+    const sanitized = sanitizeRelayUrls(existing);
+    const filtered: string[] = [];
+    const removed: string[] = [];
+
+    for (const url of sanitized) {
+      try {
+        const hostname = new URL(url).hostname.toLowerCase();
+        if (RELAY_DENYLIST.has(hostname)) {
+          removed.push(url);
+          continue;
+        }
+      } catch (error) {
+        removed.push(url);
+        continue;
+      }
+      filtered.push(url);
+    }
+
+    let next = filtered;
+    if (!next.length) {
+      next = [...DEFAULT_RELAYS];
+    }
+
+    const beforeKey = JSON.stringify(existing);
+    const afterKey = JSON.stringify(next);
+    const changed = beforeKey !== afterKey;
+
+    defaultNostrRelays.value = next;
+
+    if (changed && removed.length) {
+      console.info(
+        "[settings] Removed blocked Nostr relays from defaults",
+        removed,
+      );
+    }
+
     return {
       getBitcoinPrice: useLocalStorage<boolean>(
         "cashu.settings.getBitcoinPrice",
@@ -29,10 +80,7 @@ export const useSettingsStore = defineStore("settings", {
         "cashu.settings.useWebsockets",
         true,
       ),
-      defaultNostrRelays: useLocalStorage<string[]>(
-        "cashu.settings.defaultNostrRelays",
-        DEFAULT_RELAYS,
-      ),
+      defaultNostrRelays,
       includeFeesInSendAmount: useLocalStorage<boolean>(
         "cashu.settings.includeFeesInSendAmount",
         false,


### PR DESCRIPTION
## Summary
- sanitize the persisted default Nostr relay list and drop hosts on a denylist
- repopulate empty results with the curated DEFAULT_RELAYS and log removals

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d27c6202b88330bd342cbc7b7566da