### PR TITLE
Implement WebSocket publish flow for Nutzap relay client

### DIFF
--- a/src/nutzap/relayEndpoints.ts
+++ b/src/nutzap/relayEndpoints.ts
@@ -1,0 +1,49 @@
+import {
+  NUTZAP_RELAY_WSS,
+  NUTZAP_RELAY_HTTP,
+  NUTZAP_WS_TIMEOUT_MS,
+  NUTZAP_HTTP_TIMEOUT_MS,
+} from './relayConfig';
+
+const DEFAULT_WS_TIMEOUT_MS = 3000;
+const DEFAULT_HTTP_TIMEOUT_MS = 5000;
+
+function stripTrailingSlashes(input: string): string {
+  return input.replace(/\/+$/, '');
+}
+
+function joinRelayPath(base: string, path: string): string {
+  const normalizedBase = stripTrailingSlashes(base || '');
+  const normalizedPath = path.replace(/^\/+/, '');
+  if (!normalizedBase) {
+    return `/${normalizedPath}`;
+  }
+  return `${normalizedBase}/${normalizedPath}`;
+}
+
+function toPositiveNumber(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  const parsed = typeof value === 'string' ? Number(value) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return parsed;
+  }
+  return fallback;
+}
+
+const FUNDSTR_HTTP_BASE = stripTrailingSlashes(NUTZAP_RELAY_HTTP);
+
+export const FUNDSTR_WS_URL = NUTZAP_RELAY_WSS;
+export const FUNDSTR_REQ_URL = joinRelayPath(FUNDSTR_HTTP_BASE, 'req');
+export const FUNDSTR_EVT_URL = joinRelayPath(FUNDSTR_HTTP_BASE, 'event');
+export const WS_FIRST_TIMEOUT_MS = toPositiveNumber(
+  NUTZAP_WS_TIMEOUT_MS,
+  DEFAULT_WS_TIMEOUT_MS,
+);
+export const HTTP_FALLBACK_TIMEOUT_MS = toPositiveNumber(
+  NUTZAP_HTTP_TIMEOUT_MS,
+  DEFAULT_HTTP_TIMEOUT_MS,
+);
+
+export { joinRelayPath, stripTrailingSlashes, toPositiveNumber };


### PR DESCRIPTION
## Summary
- add WebSocket publish pipeline to the shared relay client with OK/NOTICE handling and HTTP fallback
- centralize relay endpoints in a shared helper and switch Nutzap publish helpers/UI to surface relay responses
- extend nostr helper tests to cover publish success, rejection, and HTTP fallback scenarios

## Testing
- pnpm vitest run src/pages/nutzap-profile/__tests__/nostrHelpers.spec.ts
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d42ffea2588330909e4cd844707625