### PR TITLE
Fix proxy relay CORS handling and upstream selection

### DIFF
--- a/workers/fundstr-proxy/.env.example
+++ b/workers/fundstr-proxy/.env.example
@@ -1,3 +1,4 @@
+# Base URL for this proxy; HTTP and WSS variants are derived automatically.
 PROXY_BASE=https://staging.fundstr.me
 
 # Optional upstream overrides for /req bridge


### PR DESCRIPTION
## Summary
- add dynamic CORS header helper so /req and /event responses always include the correct Access-Control headers
- guard derived PROXY_BASE targets to avoid self-recursive upstream fetches and prefer configured relays
- document the PROXY_BASE usage in the worker env example for deploys

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d3cdc1299483308f834b4f6e05c38a