### PR TITLE
Refactor Nutzap profile into toolkit experience

### DIFF
--- a/src/components/nutzap/NutzapExplorerV2.vue
+++ b/src/components/nutzap/NutzapExplorerV2.vue
@@ -1,0 +1,620 @@
+<template>
+  <q-card class="q-pa-md column q-gutter-md">
+    <div class="row items-center justify-between">
+      <div class="text-subtitle1">Explorer v2 — Multi-Relay Search</div>
+      <div class="text-caption text-2">{{ statusText }}</div>
+    </div>
+
+    <div class="column q-gutter-sm">
+      <div class="row q-col-gutter-sm items-stretch">
+        <div class="col-12 col-md-6 col-lg-7">
+          <q-input
+            v-model="query"
+            dense
+            filled
+            label="npub / note / nprofile / nevent / naddr / NIP-05 / text"
+            @keyup.enter="runSearch"
+          />
+        </div>
+        <div class="col-12 col-md-2 col-lg-2">
+          <q-select
+            v-model="mode"
+            dense
+            filled
+            :options="modeOptions"
+            emit-value
+            map-options
+            label="Mode"
+          />
+        </div>
+        <div class="col-6 col-md-2 col-lg-1">
+          <q-input v-model.number="limit" type="number" dense filled label="Limit" />
+        </div>
+        <div class="col-6 col-md-2 col-lg-2">
+          <q-input v-model.number="days" type="number" dense filled label="Days back" />
+        </div>
+      </div>
+      <div class="row q-col-gutter-sm items-center">
+        <div class="col-auto">
+          <q-btn color="primary" label="Search" @click="runSearch" :disable="running" :loading="running" />
+        </div>
+        <div class="col-auto">
+          <q-btn flat label="Stop" color="primary" :disable="!running" @click="stopSearch" />
+        </div>
+        <div class="col-auto">
+          <q-checkbox v-model="onlyFundstr" label="Only relay.fundstr.me" dense />
+        </div>
+      </div>
+    </div>
+
+    <q-separator />
+
+    <div class="column q-gutter-sm">
+      <div class="row items-center q-gutter-sm wrap">
+        <div class="text-caption text-2">Active relays</div>
+        <q-chip
+          v-for="relay in relayList"
+          :key="relay"
+          dense
+          removable
+          color="primary"
+          text-color="white"
+          @remove="removeRelay(relay)"
+        >
+          {{ relay }}
+        </q-chip>
+        <div v-if="!relayList.length" class="text-caption text-2">No relays selected.</div>
+      </div>
+      <div class="row q-col-gutter-sm items-stretch">
+        <div class="col-12 col-md-8">
+          <q-input v-model="newRelay" dense filled label="Add relay (wss://)" />
+        </div>
+        <div class="col-6 col-md-2">
+          <q-btn color="primary" label="Add" class="full-width" @click="addRelay" />
+        </div>
+        <div class="col-6 col-md-2">
+          <q-btn flat color="primary" label="Reset" class="full-width" @click="resetRelays" />
+        </div>
+      </div>
+    </div>
+
+    <q-separator />
+
+    <div class="column q-gutter-sm">
+      <template v-if="!results.length">
+        <div class="text-caption text-2">No results yet.</div>
+      </template>
+      <template v-else>
+        <q-card v-for="item in results" :key="item.id" class="bg-surface-2 q-pa-md">
+          <component :is="getRenderer(item)" :entry="item" />
+        </q-card>
+      </template>
+    </div>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+import { computed, defineAsyncComponent, onBeforeUnmount, reactive, ref } from 'vue';
+import { nip05, nip19, SimplePool, type Event as NostrEvent } from 'nostr-tools';
+
+const DEFAULT_RELAYS = [
+  'wss://relay.fundstr.me',
+  'wss://relay.damus.io',
+  'wss://relay.primal.net',
+  'wss://relay.snort.social',
+  'wss://nos.lol',
+  'wss://offchain.pub',
+  'wss://purplepag.es',
+  'wss://eden.nostr.land',
+];
+
+const WS_SUBPROTOCOLS = ['nostr'];
+
+type ExplorerMode = 'auto' | 'profiles' | 'notes' | 'any';
+
+type ResultKind = 'info' | 'error' | 'profile' | 'note' | 'nutzap-profile' | 'tiers';
+
+interface BaseResult {
+  id: string;
+  kind: ResultKind;
+  message?: string;
+}
+
+interface EventResult extends BaseResult {
+  event: NostrEvent;
+}
+
+type ExplorerResult = BaseResult | EventResult;
+
+const modeOptions = [
+  { label: 'Auto', value: 'auto' },
+  { label: 'Profiles', value: 'profiles' },
+  { label: 'Notes', value: 'notes' },
+  { label: 'Any', value: 'any' },
+];
+
+const query = ref('');
+const mode = ref<ExplorerMode>('auto');
+const limit = ref(40);
+const days = ref(30);
+const onlyFundstr = ref(false);
+const newRelay = ref('');
+const relays = reactive(new Set(DEFAULT_RELAYS));
+const status = ref('Idle');
+const running = ref(false);
+const results = ref<ExplorerResult[]>([]);
+const searchToken = ref(0);
+const activeClosers: Array<() => void> = [];
+const pool = new SimplePool();
+
+const relayList = computed(() => Array.from(relays.values()));
+const statusText = computed(() => status.value);
+
+const renderers = {
+  info: defineAsyncComponent(() => import('./parts/ExplorerInfo.vue')),
+  error: defineAsyncComponent(() => import('./parts/ExplorerError.vue')),
+  profile: defineAsyncComponent(() => import('./parts/ExplorerProfileCard.vue')),
+  note: defineAsyncComponent(() => import('./parts/ExplorerNoteCard.vue')),
+  'nutzap-profile': defineAsyncComponent(() => import('./parts/ExplorerNutzapProfileCard.vue')),
+  tiers: defineAsyncComponent(() => import('./parts/ExplorerTiersCard.vue')),
+};
+
+function getRenderer(entry: ExplorerResult) {
+  return renderers[entry.kind] ?? renderers.info;
+}
+
+function pushInfo(message: string) {
+  results.value.unshift({ id: `${Date.now()}-${Math.random()}`, kind: 'info', message });
+}
+
+function pushError(message: string) {
+  results.value.unshift({ id: `${Date.now()}-${Math.random()}`, kind: 'error', message });
+}
+
+function setStatus(text: string) {
+  status.value = text;
+}
+
+function normalize(url: string) {
+  try {
+    const parsed = new URL(url.trim());
+    if (!/^wss?:$/i.test(parsed.protocol)) {
+      return '';
+    }
+    parsed.pathname = parsed.pathname.replace(/\/$/, '');
+    parsed.hash = '';
+    parsed.search = '';
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`.toLowerCase();
+  } catch {
+    if (!url) return '';
+    const prefixed = url.trim().startsWith('wss://') ? url.trim() : `wss://${url.trim()}`;
+    return normalize(prefixed);
+  }
+}
+
+function addRelay() {
+  const value = newRelay.value.trim();
+  if (!value) return;
+  const normalized = normalize(value);
+  if (!normalized) {
+    setStatus('Invalid relay URL.');
+    return;
+  }
+  relays.add(normalized);
+  newRelay.value = '';
+  setStatus(`Relay added: ${normalized}`);
+}
+
+function removeRelay(url: string) {
+  relays.delete(url);
+}
+
+function resetRelays() {
+  relays.clear();
+  DEFAULT_RELAYS.forEach(url => relays.add(url));
+  setStatus('Relays reset to defaults.');
+}
+
+function stopSearch() {
+  running.value = false;
+  setStatus('Stopped');
+  for (const close of activeClosers.splice(0)) {
+    try {
+      close();
+    } catch (err) {
+      console.warn('[explorer] close failed', err);
+    }
+  }
+}
+
+onBeforeUnmount(() => {
+  stopSearch();
+  pool.close();
+});
+
+async function listOnceViaPool(filters: any | any[], relayUrls: string[], timeoutMs = 8000) {
+  const token = ++searchToken.value;
+  const sub = pool.sub(relayUrls, Array.isArray(filters) ? filters : [filters]);
+  let resolved = false;
+  const events: NostrEvent[] = [];
+  const close = () => {
+    if (resolved) return;
+    resolved = true;
+    try {
+      sub.unsub();
+    } catch {/* noop */}
+    const idx = activeClosers.indexOf(close);
+    if (idx >= 0) activeClosers.splice(idx, 1);
+  };
+  activeClosers.push(close);
+
+  return await new Promise<NostrEvent[]>(resolve => {
+    const timer = setTimeout(() => {
+      close();
+      resolve(events);
+    }, timeoutMs);
+
+    sub.on('event', event => {
+      if (token !== searchToken.value) return;
+      events.push(event as NostrEvent);
+    });
+    sub.on('eose', () => {
+      clearTimeout(timer);
+      close();
+      resolve(events);
+    });
+  });
+}
+
+async function listOnceViaRaw(filters: any, relayUrls: string[], timeoutMs = 8000) {
+  const token = ++searchToken.value;
+  const events: NostrEvent[] = [];
+  const seen = new Set<string>();
+  const closers: Array<() => void> = [];
+  let pending = relayUrls.length;
+
+  return await new Promise<NostrEvent[]>(resolve => {
+    const finish = () => {
+      for (const close of closers) close();
+      const idx = activeClosers.indexOf(finish);
+      if (idx >= 0) activeClosers.splice(idx, 1);
+      resolve(events.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0)));
+    };
+
+    if (!pending) {
+      finish();
+      return;
+    }
+
+    relayUrls.forEach((url, index) => {
+      let closed = false;
+      const ws = new WebSocket(url, WS_SUBPROTOCOLS);
+      const subId = `srch-${token}-${index}-${Math.random().toString(36).slice(2)}`;
+
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        try {
+          ws.send(JSON.stringify(['CLOSE', subId]));
+        } catch {/* noop */}
+        try {
+          ws.close();
+        } catch {/* noop */}
+        const idxActive = activeClosers.indexOf(close);
+        if (idxActive >= 0) {
+          activeClosers.splice(idxActive, 1);
+        }
+        pending -= 1;
+        if (pending <= 0) finish();
+      };
+
+      closers.push(close);
+      activeClosers.push(close);
+
+      const timer = setTimeout(() => close(), timeoutMs);
+
+      ws.onopen = () => {
+        try {
+          ws.send(JSON.stringify(['REQ', subId, filters]));
+        } catch (err) {
+          console.warn('[explorer] raw send failed', err);
+          close();
+        }
+      };
+      ws.onmessage = evt => {
+        try {
+          const payload = JSON.parse(evt.data as string);
+          if (!Array.isArray(payload)) return;
+          if (payload[0] === 'EVENT') {
+            const event = payload[2] as NostrEvent;
+            if (searchToken.value !== token) return;
+            if (!event?.id || seen.has(event.id)) return;
+            seen.add(event.id);
+            events.push(event);
+          } else if (payload[0] === 'EOSE') {
+            clearTimeout(timer);
+            close();
+          }
+        } catch (err) {
+          console.warn('[explorer] raw parse failed', err);
+        }
+      };
+      ws.onerror = () => close();
+      ws.onclose = () => close();
+    });
+  });
+}
+
+async function listOnceMulti(filters: any | any[], relayUrls: string[], timeoutMs = 8000) {
+  try {
+    const events = await listOnceViaPool(filters, relayUrls, timeoutMs);
+    return events.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0));
+  } catch (err) {
+    console.warn('[explorer] pool failed, using raw fallback', err);
+    return await listOnceViaRaw(filters, relayUrls, timeoutMs);
+  }
+}
+
+function pickRelays(additional?: string[]) {
+  if (onlyFundstr.value) {
+    return ['wss://relay.fundstr.me'];
+  }
+  const selected = new Set(relayList.value);
+  for (const url of additional ?? []) {
+    const normalized = normalize(url);
+    if (normalized) selected.add(normalized);
+  }
+  return Array.from(selected.values());
+}
+
+function uniqueBy<T extends { id?: string }>(events: T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const event of events) {
+    const id = typeof event.id === 'string' ? event.id : '';
+    if (!id) continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(event);
+  }
+  return out;
+}
+
+function pushEvent(kind: ResultKind, event: NostrEvent) {
+  results.value.unshift({
+    id: `${event.id}-${kind}`,
+    kind,
+    event,
+  });
+}
+
+async function resolveNip05(identifier: string) {
+  try {
+    const resolved = await nip05.queryProfile(identifier);
+    return resolved?.pubkey ?? null;
+  } catch (err) {
+    console.warn('[explorer] nip05 resolve failed', err);
+    return null;
+  }
+}
+
+function renderInfo(message: string) {
+  pushInfo(message);
+}
+
+function renderError(message: string) {
+  pushError(message);
+}
+
+function routeEvent(event: NostrEvent) {
+  if (event.kind === 0) {
+    pushEvent('profile', event);
+  } else if (event.kind === 1) {
+    pushEvent('note', event);
+  } else if (event.kind === 10019) {
+    pushEvent('nutzap-profile', event);
+  } else if (event.kind === 30000) {
+    pushEvent('tiers', event);
+  } else {
+    results.value.unshift({
+      id: `${event.id}-raw`,
+      kind: 'info',
+      message: JSON.stringify(event, null, 2),
+    });
+  }
+}
+
+async function runSearch() {
+  if (running.value) {
+    stopSearch();
+  }
+
+  const input = query.value.trim();
+  if (!input) {
+    setStatus('Enter a query.');
+    return;
+  }
+
+  running.value = true;
+  results.value = [];
+  setStatus('Searching…');
+
+  const sinceDays = Number.isFinite(days.value) && days.value > 0 ? days.value : 0;
+  const since = sinceDays ? Math.floor(Date.now() / 1000) - sinceDays * 86400 : undefined;
+  const limitValue = Math.max(1, Math.min(limit.value || 40, 500));
+
+  let pubkeyHex: string | null = null;
+  let eventId: string | null = null;
+  let pointerRelays: string[] = [];
+  let relaySelection = pickRelays();
+
+  try {
+    const decoded = nip19.decode(input);
+    switch (decoded.type) {
+      case 'npub':
+        pubkeyHex = typeof decoded.data === 'string'
+          ? decoded.data
+          : Array.from(decoded.data as Uint8Array).map(b => b.toString(16).padStart(2, '0')).join('');
+        break;
+      case 'nprofile':
+        pubkeyHex = decoded.data.pubkey;
+        pointerRelays = decoded.data.relays ?? [];
+        break;
+      case 'note':
+        eventId = typeof decoded.data === 'string'
+          ? decoded.data
+          : Array.from(decoded.data as Uint8Array).map(b => b.toString(16).padStart(2, '0')).join('');
+        break;
+      case 'nevent':
+        eventId = decoded.data.id;
+        pointerRelays = decoded.data.relays ?? [];
+        break;
+      case 'naddr':
+        relaySelection = pickRelays(decoded.data.relays ?? []);
+        setStatus('Fetching naddr…');
+        {
+          const events = await listOnceMulti(
+            {
+              kinds: [decoded.data.kind],
+              authors: [decoded.data.pubkey],
+              '#d': [decoded.data.identifier],
+              limit: limitValue,
+            },
+            relaySelection,
+            8000
+          );
+          if (!events.length) {
+            renderInfo('No results for pointer on selected relays.');
+          } else {
+            for (const event of events) {
+              routeEvent(event);
+            }
+          }
+        }
+        running.value = false;
+        setStatus('Done');
+        return;
+      default:
+        break;
+    }
+  } catch (err) {
+    // not bech32, continue
+  }
+
+  if (!pubkeyHex && /^[0-9a-f]{64}$/i.test(input)) {
+    setStatus('Fetching event by id…');
+    const events = await listOnceMulti({ ids: [input], limit: 1 }, relaySelection, 6000);
+    if (events.length) {
+      routeEvent(events[0]);
+      pubkeyHex = events[0].pubkey;
+    } else {
+      pubkeyHex = input.toLowerCase();
+    }
+  }
+
+  if (!pubkeyHex && input.includes('@')) {
+    setStatus('Resolving NIP-05…');
+    pubkeyHex = await resolveNip05(input);
+    if (!pubkeyHex) {
+      renderError('Unable to resolve NIP-05.');
+      running.value = false;
+      setStatus('Done');
+      return;
+    }
+  }
+
+  relaySelection = pickRelays(pointerRelays);
+
+  if (!pubkeyHex && !eventId) {
+    setStatus('Running text search…');
+    const filter: any = { search: input, limit: limitValue };
+    if (mode.value === 'profiles') filter.kinds = [0];
+    if (mode.value === 'notes') filter.kinds = [1];
+    const events = await listOnceMulti(filter, relaySelection, 8000);
+    if (!events.length) {
+      renderInfo('No results from text search.');
+    } else {
+      const profiles = new Map<string, NostrEvent>();
+      for (const event of events) {
+        if (event.kind === 0) {
+          const existing = profiles.get(event.pubkey);
+          if (!existing || existing.created_at < event.created_at) {
+            profiles.set(event.pubkey, event);
+          }
+        }
+      }
+      profiles.forEach(event => pushEvent('profile', event));
+      events.filter(event => event.kind === 1).slice(0, limitValue).forEach(event => pushEvent('note', event));
+    }
+    running.value = false;
+    setStatus('Done');
+    return;
+  }
+
+  if (eventId) {
+    setStatus('Fetching event by id…');
+    const events = await listOnceMulti({ ids: [eventId], limit: 1 }, relaySelection, 7000);
+    if (events.length) {
+      routeEvent(events[0]);
+      pubkeyHex = events[0].pubkey;
+    } else {
+      renderInfo('No event found for supplied id.');
+    }
+  }
+
+  if (pubkeyHex) {
+    if (mode.value !== 'notes') {
+      setStatus('Fetching profile…');
+      const profiles = await listOnceMulti(
+        { kinds: [0], authors: [pubkeyHex], limit: 5 },
+        relaySelection,
+        7000
+      );
+      const latest = profiles.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))[0];
+      if (latest) {
+        pushEvent('profile', latest);
+      } else {
+        renderInfo('No profile found.');
+      }
+    }
+
+    if (mode.value !== 'profiles') {
+      setStatus('Fetching notes…');
+      const noteFilter: any = { kinds: [1], authors: [pubkeyHex], limit: limitValue };
+      if (since) noteFilter.since = since;
+      const notes = await listOnceMulti(noteFilter, relaySelection, 8000);
+      if (!notes.length) {
+        renderInfo('No recent notes.');
+      } else {
+        uniqueBy(notes)
+          .slice(0, limitValue)
+          .forEach(event => pushEvent('note', event));
+      }
+    }
+
+    if (mode.value === 'auto' || mode.value === 'any') {
+      setStatus('Checking Nutzap profile…');
+      const nz = await listOnceMulti(
+        { kinds: [10019], authors: [pubkeyHex], limit: 3 },
+        relaySelection,
+        6000
+      );
+      if (nz.length) {
+        pushEvent('nutzap-profile', nz.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))[0]);
+      }
+
+      const tr = await listOnceMulti(
+        { kinds: [30000], authors: [pubkeyHex], '#d': ['tiers'], limit: 3 },
+        relaySelection,
+        6000
+      );
+      if (tr.length) {
+        pushEvent('tiers', tr.sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))[0]);
+      }
+    }
+  }
+
+  running.value = false;
+  setStatus('Done');
+}
+</script>

--- a/src/components/nutzap/parts/ExplorerError.vue
+++ b/src/components/nutzap/parts/ExplorerError.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="text-caption text-negative">{{ entry.message }}</div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ entry: { message?: string } }>();
+const entry = props.entry;
+</script>

--- a/src/components/nutzap/parts/ExplorerInfo.vue
+++ b/src/components/nutzap/parts/ExplorerInfo.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="text-caption text-2">{{ entry.message }}</div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ entry: { message?: string } }>();
+const entry = props.entry;
+</script>

--- a/src/components/nutzap/parts/ExplorerNoteCard.vue
+++ b/src/components/nutzap/parts/ExplorerNoteCard.vue
@@ -1,0 +1,31 @@
+<template>
+  <div class="column q-gutter-xs">
+    <div class="text-caption text-2">{{ timestamp }}</div>
+    <div class="text-body2" style="white-space: pre-wrap">{{ entry.event.content }}</div>
+    <div class="text-caption text-2">id {{ notePreview }}</div>
+    <q-expansion-item dense dense-toggle label="Raw event">
+      <pre class="text-caption mono q-mt-sm">{{ rawJson }}</pre>
+    </q-expansion-item>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { date } from 'quasar';
+import { nip19, type Event as NostrEvent } from 'nostr-tools';
+
+type Entry = { event: NostrEvent };
+
+const props = defineProps<{ entry: Entry }>();
+
+const timestamp = computed(() => date.formatDate(props.entry.event.created_at * 1000, 'YYYY-MM-DD HH:mm'));
+const notePreview = computed(() => {
+  try {
+    const encoded = nip19.noteEncode(props.entry.event.id);
+    return `${encoded.slice(0, 12)}…`;
+  } catch {
+    return props.entry.event.id;
+  }
+});
+const rawJson = computed(() => JSON.stringify(props.entry.event, null, 2));
+</script>

--- a/src/components/nutzap/parts/ExplorerNutzapProfileCard.vue
+++ b/src/components/nutzap/parts/ExplorerNutzapProfileCard.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="column q-gutter-xs">
+    <div class="text-subtitle1">Nutzap Profile (kind 10019)</div>
+    <div class="text-caption text-2">p2pk: <span class="mono">{{ p2pkPreview }}</span></div>
+    <div class="text-caption text-2">Mints: {{ mintsList }}</div>
+    <div class="text-caption text-2">Relays: {{ relaysList }}</div>
+    <div class="text-caption text-2">Tier address: <span class="mono">{{ tierAddr }}</span></div>
+    <q-expansion-item dense dense-toggle label="Raw event">
+      <pre class="text-caption mono q-mt-sm">{{ rawJson }}</pre>
+    </q-expansion-item>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { Event as NostrEvent } from 'nostr-tools';
+
+type Entry = { event: NostrEvent };
+
+const props = defineProps<{ entry: Entry }>();
+
+const content = computed(() => {
+  try {
+    return JSON.parse(props.entry.event.content || '{}');
+  } catch {
+    return {} as Record<string, unknown>;
+  }
+});
+
+const p2pkPreview = computed(() => {
+  const value = (content.value.p2pk as string) || '';
+  return value ? `${value.slice(0, 14)}…` : '—';
+});
+const mintsList = computed(() => (Array.isArray(content.value.mints) ? content.value.mints.join(', ') : '—'));
+const relaysList = computed(() => (Array.isArray(content.value.relays) ? content.value.relays.join(', ') : '—'));
+const tierAddr = computed(() => (content.value.tierAddr as string) || '');
+const rawJson = computed(() => JSON.stringify(props.entry.event, null, 2));
+</script>

--- a/src/components/nutzap/parts/ExplorerProfileCard.vue
+++ b/src/components/nutzap/parts/ExplorerProfileCard.vue
@@ -1,0 +1,46 @@
+<template>
+  <div class="column q-gutter-xs">
+    <div class="row items-center q-gutter-sm">
+      <div class="text-subtitle1">{{ displayName }}</div>
+      <div class="text-caption text-2">{{ nip05Id }}</div>
+    </div>
+    <div class="text-caption text-2">npub: <span class="mono">{{ npubPreview }}</span></div>
+    <div class="text-caption text-2">Updated {{ updatedAt }}</div>
+    <q-expansion-item dense dense-toggle label="Raw event">
+      <pre class="text-caption mono q-mt-sm">{{ rawJson }}</pre>
+    </q-expansion-item>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { date } from 'quasar';
+import { nip19, type Event as NostrEvent } from 'nostr-tools';
+
+type Entry = { event: NostrEvent };
+
+const props = defineProps<{ entry: Entry }>();
+
+const content = computed(() => {
+  try {
+    return JSON.parse(props.entry.event.content || '{}');
+  } catch {
+    return {} as Record<string, unknown>;
+  }
+});
+
+const displayName = computed(() =>
+  (content.value.display_name as string) || (content.value.name as string) || 'Unnamed'
+);
+const nip05Id = computed(() => (content.value.nip05 as string) || '');
+const npubPreview = computed(() => {
+  try {
+    const npub = nip19.npubEncode(props.entry.event.pubkey);
+    return `${npub.slice(0, 12)}…${npub.slice(-6)}`;
+  } catch {
+    return props.entry.event.pubkey;
+  }
+});
+const updatedAt = computed(() => date.formatDate(props.entry.event.created_at * 1000, 'YYYY-MM-DD HH:mm'));
+const rawJson = computed(() => JSON.stringify(props.entry.event, null, 2));
+</script>

--- a/src/components/nutzap/parts/ExplorerTiersCard.vue
+++ b/src/components/nutzap/parts/ExplorerTiersCard.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="column q-gutter-xs">
+    <div class="text-subtitle1">Nutzap Tiers (kind 30000)</div>
+    <q-list dense>
+      <template v-if="tiers.length">
+        <q-item v-for="tier in tiers" :key="tier.id" dense>
+          <q-item-section>
+            <div class="text-body2">
+              <span class="mono">{{ tier.id }}</span> — <b>{{ tier.title }}</b> · {{ tier.price }} sats / {{ tier.frequency }}
+            </div>
+            <div v-if="tier.description" class="text-caption text-2">{{ tier.description }}</div>
+          </q-item-section>
+        </q-item>
+      </template>
+      <template v-else>
+        <q-item dense>
+          <q-item-section class="text-caption text-2">No tiers found.</q-item-section>
+        </q-item>
+      </template>
+    </q-list>
+    <q-expansion-item dense dense-toggle label="Raw event">
+      <pre class="text-caption mono q-mt-sm">{{ rawJson }}</pre>
+    </q-expansion-item>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { Event as NostrEvent } from 'nostr-tools';
+
+type Entry = { event: NostrEvent };
+
+const props = defineProps<{ entry: Entry }>();
+
+const parsed = computed(() => {
+  try {
+    return JSON.parse(props.entry.event.content || '{}');
+  } catch {
+    return {};
+  }
+});
+
+const tiers = computed(() => {
+  const raw = parsed.value;
+  const list = Array.isArray(raw?.tiers) ? raw.tiers : Array.isArray(raw) ? raw : [];
+  return list.map((tier: any) => ({
+    id: tier.id || '',
+    title: tier.title || '',
+    price: Number.isFinite(Number(tier.price)) ? Number(tier.price) : Number(tier.price_sats) || 0,
+    frequency: tier.frequency || 'monthly',
+    description: tier.description || '',
+  }));
+});
+
+const rawJson = computed(() => JSON.stringify(props.entry.event, null, 2));
+</script>

--- a/src/nutzap/useNutzapToolkit.ts
+++ b/src/nutzap/useNutzapToolkit.ts
@@ -1,0 +1,172 @@
+import { computed, onMounted, ref } from 'vue';
+import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools';
+import { utils as secpUtils, getPublicKey as secpGetPublicKey } from '@noble/secp256k1';
+import { NDKPrivateKeySigner } from '@nostr-dev-kit/ndk';
+import { fundstrRelayClient, useFundstrRelayLogFeed, useFundstrRelayStatus } from './relayClient';
+import { getNutzapNdk } from './ndkInstance';
+
+const STORAGE_KEY = 'nutzap.toolkit.sk';
+
+function hexToBytes(hex: string): Uint8Array {
+  const normalized = hex.trim().toLowerCase();
+  if (!/^[0-9a-f]{64}$/i.test(normalized)) {
+    throw new Error('Secret key must be a 64-character hex string.');
+  }
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i += 1) {
+    out[i] = parseInt(normalized.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function bytesFromHexish(input: string): Uint8Array {
+  if (input.startsWith('nsec')) {
+    const decoded = nip19.decode(input);
+    if (decoded.type !== 'nsec') {
+      throw new Error('Provided bech32 value is not an nsec secret.');
+    }
+    const payload = decoded.data;
+    if (payload instanceof Uint8Array) {
+      return payload;
+    }
+    if (Array.isArray(payload)) {
+      return Uint8Array.from(payload);
+    }
+    if (typeof payload === 'string') {
+      return hexToBytes(payload);
+    }
+    throw new Error('Unsupported nsec payload.');
+  }
+  return hexToBytes(input);
+}
+
+function setNdkSigner(hex: string) {
+  try {
+    const signer = new NDKPrivateKeySigner(hex);
+    const ndk = getNutzapNdk();
+    ndk.signer = signer;
+  } catch (error) {
+    console.warn('[nutzap-toolkit] failed to set NDK signer', error);
+  }
+}
+
+export function useNutzapToolkit() {
+  const sk = ref<Uint8Array | null>(null);
+  const skHex = ref('');
+  const pk = ref('');
+  const nsec = computed(() => (sk.value ? nip19.nsecEncode(sk.value) : ''));
+  const npub = computed(() => (pk.value ? nip19.npubEncode(pk.value) : ''));
+  const tierAddress = computed(() => (pk.value ? `30000:${pk.value}:tiers` : ''));
+  const relayStatus = useFundstrRelayStatus();
+  const relayLogFeed = useFundstrRelayLogFeed();
+
+  const cashuPriv = ref('');
+  const cashuPub = ref('');
+
+  function updateKeys(secret: Uint8Array) {
+    const nextSk = new Uint8Array(secret);
+    const secretHex = toHex(nextSk);
+    sk.value = nextSk;
+    skHex.value = secretHex;
+    pk.value = getPublicKey(nextSk);
+    setNdkSigner(secretHex);
+  }
+
+  function generate() {
+    const key = generateSecretKey();
+    updateKeys(key);
+  }
+
+  function loadFromInput(input: string) {
+    const bytes = bytesFromHexish(input.trim());
+    updateKeys(bytes);
+  }
+
+  function saveToStorage() {
+    if (!skHex.value) {
+      throw new Error('No secret key loaded.');
+    }
+    localStorage.setItem(STORAGE_KEY, skHex.value);
+  }
+
+  function loadFromStorage() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      throw new Error('Nothing stored locally.');
+    }
+    const bytes = hexToBytes(stored);
+    updateKeys(bytes);
+  }
+
+  function clearStorage() {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+
+  function connectRelay() {
+    fundstrRelayClient.connect();
+  }
+
+  function deriveCashuFromPrivate(input: string) {
+    const normalized = input.trim();
+    if (!normalized) {
+      throw new Error('Provide a Cashu private key in hex format.');
+    }
+    if (!/^[0-9a-f]{64}$/i.test(normalized)) {
+      throw new Error('Cashu private key must be 64 hex characters.');
+    }
+    const bytes = hexToBytes(normalized);
+    const pub = toHex(secpGetPublicKey(bytes, true));
+    cashuPriv.value = normalized.toLowerCase();
+    cashuPub.value = pub;
+    return pub;
+  }
+
+  function generateCashuKeypair() {
+    const privBytes = secpUtils.randomPrivateKey();
+    const priv = toHex(privBytes);
+    const pub = toHex(secpGetPublicKey(privBytes, true));
+    cashuPriv.value = priv;
+    cashuPub.value = pub;
+    return { priv, pub };
+  }
+
+  onMounted(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored && /^[0-9a-f]{64}$/i.test(stored)) {
+        updateKeys(hexToBytes(stored));
+      }
+    } catch (error) {
+      console.warn('[nutzap-toolkit] failed to load stored key', error);
+    }
+    connectRelay();
+  });
+
+  return {
+    secretKeyHex: skHex,
+    publicKey: pk,
+    nsec,
+    npub,
+    tierAddress,
+    relayStatus,
+    relayLogFeed,
+    cashuPriv,
+    cashuPub,
+    generate,
+    loadFromInput,
+    saveToStorage,
+    loadFromStorage,
+    clearStorage,
+    connectRelay,
+    deriveCashuFromPrivate,
+    generateCashuKeypair,
+  };
+}
+
+export type NutzapToolkit = ReturnType<typeof useNutzapToolkit>;

--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -1,907 +1,513 @@
 <template>
-  <q-page class="bg-surface-1 q-pa-md q-gutter-md column">
+  <q-page class="bg-surface-1 q-pa-md column q-gutter-md">
     <div class="row items-center q-gutter-sm">
       <RelayStatusIndicator />
-      <div class="text-caption text-2">Isolated relay: relay.fundstr.me (WS → HTTP fallback)</div>
+      <q-chip size="sm" color="primary" text-color="white" outline>
+        Relay status: {{ toolkit.relayStatus }}
+      </q-chip>
     </div>
 
-    <q-card class="q-pa-md">
-      <div class="text-subtitle1 q-mb-sm">Author</div>
-      <q-input
-        v-model="authorInput"
-        label="Author (npub or hex pubkey)"
-        dense
-        filled
-        autocomplete="off"
-      />
-      <div class="row items-center q-gutter-sm q-mt-sm">
-        <q-btn
-          color="primary"
-          label="Load Data"
-          :disable="!authorInput.trim() || loading"
-          :loading="loading"
-          @click="loadAll"
-        />
-      </div>
-      <div class="text-caption text-2 q-mt-sm">
-        Tier address preview: {{ tierAddressPreview }}
-      </div>
-    </q-card>
-
-    <q-card class="q-pa-md">
-      <div class="text-subtitle1 q-mb-sm">Payment Profile (kind 10019)</div>
-      <q-input v-model="displayName" label="Display Name" dense filled class="q-mb-sm" />
-      <q-input v-model="pictureUrl" label="Picture URL" dense filled class="q-mb-sm" />
-      <q-input v-model="p2pkPub" label="P2PK Public Key" dense filled class="q-mb-sm" />
-      <q-input
-        v-model="mintsText"
-        type="textarea"
-        label="Trusted Mints (one per line)"
-        dense
-        filled
-        autogrow
-        class="q-mb-sm"
-      />
-      <q-input
-        v-model="relaysText"
-        type="textarea"
-        label="Relay Hints (optional, one per line)"
-        dense
-        filled
-        autogrow
-      />
-      <div class="row justify-end q-gutter-sm q-mt-md">
-        <q-btn
-          color="primary"
-          label="Publish Profile"
-          :disable="profilePublishDisabled"
-          :loading="publishingProfile"
-          @click="publishProfile"
-        />
-      </div>
-      <div class="text-caption q-mt-sm" v-if="lastProfilePublishInfo">
-        {{ lastProfilePublishInfo }}
-      </div>
-    </q-card>
-
-    <q-card class="q-pa-md">
-      <div class="row items-center justify-between q-mb-sm">
-        <div>
-          <div class="text-subtitle1">Tiers ({{ tiers.length }})</div>
-          <div class="text-caption text-2">
-            Publishing as {{ tierKindLabel }} — parameterized replaceable ["d","tiers"].
-          </div>
-        </div>
-        <div class="row items-center q-gutter-sm">
-          <q-btn-toggle
-            v-model="tierKind"
-            :options="tierKindOptions"
-            dense
-            toggle-color="primary"
-            unelevated
-          />
-          <q-btn dense color="primary" label="Add Tier" @click="openNewTier" />
-        </div>
-      </div>
-      <q-list bordered separator v-if="tiers.length">
-        <q-item v-for="tier in tiers" :key="tier.id">
-          <q-item-section>
-            <div class="text-body1">
-              {{ tier.title }} — {{ tier.price }} sats ({{ frequencyLabel(tier.frequency) }})
+    <div class="row q-col-gutter-md items-start">
+      <div class="col-12 col-lg-4 column q-gutter-md">
+        <q-card>
+          <q-card-section>
+            <div class="text-subtitle1">1) Keys</div>
+            <div class="text-caption text-2 q-mb-sm">
+              Generate or import an nsec. Keys are stored locally and applied to the isolated Fundstr relay signer.
             </div>
-            <div class="text-caption" v-if="tier.description">{{ tier.description }}</div>
-            <div class="text-caption" v-if="tier.media?.length">
-              Media: {{ tier.media.map(m => m.url).join(', ') }}
+            <div class="row q-col-gutter-sm q-mb-sm">
+              <div class="col-auto">
+                <q-btn label="Generate" color="primary" @click="handleGenerate" />
+              </div>
+              <div class="col-auto">
+                <q-btn label="Save" color="primary" flat @click="handleSave" />
+              </div>
+              <div class="col-auto">
+                <q-btn label="Load" color="primary" flat @click="handleLoad" />
+              </div>
+              <div class="col-auto">
+                <q-btn label="Forget" color="negative" flat @click="handleForget" />
+              </div>
             </div>
-          </q-item-section>
-          <q-item-section side>
-            <q-btn dense flat icon="edit" @click="editTier(tier)" />
-            <q-btn dense flat icon="delete" color="negative" @click="removeTier(tier.id)" />
-          </q-item-section>
-        </q-item>
-      </q-list>
-      <div v-else class="text-caption text-2">No tiers yet. Add at least one tier before publishing.</div>
-      <div class="row justify-end q-gutter-sm q-mt-md">
-        <q-btn
-          color="primary"
-          label="Publish Tiers"
-          :disable="tiersPublishDisabled"
-          :loading="publishingTiers"
-          @click="publishTiers"
-        />
-      </div>
-      <div class="text-caption q-mt-sm" v-if="lastTiersPublishInfo">
-        {{ lastTiersPublishInfo }}
-      </div>
-    </q-card>
+            <q-input v-model="nsecInput" dense filled label="Import nsec / 64-hex" class="q-mb-sm" />
+            <q-btn label="Load input" color="primary" flat class="q-mb-md" @click="handleLoadInput" />
+            <q-input :model-value="toolkit.npub" dense filled readonly label="npub" class="q-mb-sm" />
+            <q-input :model-value="toolkit.nsec" dense filled readonly label="nsec" />
+          </q-card-section>
+        </q-card>
 
-    <q-dialog v-model="showTierDialog" @hide="resetTierForm">
-      <q-card class="q-pa-md" style="min-width: 420px">
-        <div class="text-subtitle1 q-mb-sm">{{ tierForm.id ? 'Edit Tier' : 'Add Tier' }}</div>
-        <q-input v-model="tierForm.title" label="Title" dense filled class="q-mb-sm" />
-        <q-input
-          v-model.number="tierForm.price"
-          type="number"
-          label="Price (sats)"
-          dense
-          filled
-          class="q-mb-sm"
-        />
-        <q-select
-          v-model="tierForm.frequency"
-          :options="tierFrequencyOptions"
-          option-label="label"
-          option-value="value"
-          emit-value
-          map-options
-          label="Frequency"
-          dense
-          filled
-          class="q-mb-sm"
-        />
-        <q-input
-          v-model="tierForm.description"
-          type="textarea"
-          label="Description"
-          dense
-          filled
-          autogrow
-          class="q-mb-sm"
-        />
-        <q-input
-          v-model="tierForm.mediaCsv"
-          label="Media URLs (comma-separated)"
-          dense
-          filled
-        />
-        <div class="row justify-end q-gutter-sm q-mt-md">
-          <q-btn flat label="Cancel" v-close-popup />
-          <q-btn color="primary" label="Save" @click="saveTier" v-close-popup />
-        </div>
-      </q-card>
-    </q-dialog>
+        <q-card>
+          <q-card-section class="q-gutter-md column">
+            <div>
+              <div class="text-subtitle1">2) Publisher</div>
+              <div class="text-caption text-2">
+                Publish test notes, Nutzap profiles (10019) or tiers (30000). Requires keys above.
+              </div>
+            </div>
+            <q-input v-model="relayUrl" dense filled readonly label="Relay" />
+            <div class="row q-col-gutter-sm">
+              <div class="col-auto">
+                <q-btn label="Connect" color="primary" @click="toolkit.connectRelay" />
+              </div>
+              <div class="col-auto">
+                <q-btn label="Publish note" color="primary" flat @click="handlePublishNote" />
+              </div>
+              <div class="col-auto">
+                <q-btn label="Publish profile" color="primary" flat @click="handlePublishProfile" />
+              </div>
+              <div class="col-auto">
+                <q-btn label="Publish tiers" color="primary" flat @click="handlePublishTiers" />
+              </div>
+            </div>
+            <q-input v-model="p2pkInput" dense filled label="P2PK public key (Cashu 33-byte hex)" />
+            <div class="row q-col-gutter-sm">
+              <div class="col">
+                <q-input v-model="p2pkPrivInput" dense filled label="Derive from Cashu private key" />
+              </div>
+              <div class="col-auto column q-gutter-xs">
+                <q-btn label="Derive" color="primary" flat @click="handleDeriveP2pk" />
+                <q-btn label="Generate" color="warning" flat @click="handleGenerateP2pk" />
+              </div>
+            </div>
+            <q-input v-model="mintsText" type="textarea" autogrow dense filled label="Mints (one per line)" />
+            <q-input v-model="relaysText" type="textarea" autogrow dense filled label="Relays (one per line)" />
+            <q-input v-model="tierAddress" dense filled label="Tier address" />
+            <q-input v-model="tiersJson" type="textarea" autogrow dense filled label="Tiers JSON" />
+          </q-card-section>
+        </q-card>
+
+        <q-card>
+          <q-card-section class="column q-gutter-sm">
+            <div class="row items-center justify-between">
+              <div class="text-subtitle1">3) Activity</div>
+              <q-btn label="Clear" flat dense @click="clearLog" />
+            </div>
+            <div class="log-window">
+              <div
+                v-for="entry in logEntries"
+                :key="entry.id"
+                :class="['text-caption mono', entry.toneClass]"
+              >
+                [{{ entry.timestamp }}] {{ entry.message }}
+              </div>
+            </div>
+          </q-card-section>
+        </q-card>
+
+        <q-card>
+          <q-card-section class="column q-gutter-sm">
+            <div class="row items-center justify-between">
+              <div class="text-subtitle1">6) Self-tests</div>
+              <q-chip dense :color="testStatusColor" text-color="white">{{ testStatusLabel }}</q-chip>
+            </div>
+            <q-btn :loading="testRunning" color="warning" label="Run tests" @click="runTests" />
+            <div class="log-window">
+              <div
+                v-for="item in testLog"
+                :key="item.id"
+                :class="['text-caption mono', item.ok ? 'text-positive' : 'text-negative']"
+              >
+                {{ item.ok ? '✔' : '✖' }} {{ item.message }}
+              </div>
+            </div>
+          </q-card-section>
+        </q-card>
+      </div>
+
+      <div class="col-12 col-lg-8 column q-gutter-md">
+        <NutzapExplorerV2 />
+
+        <q-card>
+          <q-card-section class="column q-gutter-sm">
+            <div class="row items-center q-gutter-sm">
+              <div class="text-subtitle1">5) Legacy Explorer</div>
+              <q-chip dense :color="legacyChipColor" text-color="white">{{ legacyChipLabel }}</q-chip>
+              <div class="text-caption text-2">Timeout {{ legacyTimeoutMs }} ms</div>
+            </div>
+            <div class="row q-col-gutter-sm">
+              <div class="col-12 col-md-3">
+                <q-input v-model="legacyKinds" dense filled label="Kinds CSV" />
+              </div>
+              <div class="col-12 col-md-3">
+                <q-input v-model="legacyAuthors" dense filled label="Authors CSV" />
+              </div>
+              <div class="col-12 col-md-3">
+                <q-input v-model="legacyIds" dense filled label="Event IDs" />
+              </div>
+              <div class="col-6 col-md-3">
+                <q-input v-model.number="legacyLimit" type="number" dense filled label="Limit" />
+              </div>
+            </div>
+            <div class="row q-col-gutter-sm">
+              <div class="col-auto">
+                <q-btn label="Query" color="primary" :loading="legacyLoading" @click="runLegacyQuery" />
+              </div>
+              <div class="col-auto">
+                <q-btn label="Clear" flat @click="legacyResults = []" />
+              </div>
+            </div>
+            <div class="column q-gutter-sm">
+              <q-card v-for="event in legacyResults" :key="event.id" class="bg-surface-2 q-pa-sm">
+                <div class="text-caption text-2">{{ formatTimestamp(event.created_at) }} · kind {{ event.kind }}</div>
+                <div class="text-caption text-2 mono">{{ event.id }}</div>
+                <div class="text-body2" style="white-space: pre-wrap">{{ event.content }}</div>
+              </q-card>
+            </div>
+          </q-card-section>
+        </q-card>
+      </div>
+    </div>
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
-import { v4 as uuidv4 } from 'uuid';
+import { computed, onMounted, ref, watch } from 'vue';
+import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools';
 import RelayStatusIndicator from 'src/nutzap/RelayStatusIndicator.vue';
-import { notifyError, notifySuccess, notifyWarning } from 'src/js/notify';
-import type { Tier } from 'src/nutzap/types';
-import { useActiveNutzapSigner } from 'src/nutzap/signer';
-import { getNutzapNdk } from 'src/nutzap/ndkInstance';
-import {
-  FUNDSTR_WS_URL,
-  FUNDSTR_REQ_URL,
-  WS_FIRST_TIMEOUT_MS,
-  HTTP_FALLBACK_TIMEOUT_MS,
-  normalizeAuthor,
-  pickLatestParamReplaceable,
-  pickLatestReplaceable,
-  publishTiers as publishTiersToRelay,
-  publishNostrEvent,
-  parseTiersContent,
-} from './nutzap-profile/nostrHelpers';
-import { fundstrRelayClient, RelayPublishError } from 'src/nutzap/relayClient';
-import { sanitizeRelayUrls } from 'src/utils/relay';
+import NutzapExplorerV2 from 'src/components/nutzap/NutzapExplorerV2.vue';
+import { notifyError, notifySuccess } from 'src/js/notify';
+import { useNutzapToolkit } from 'src/nutzap/useNutzapToolkit';
+import { fundstrRelayClient } from 'src/nutzap/relayClient';
+import { publishNostrEvent } from './nutzap-profile/nostrHelpers';
+import { NUTZAP_RELAY_WSS } from 'src/nutzap/relayConfig';
 
-type TierKind = 30019 | 30000;
+const toolkit = useNutzapToolkit();
 
-const tierFrequencies: Tier['frequency'][] = ['one_time', 'monthly', 'yearly'];
+const relayUrl = ref(NUTZAP_RELAY_WSS);
+const nsecInput = ref('');
+const p2pkInput = ref('');
+const p2pkPrivInput = ref('');
+const mintsText = ref('https://mint.fundstr.network/cashu');
+const relaysText = ref('wss://relay.fundstr.me\nwss://relay.damus.io');
+const tierAddress = ref('');
+const tiersJson = ref(`{
+  "v": 1,
+  "tiers": [
+    { "id": "backstage-pass", "title": "Backstage Pass", "price": 2000, "frequency": "monthly", "description": "Behind the scenes" },
+    { "id": "producer-circle", "title": "Producer Circle", "price": 15000, "frequency": "monthly", "description": "Strategy & credits" }
+  ]
+}`);
 
-type TierFormState = {
-  id: string;
-  title: string;
-  price: number;
-  frequency: Tier['frequency'];
-  description: string;
-  mediaCsv: string;
-};
-
-const authorInput = ref('');
-const displayName = ref('');
-const pictureUrl = ref('');
-const p2pkPub = ref('');
-const mintsText = ref('');
-const relaysText = ref(FUNDSTR_WS_URL);
-const tiers = ref<Tier[]>([]);
-const tierKind = ref<TierKind>(30019);
-const tierForm = ref<TierFormState>({
-  id: '',
-  title: '',
-  price: 0,
-  frequency: 'monthly',
-  description: '',
-  mediaCsv: '',
-});
-const showTierDialog = ref(false);
-const loading = ref(false);
-const publishingProfile = ref(false);
-const publishingTiers = ref(false);
-const lastProfilePublishInfo = ref('');
-const lastTiersPublishInfo = ref('');
-const hasAutoLoaded = ref(false);
-
-const { pubkey, signer } = useActiveNutzapSigner();
-
-const relaySocket = fundstrRelayClient;
-let profileSubId: string | null = null;
-let tiersSubId: string | null = null;
-let stopRelayStatusListener: (() => void) | null = null;
-let hasRelayConnected = false;
-let reloadAfterReconnect = false;
-let activeAuthorHex: string | null = null;
-
-const mintList = computed(() =>
-  mintsText.value
-    .split('\n')
-    .map(s => s.trim())
-    .filter(Boolean)
+watch(
+  () => toolkit.tierAddress.value,
+  value => {
+    if (!tierAddress.value) {
+      tierAddress.value = value;
+    }
+  },
+  { immediate: true }
 );
 
-const relayList = computed(() => {
-  const entries = relaysText.value
-    .split('\n')
-    .map(s => s.trim())
+watch(
+  () => toolkit.cashuPub.value,
+  value => {
+    if (!p2pkInput.value && value) {
+      p2pkInput.value = value;
+    }
+  },
+  { immediate: true }
+);
+
+interface LogEntry {
+  id: number;
+  timestamp: string;
+  tone: 'info' | 'success' | 'error';
+  message: string;
+  toneClass: string;
+}
+
+const logEntries = ref<LogEntry[]>([]);
+let logSequence = 0;
+let lastRelayLogId = 0;
+
+function formatTs(ts: number) {
+  return new Date(ts).toLocaleTimeString();
+}
+
+function pushLog(message: string, tone: 'info' | 'success' | 'error' = 'info') {
+  const entry = {
+    id: ++logSequence,
+    timestamp: formatTs(Date.now()),
+    tone,
+    message,
+    toneClass: tone === 'success' ? 'text-positive' : tone === 'error' ? 'text-negative' : 'text-2',
+  };
+  logEntries.value = [entry, ...logEntries.value].slice(0, 200);
+}
+
+watch(
+  () => toolkit.relayLogFeed.value,
+  next => {
+    for (const entry of next) {
+      if (entry.id <= lastRelayLogId) continue;
+      pushLog(`[relay] ${entry.message}`, entry.level === 'error' ? 'error' : entry.level === 'warn' ? 'info' : 'info');
+      lastRelayLogId = Math.max(lastRelayLogId, entry.id);
+    }
+  },
+  { immediate: true, deep: true }
+);
+
+function handleGenerate() {
+  toolkit.generate();
+  tierAddress.value = toolkit.tierAddress.value;
+  pushLog('Generated new secret key', 'success');
+}
+
+function handleSave() {
+  try {
+    toolkit.saveToStorage();
+    pushLog('Saved secret key to localStorage', 'success');
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+function handleLoad() {
+  try {
+    toolkit.loadFromStorage();
+    tierAddress.value = toolkit.tierAddress.value;
+    pushLog('Loaded secret key from localStorage', 'success');
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+function handleForget() {
+  toolkit.clearStorage();
+  pushLog('Cleared stored key');
+}
+
+function handleLoadInput() {
+  try {
+    toolkit.loadFromInput(nsecInput.value);
+    tierAddress.value = toolkit.tierAddress.value;
+    pushLog('Loaded keys from input', 'success');
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+function handleDeriveP2pk() {
+  try {
+    const pub = toolkit.deriveCashuFromPrivate(p2pkPrivInput.value);
+    p2pkInput.value = pub;
+    pushLog('Derived Cashu P2PK public key', 'success');
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+function handleGenerateP2pk() {
+  try {
+    const { pub, priv } = toolkit.generateCashuKeypair();
+    p2pkInput.value = pub;
+    p2pkPrivInput.value = priv;
+    pushLog('Generated Cashu P2PK keypair', 'success');
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : String(err));
+  }
+}
+
+function getLines(text: string) {
+  return text
+    .split(/\r?\n/)
+    .map(line => line.trim())
     .filter(Boolean);
-  const set = new Set(entries);
-  set.add(FUNDSTR_WS_URL);
-  return Array.from(set);
-});
+}
 
-const tierKindOptions = [
-  { label: 'Canonical (30019)', value: 30019 },
-  { label: 'Legacy (30000)', value: 30000 },
-] as const;
-
-const tierKindLabel = computed(() =>
-  tierKind.value === 30019 ? 'Canonical (30019)' : 'Legacy (30000)'
-);
-
-const tierAddressPreview = computed(() => {
+async function handlePublishNote() {
   try {
-    const authorHex = normalizeAuthor(authorInput.value);
-    return `${tierKind.value}:${authorHex}:tiers`;
-  } catch {
-    return `${tierKind.value}:<author>:tiers`;
-  }
-});
-
-const profilePublishDisabled = computed(
-  () =>
-    publishingProfile.value ||
-    !authorInput.value.trim() ||
-    !p2pkPub.value.trim() ||
-    mintList.value.length === 0 ||
-    tiers.value.length === 0
-);
-
-const tiersPublishDisabled = computed(
-  () =>
-    publishingTiers.value || !authorInput.value.trim() || tiers.value.length === 0
-);
-
-const tierFrequencyOptions = computed(() =>
-  tierFrequencies.map(value => ({
-    value,
-    label:
-      value === 'one_time'
-        ? 'One-time'
-        : value === 'monthly'
-          ? 'Monthly'
-          : 'Yearly',
-  }))
-);
-
-function toMediaCsv(media?: { type: string; url: string }[]) {
-  if (!media) return '';
-  return media
-    .map(m => m?.url)
-    .filter((u): u is string => typeof u === 'string' && !!u)
-    .join(', ');
-}
-
-function resetTierForm() {
-  tierForm.value = {
-    id: '',
-    title: '',
-    price: 0,
-    frequency: 'monthly',
-    description: '',
-    mediaCsv: '',
-  };
-}
-
-function openNewTier() {
-  resetTierForm();
-  showTierDialog.value = true;
-}
-
-function editTier(tier: Tier) {
-  tierForm.value = {
-    id: tier.id,
-    title: tier.title,
-    price: tier.price,
-    frequency: tier.frequency,
-    description: tier.description ?? '',
-    mediaCsv: toMediaCsv(tier.media),
-  };
-  showTierDialog.value = true;
-}
-
-function removeTier(id: string) {
-  tiers.value = tiers.value.filter(t => t.id !== id);
-}
-
-function saveTier() {
-  const form = tierForm.value;
-  const media = form.mediaCsv
-    .split(',')
-    .map(s => s.trim())
-    .filter(Boolean)
-    .map(url => ({ type: 'link', url }));
-  const tier: Tier = {
-    id: form.id || uuidv4(),
-    title: form.title.trim(),
-    price: Number(form.price) || 0,
-    frequency: form.frequency,
-    description: form.description ? form.description.trim() : undefined,
-    media: media.length ? media : undefined,
-  };
-
-  if (form.id) {
-    tiers.value = tiers.value.map(t => (t.id === form.id ? tier : t));
-  } else {
-    tiers.value = [...tiers.value, tier];
-  }
-
-  resetTierForm();
-}
-
-function applyTiersEvent(event: any | null, overrideKind?: TierKind | null) {
-  if (!event) {
-    tiers.value = [];
-    return;
-  }
-
-  const eventKind =
-    overrideKind && (overrideKind === 30019 || overrideKind === 30000)
-      ? overrideKind
-      : typeof event?.kind === 'number' && (event.kind === 30019 || event.kind === 30000)
-        ? (event.kind as TierKind)
-        : null;
-
-  if (eventKind) {
-    tierKind.value = eventKind;
-  }
-
-  const content = typeof event?.content === 'string' ? event.content : undefined;
-  tiers.value = parseTiersContent(content);
-}
-
-function buildRelayList(rawRelays: string[]) {
-  const sanitizedEntries: string[] = [];
-  const droppedEntries: string[] = [];
-
-  for (const relay of rawRelays) {
-    const sanitized = sanitizeRelayUrls([relay], 1)[0];
-    if (sanitized) {
-      sanitizedEntries.push(sanitized);
-    } else {
-      droppedEntries.push(relay);
-    }
-  }
-
-  const sanitizedSet = new Set<string>();
-  for (const relay of sanitizedEntries) {
-    sanitizedSet.add(relay);
-  }
-  if (!sanitizedSet.has(FUNDSTR_WS_URL)) {
-    sanitizedSet.add(FUNDSTR_WS_URL);
-  }
-
-  return { sanitized: Array.from(sanitizedSet), dropped: droppedEntries };
-}
-
-function applyProfileEvent(latest: any | null) {
-  if (!latest) {
-    displayName.value = '';
-    pictureUrl.value = '';
-    p2pkPub.value = '';
-    mintsText.value = '';
-    relaysText.value = FUNDSTR_WS_URL;
-    return;
-  }
-
-  if (typeof latest.pubkey === 'string' && latest.pubkey) {
-    authorInput.value = latest.pubkey.toLowerCase();
-  }
-
-  try {
-    const parsed = latest.content ? JSON.parse(latest.content) : {};
-    if (typeof parsed.p2pk === 'string') {
-      p2pkPub.value = parsed.p2pk;
-    }
-    if (Array.isArray(parsed.mints)) {
-      mintsText.value = parsed.mints.join('\n');
-    }
-    if (Array.isArray(parsed.relays) && parsed.relays.length > 0) {
-      const rawRelays = parsed.relays
-        .map((entry: unknown) => (typeof entry === 'string' ? entry.trim() : ''))
-        .filter(Boolean);
-      const { sanitized, dropped } = buildRelayList(rawRelays);
-      if (dropped.length > 0) {
-        notifyWarning(
-          dropped.length === 1
-            ? 'Discarded invalid relay URL'
-            : 'Discarded invalid relay URLs',
-          dropped.join(', ')
-        );
-      }
-      relaysText.value = sanitized.join('\n');
-    } else {
-      relaysText.value = FUNDSTR_WS_URL;
-    }
-    if (typeof parsed.tierAddr === 'string') {
-      const [kindPart, , dPart] = parsed.tierAddr.split(':');
-      const maybeKind = Number(kindPart);
-      if ((maybeKind === 30019 || maybeKind === 30000) && dPart === 'tiers') {
-        tierKind.value = maybeKind as TierKind;
-      }
-    }
-  } catch (err) {
-    console.warn('[nutzap] failed to parse profile content', err);
-  }
-
-  const tags = Array.isArray(latest.tags) ? latest.tags : [];
-  const nameTag = tags.find((t: any) => Array.isArray(t) && t[0] === 'name' && t[1]);
-  if (nameTag) {
-    displayName.value = nameTag[1];
-  }
-  const pictureTag = tags.find((t: any) => Array.isArray(t) && t[0] === 'picture' && t[1]);
-  if (pictureTag) {
-    pictureUrl.value = pictureTag[1];
-  }
-  const mintTags = tags.filter((t: any) => Array.isArray(t) && t[0] === 'mint' && t[1]);
-  if (!mintsText.value && mintTags.length) {
-    mintsText.value = mintTags.map((t: any) => t[1]).join('\n');
-  }
-  const relayTags = tags.filter((t: any) => Array.isArray(t) && t[0] === 'relay' && t[1]);
-  if ((!relaysText.value || relaysText.value === FUNDSTR_WS_URL) && relayTags.length) {
-    const rawRelays = relayTags
-      .map((t: any) => (typeof t[1] === 'string' ? t[1].trim() : ''))
-      .filter(Boolean);
-    const { sanitized, dropped } = buildRelayList(rawRelays);
-    if (dropped.length > 0) {
-      notifyWarning(
-        dropped.length === 1
-          ? 'Discarded invalid relay URL'
-          : 'Discarded invalid relay URLs',
-        dropped.join(', ')
-      );
-    }
-    relaysText.value = sanitized.join('\n');
-  }
-  if (!p2pkPub.value) {
-    const pkTag = tags.find((t: any) => Array.isArray(t) && t[0] === 'pubkey' && t[1]);
-    if (pkTag) {
-      p2pkPub.value = pkTag[1];
-    }
-  }
-}
-
-async function loadTiers(authorHex: string) {
-  try {
-    const normalized = authorHex.toLowerCase();
-    const events = await relaySocket.requestOnce(
-      [
-        {
-          kinds: [30019, 30000],
-          authors: [normalized],
-          '#d': ['tiers'],
-          limit: 2,
-        },
-      ],
-      {
-        timeoutMs: WS_FIRST_TIMEOUT_MS,
-        httpFallback: {
-          url: FUNDSTR_REQ_URL,
-          timeoutMs: HTTP_FALLBACK_TIMEOUT_MS,
-        },
-      }
-    );
-
-    const latest = pickLatestParamReplaceable(events);
-    applyTiersEvent(latest);
-  } catch (err) {
-    console.error('[nutzap] failed to load tiers', err);
-    const message = err instanceof Error ? err.message : String(err);
-    notifyError(message);
-    throw err instanceof Error ? err : new Error(message);
-  }
-}
-
-async function loadProfile(authorHex: string) {
-  try {
-    const normalized = authorHex.toLowerCase();
-    const events = await relaySocket.requestOnce(
-      [{ kinds: [10019], authors: [normalized], limit: 1 }],
-      {
-        timeoutMs: WS_FIRST_TIMEOUT_MS,
-        httpFallback: {
-          url: FUNDSTR_REQ_URL,
-          timeoutMs: HTTP_FALLBACK_TIMEOUT_MS,
-        },
-      }
-    );
-
-    const latest = pickLatestReplaceable(events);
-    applyProfileEvent(latest);
-  } catch (err) {
-    console.error('[nutzap] failed to load profile', err);
-    const message = err instanceof Error ? err.message : String(err);
-    notifyError(message);
-    throw err instanceof Error ? err : new Error(message);
-  }
-}
-
-function cleanupSubscriptions() {
-  if (profileSubId) {
-    relaySocket.unsubscribe(profileSubId);
-    profileSubId = null;
-  }
-  if (tiersSubId) {
-    relaySocket.unsubscribe(tiersSubId);
-    tiersSubId = null;
-  }
-}
-
-function ensureRelayStatusListener() {
-  if (!relaySocket.isSupported || stopRelayStatusListener) {
-    return;
-  }
-
-  stopRelayStatusListener = relaySocket.onStatusChange(status => {
-    if (status === 'connected') {
-      if (hasRelayConnected && reloadAfterReconnect && activeAuthorHex) {
-        reloadAfterReconnect = false;
-        void loadAll();
-      }
-      hasRelayConnected = true;
-    } else if (
-      hasRelayConnected &&
-      (status === 'reconnecting' || status === 'connecting' || status === 'disconnected')
-    ) {
-      if (activeAuthorHex) {
-        reloadAfterReconnect = true;
-      }
-    }
-  });
-}
-
-function setupSubscriptions(authorHex: string) {
-  if (!relaySocket.isSupported) {
-    return;
-  }
-
-  ensureRelayStatusListener();
-
-  const normalized = authorHex.toLowerCase();
-
-  let profileSeen = false;
-  let profileLatestAt = 0;
-
-  try {
-    profileSubId = relaySocket.subscribe(
-      [{ kinds: [10019], authors: [normalized], limit: 1 }],
-      event => {
-        if (!event || typeof event.kind !== 'number' || event.kind !== 10019) {
-          return;
-        }
-        const eventAuthor = typeof event.pubkey === 'string' ? event.pubkey.toLowerCase() : '';
-        if (eventAuthor !== normalized) {
-          return;
-        }
-        const createdAt = typeof event.created_at === 'number' ? event.created_at : 0;
-        if (!profileSeen || createdAt >= profileLatestAt) {
-          profileSeen = true;
-          profileLatestAt = createdAt;
-          applyProfileEvent(event);
-        }
-      },
-      () => {
-        if (!profileSeen) {
-          applyProfileEvent(null);
-        }
-      }
-    );
-  } catch (err) {
-    console.warn('[nutzap] failed to subscribe to profile', err);
-    profileSubId = null;
-  }
-
-  let tierSeen = false;
-  let tierLatestAt = 0;
-
-  try {
-    tiersSubId = relaySocket.subscribe(
-      [
-        {
-          kinds: [30019, 30000],
-          authors: [normalized],
-          '#d': ['tiers'],
-          limit: 1,
-        },
-      ],
-      event => {
-        if (!event || typeof event.kind !== 'number') {
-          return;
-        }
-        if (event.kind !== 30019 && event.kind !== 30000) {
-          return;
-        }
-        const eventAuthor = typeof event.pubkey === 'string' ? event.pubkey.toLowerCase() : '';
-        if (eventAuthor !== normalized) {
-          return;
-        }
-        const createdAt = typeof event.created_at === 'number' ? event.created_at : 0;
-        if (!tierSeen || createdAt >= tierLatestAt) {
-          tierSeen = true;
-          tierLatestAt = createdAt;
-          applyTiersEvent(event);
-        }
-      },
-      () => {
-        if (!tierSeen) {
-          applyTiersEvent(null);
-        }
-      }
-    );
-  } catch (err) {
-    console.warn('[nutzap] failed to subscribe to tiers', err);
-    tiersSubId = null;
-  }
-}
-
-function refreshSubscriptions(force = false) {
-  let nextHex: string | null = null;
-  try {
-    nextHex = normalizeAuthor(authorInput.value);
-  } catch {
-    nextHex = null;
-  }
-
-  if (!force && nextHex === activeAuthorHex) {
-    return;
-  }
-
-  const previousHex = activeAuthorHex;
-  activeAuthorHex = nextHex;
-
-  cleanupSubscriptions();
-
-  if (!nextHex) {
-    reloadAfterReconnect = false;
-    if (previousHex) {
-      applyProfileEvent(null);
-      applyTiersEvent(null);
-    }
-    return;
-  }
-
-  if (previousHex && previousHex !== nextHex) {
-    applyProfileEvent(null);
-    applyTiersEvent(null);
-  }
-
-  setupSubscriptions(nextHex);
-}
-
-async function loadAll() {
-  let authorHex: string;
-  try {
-    authorHex = normalizeAuthor(authorInput.value);
-  } catch (err) {
-    notifyError(err instanceof Error ? err.message : String(err));
-    return;
-  }
-
-  loading.value = true;
-  try {
-    await Promise.all([loadTiers(authorHex), loadProfile(authorHex)]);
-  } catch (err) {
-    console.error('[nutzap] failed to load Nutzap profile', err);
-    if (!(err instanceof Error)) {
-      notifyError('Failed to load Nutzap profile.');
-    }
-  } finally {
-    loading.value = false;
-  }
-}
-
-async function publishTiers() {
-  let authorHex: string;
-  try {
-    authorHex = normalizeAuthor(authorInput.value);
-  } catch (err) {
-    notifyError(err instanceof Error ? err.message : String(err));
-    return;
-  }
-
-  if (tiers.value.length === 0) {
-    notifyError('Add at least one tier before publishing.');
-    return;
-  }
-
-  publishingTiers.value = true;
-  try {
-    const { ack, event } = await publishTiersToRelay(tiers.value, tierKind.value);
-    const signerPubkey = event?.pubkey;
-    const reloadKey = typeof signerPubkey === 'string' && signerPubkey ? signerPubkey : authorHex;
-    if (signerPubkey && signerPubkey !== authorInput.value) {
-      authorInput.value = signerPubkey;
-    }
-    const eventId = ack?.id ?? event?.id;
-    const relayMessage = typeof ack?.message === 'string' && ack.message ? ` — ${ack.message}` : '';
-    lastTiersPublishInfo.value = eventId
-      ? `Tiers published (kind ${tierKind.value}) — id ${eventId}${relayMessage}`
-      : `Tiers published (kind ${tierKind.value})${relayMessage}`;
-    const successMessage =
-      typeof ack?.message === 'string' && ack.message
-        ? `Relay accepted tiers — ${ack.message}`
-        : 'Subscription tiers published to relay.fundstr.me.';
-    notifySuccess(successMessage);
-    await loadTiers(reloadKey);
-    refreshSubscriptions(true);
-  } catch (err) {
-    console.error('[nutzap] publish tiers failed', err);
-    if (err instanceof RelayPublishError) {
-      const message = err.ack.message ?? 'Relay rejected event.';
-      lastTiersPublishInfo.value = `Tiers publish rejected — id ${err.ack.id}${
-        err.ack.message ? ` — ${err.ack.message}` : ''
-      }`;
-      notifyError(message);
-    } else {
-      notifyError(err instanceof Error ? err.message : 'Unable to publish tiers.');
-    }
-  } finally {
-    publishingTiers.value = false;
-  }
-}
-
-async function publishProfile() {
-  let authorHex: string;
-  try {
-    authorHex = normalizeAuthor(authorInput.value);
-  } catch (err) {
-    notifyError(err instanceof Error ? err.message : String(err));
-    return;
-  }
-
-  if (!p2pkPub.value.trim()) {
-    notifyError('P2PK public key is required.');
-    return;
-  }
-  if (mintList.value.length === 0) {
-    notifyError('Add at least one trusted mint URL.');
-    return;
-  }
-  if (tiers.value.length === 0) {
-    notifyError('Add at least one tier before publishing.');
-    return;
-  }
-
-  publishingProfile.value = true;
-  try {
-    const relays = relayList.value;
-    const content = JSON.stringify({
-      v: 1,
-      p2pk: p2pkPub.value.trim(),
-      mints: mintList.value,
-      relays,
-      tierAddr: `${tierKind.value}:${authorHex}:tiers`,
+    const result = await publishNostrEvent({
+      kind: 1,
+      content: `Hello from Fundstr Nutzap toolkit at ${new Date().toISOString()}`,
+      tags: [],
     });
+    pushLog(`Published note ${result.event.id} (${result.ack.via})`, result.ack.accepted ? 'success' : 'error');
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : String(err));
+  }
+}
 
-    const tags: string[][] = [
+async function handlePublishProfile() {
+  try {
+    const p2pk = p2pkInput.value || toolkit.cashuPub.value;
+    if (!p2pk || !/^(02|03)[0-9a-fA-F]{64}$/.test(p2pk)) {
+      throw new Error('Provide a Cashu P2PK compressed public key.');
+    }
+    const profile = {
+      v: 1,
+      p2pk,
+      mints: getLines(mintsText.value),
+      relays: getLines(relaysText.value),
+      tierAddr: tierAddress.value || toolkit.tierAddress.value,
+    };
+    const tags = [
       ['t', 'nutzap-profile'],
       ['client', 'fundstr'],
-      ...mintList.value.map(mint => ['mint', mint, 'sat']),
-      ...relays.map(relay => ['relay', relay]),
+      ...profile.mints.map(mint => ['mint', mint, 'sat']),
+      ...profile.relays.map(relay => ['relay', relay]),
     ];
-    tags.push(['a', `${tierKind.value}:${authorHex}:tiers`]);
-    if (displayName.value.trim()) {
-      tags.push(['name', displayName.value.trim()]);
-    }
-    if (pictureUrl.value.trim()) {
-      tags.push(['picture', pictureUrl.value.trim()]);
-    }
-
-    const { ack, event } = await publishNostrEvent({ kind: 10019, tags, content });
-    const signerPubkey = event?.pubkey;
-    const reloadKey = typeof signerPubkey === 'string' && signerPubkey ? signerPubkey : authorHex;
-    if (signerPubkey && signerPubkey !== authorInput.value) {
-      authorInput.value = signerPubkey;
-    }
-    const eventId = ack?.id ?? event?.id;
-    const relayMessage = typeof ack?.message === 'string' && ack.message ? ` — ${ack.message}` : '';
-    lastProfilePublishInfo.value = eventId
-      ? `Profile published — id ${eventId}${relayMessage}`
-      : `Profile published to relay.fundstr.me.${relayMessage}`;
-    const successMessage =
-      typeof ack?.message === 'string' && ack.message
-        ? `Relay accepted profile — ${ack.message}`
-        : 'Nutzap profile published to relay.fundstr.me.';
-    notifySuccess(successMessage);
-    await loadProfile(reloadKey);
-    refreshSubscriptions(true);
+    const result = await publishNostrEvent({
+      kind: 10019,
+      tags,
+      content: JSON.stringify(profile),
+    });
+    pushLog(`Published Nutzap profile ${result.event.id}`, result.ack.accepted ? 'success' : 'error');
+    notifySuccess('Nutzap profile published.');
   } catch (err) {
-    console.error('[nutzap] publish profile failed', err);
-    if (err instanceof RelayPublishError) {
-      const message = err.ack.message ?? 'Relay rejected event.';
-      lastProfilePublishInfo.value = `Profile publish rejected — id ${err.ack.id}${
-        err.ack.message ? ` — ${err.ack.message}` : ''
-      }`;
-      notifyError(message);
-    } else {
-      notifyError(err instanceof Error ? err.message : 'Unable to publish Nutzap profile.');
-    }
-  } finally {
-    publishingProfile.value = false;
+    notifyError(err instanceof Error ? err.message : String(err));
   }
 }
 
-function frequencyLabel(value: Tier['frequency']) {
-  return value === 'one_time' ? 'one-time' : value;
+async function handlePublishTiers() {
+  try {
+    const parsed = JSON.parse(tiersJson.value);
+    const result = await publishNostrEvent({
+      kind: 30000,
+      tags: [
+        ['d', 'tiers'],
+        ['t', 'nutzap-tiers'],
+        ['client', 'fundstr'],
+      ],
+      content: JSON.stringify(parsed),
+    });
+    pushLog(`Published tiers ${result.event.id}`, result.ack.accepted ? 'success' : 'error');
+    notifySuccess('Tiers published.');
+  } catch (err) {
+    notifyError(err instanceof Error ? err.message : String(err));
+  }
 }
 
-watch(
-  () => authorInput.value,
-  () => {
-    refreshSubscriptions();
-  },
-  { immediate: true }
-);
+function clearLog() {
+  logEntries.value = [];
+}
 
-watch(
-  signer,
-  newSigner => {
-    const ndk = getNutzapNdk();
-    ndk.signer = newSigner ?? undefined;
-  },
-  { immediate: true }
-);
+interface TestLogEntry {
+  id: number;
+  message: string;
+  ok: boolean;
+}
 
-watch(pubkey, newPubkey => {
-  if (newPubkey && !authorInput.value) {
-    authorInput.value = newPubkey;
-  }
-  if (newPubkey && !hasAutoLoaded.value) {
-    hasAutoLoaded.value = true;
-    void loadAll();
-  }
+const testLog = ref<TestLogEntry[]>([]);
+const testRunning = ref(false);
+
+const testStatusLabel = computed(() => {
+  if (testRunning.value) return 'Running…';
+  if (!testLog.value.length) return 'Idle';
+  return testLog.value.every(entry => entry.ok) ? 'All passed' : 'Failed';
 });
+
+const testStatusColor = computed(() => {
+  if (testRunning.value) return 'warning';
+  if (!testLog.value.length) return 'primary';
+  return testLog.value.every(entry => entry.ok) ? 'positive' : 'negative';
+});
+
+function pushTest(message: string, ok: boolean) {
+  testLog.value = [...testLog.value, { id: testLog.value.length + 1, message, ok }];
+}
+
+async function runTests() {
+  testRunning.value = true;
+  testLog.value = [];
+  try {
+    const sk = generateSecretKey();
+    pushTest('generateSecretKey returns 32 bytes', sk instanceof Uint8Array && sk.length === 32);
+    const skHex = Array.from(sk)
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('');
+    const pk = getPublicKey(sk);
+    pushTest('getPublicKey produces 64 hex', typeof pk === 'string' && pk.length === 64);
+    const npub = nip19.npubEncode(pk);
+    pushTest('npub encode/decode roundtrip', nip19.decode(npub).data === pk);
+    const nsec = nip19.nsecEncode(sk);
+    const decoded = nip19.decode(nsec);
+    const decodedBytes = decoded.data instanceof Uint8Array ? decoded.data : new Uint8Array(decoded.data as number[]);
+    pushTest('nsec decode matches original', decodedBytes.length === sk.length);
+  } catch (err) {
+    pushTest(err instanceof Error ? err.message : String(err), false);
+  } finally {
+    testRunning.value = false;
+  }
+}
+
+const legacyKinds = ref('1,10019,30000');
+const legacyAuthors = ref('');
+const legacyIds = ref('');
+const legacyLimit = ref(10);
+const legacyResults = ref<any[]>([]);
+const legacyStatus = ref<'idle' | 'waiting' | 'done' | 'timeout'>('idle');
+const legacyLoading = ref(false);
+const legacyTimeoutMs = 5000;
+
+const legacyChipLabel = computed(() => {
+  if (legacyStatus.value === 'waiting') return 'Waiting…';
+  if (legacyStatus.value === 'timeout') return 'Timeout';
+  if (legacyStatus.value === 'done') return 'EOSE';
+  return 'Idle';
+});
+
+const legacyChipColor = computed(() => {
+  if (legacyStatus.value === 'waiting') return 'warning';
+  if (legacyStatus.value === 'timeout') return 'negative';
+  if (legacyStatus.value === 'done') return 'positive';
+  return 'primary';
+});
+
+function formatTimestamp(sec: number) {
+  return new Date(sec * 1000).toLocaleString();
+}
+
+function parseCsv(input: string) {
+  return input
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean);
+}
+
+async function runLegacyQuery() {
+  legacyLoading.value = true;
+  legacyStatus.value = 'waiting';
+  try {
+    const kinds = parseCsv(legacyKinds.value)
+      .map(Number)
+      .filter(value => Number.isInteger(value));
+    const authors = parseCsv(legacyAuthors.value);
+    const ids = parseCsv(legacyIds.value);
+    const filters = [
+      {
+        kinds,
+        ...(authors.length ? { authors } : {}),
+        ...(ids.length ? { ids } : {}),
+        limit: Math.max(1, Math.min(legacyLimit.value || 10, 100)),
+      },
+    ];
+    const events = await fundstrRelayClient.requestOnce(filters, { timeoutMs: legacyTimeoutMs });
+    legacyResults.value = events;
+    legacyStatus.value = 'done';
+  } catch (err) {
+    legacyStatus.value = 'timeout';
+    notifyError(err instanceof Error ? err.message : String(err));
+  } finally {
+    legacyLoading.value = false;
+  }
+}
 
 onMounted(() => {
-  if (!relaysText.value) {
-    relaysText.value = FUNDSTR_WS_URL;
-  }
-  if (pubkey.value && !authorInput.value) {
-    authorInput.value = pubkey.value;
-  }
-  if (authorInput.value && !hasAutoLoaded.value) {
-    hasAutoLoaded.value = true;
-    void loadAll();
-  }
-  ensureRelayStatusListener();
-});
-
-onBeforeUnmount(() => {
-  cleanupSubscriptions();
-  if (stopRelayStatusListener) {
-    stopRelayStatusListener();
-    stopRelayStatusListener = null;
-  }
-  reloadAfterReconnect = false;
+  toolkit.connectRelay();
 });
 </script>
+
+<style scoped>
+.log-window {
+  max-height: 200px;
+  overflow-y: auto;
+  background: var(--surface-2);
+  border-radius: 8px;
+  padding: 8px;
+  border: 1px solid var(--surface-contrast-border);
+}
+.mono {
+  font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+</style>


### PR DESCRIPTION
## Summary
- rebuild the Nutzap profile page as a multi-section toolkit with key management, publisher controls, activity log, self-tests, and legacy explorer
- introduce a `useNutzapToolkit` composable to manage keys, Cashu helpers, and relay status/log wiring
- add a reusable Explorer v2 component with multi-relay search and result renderers for profiles, notes, Nutzap profiles, and tiers

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d5876826508330918d7eb5ac03ad1e