### PR TITLE
Update Nutzap relay fallbacks and HTTP headers

### DIFF
--- a/docs/relay-access.md
+++ b/docs/relay-access.md
@@ -16,7 +16,7 @@ Publishes must send a fully signed NIP-01 event to /event; the client validates 
    automatically performs the same query over HTTP:
    `https://relay.fundstr.me/req?filters=…`.
 4. When Fundstr returns no data the client fans out across a vetted pool of
-   public relays (`relay.primal.net`, `relay.f7z.io`, `nos.lol`,
+   public relays (`relay.primal.net`, `relay.fundstr.me`, `nos.lol`,
    `relay.damus.io`). This pool is also used when discovery explicitly prefers
    public relays.
 

--- a/src/nostr/relayClient.ts
+++ b/src/nostr/relayClient.ts
@@ -34,7 +34,7 @@ const FUNDSTR = {
 
 const PUBLIC_POOL = [
   "wss://relay.primal.net",
-  "wss://relay.f7z.io",
+  "wss://relay.fundstr.me",
   "wss://nos.lol",
   "wss://relay.damus.io",
 ];

--- a/src/nostr/relays.ts
+++ b/src/nostr/relays.ts
@@ -8,8 +8,6 @@ export const DM_BLOCKLIST = new Set<string>([
   'wss://purplepag.es/',
   'wss://relayable.org',
   'wss://relayable.org/',
-  'wss://relay.f7z.io',
-  'wss://relay.f7z.io/',
   'wss://relay.nostr.band',
   'wss://relay.nostr.band/',
 ]);

--- a/src/pages/nutzap-profile/nostrHelpers.ts
+++ b/src/pages/nutzap-profile/nostrHelpers.ts
@@ -492,7 +492,9 @@ export async function fundstrFirstQuery(
     url.searchParams.set('filters', JSON.stringify(filters));
     const response = await fetch(url.toString(), {
       method: 'GET',
-      headers: { Accept: 'application/json' },
+      headers: {
+        Accept: 'application/nostr+json, application/json;q=0.9, */*;q=0.1',
+      },
     });
     const bodyText = await response.text();
     const normalizeSnippet = (input: string) =>
@@ -508,7 +510,11 @@ export async function fundstrFirstQuery(
     }
 
     const contentType = response.headers.get('content-type') || '';
-    if (!contentType.toLowerCase().includes('application/json')) {
+    const normalizedType = contentType.toLowerCase();
+    const isJson =
+      normalizedType.includes('application/json') ||
+      normalizedType.includes('application/nostr+json');
+    if (!isJson) {
       const snippet = normalizeSnippet(bodyText) || '[empty response body]';
       const typeLabel = contentType || 'unknown content-type';
       throw new Error(`Unexpected response (${response.status}, ${typeLabel}): ${snippet}`);


### PR DESCRIPTION
## Summary
- replace the f7z fallback relay with wss://relay.fundstr.me in the nostr client and DM relay helpers
- accept application/nostr+json responses from the HTTP fallback and request them explicitly
- align relay access documentation with the updated fallback pool

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d385bcd31c8330b8c665b649f9f300