### PR TITLE
feat: add multi-relay search explorer

### DIFF
--- a/src/nutzap/onepage/NutzapExplorerSearch.vue
+++ b/src/nutzap/onepage/NutzapExplorerSearch.vue
@@ -1,0 +1,389 @@
+<template>
+  <div class="explorer-v2 column q-gutter-md">
+    <div class="row items-end q-col-gutter-md">
+      <q-input
+        v-model="query"
+        class="col-12 col-md"
+        dense
+        filled
+        label="Query or pointer"
+        autocomplete="off"
+        placeholder="npub, nprofile, naddr, note, hex, or NIP-05"
+      />
+      <div class="col-12 col-md-auto row items-center q-gutter-sm">
+        <q-btn-toggle
+          v-model="mode"
+          :options="modeOptions"
+          dense
+          unelevated
+          toggle-color="primary"
+          class="mode-toggle"
+        />
+        <q-btn
+          color="primary"
+          :label="loading ? 'Searching…' : 'Run search'"
+          :loading="loading"
+          :disable="!canSearch || loading"
+          @click="runSearch"
+        />
+      </div>
+    </div>
+
+    <div class="row q-col-gutter-md">
+      <q-input
+        v-model.number="limit"
+        class="col-12 col-sm-4"
+        dense
+        type="number"
+        filled
+        label="Result limit"
+        :min="1"
+        :max="200"
+      />
+      <q-input
+        v-model.number="daysBack"
+        class="col-12 col-sm-4"
+        dense
+        type="number"
+        filled
+        label="Days back"
+        :min="0"
+      />
+      <q-input
+        v-model="relayInput"
+        class="col-12 col-sm-4"
+        dense
+        filled
+        type="textarea"
+        autogrow
+        label="Relay list"
+        hint="Comma or newline separated"
+      />
+    </div>
+
+    <div class="text-caption text-2">
+      Active relays:
+      <span class="text-1">
+        {{ activeRelays.length ? activeRelays.join(', ') : 'None' }}
+      </span>
+    </div>
+
+    <q-banner v-if="errorMessage" class="bg-negative text-white">
+      {{ errorMessage }}
+    </q-banner>
+
+    <div v-if="pointerSummary" class="text-caption text-2">
+      Pointer: <span class="text-1">{{ pointerSummary }}</span>
+    </div>
+
+    <div v-if="timedOut" class="text-caption text-warning">
+      Partial results returned before timeout.
+    </div>
+
+    <div v-if="loading" class="column items-center q-gutter-sm q-py-md">
+      <q-spinner color="primary" size="24px" />
+      <div class="text-caption text-2">Fetching from relays…</div>
+    </div>
+
+    <div v-else>
+      <div v-if="!results.length" class="text-caption text-2">
+        No results yet. Enter a pointer or query to search the relay set.
+      </div>
+      <div v-else class="column q-gutter-md">
+        <q-card v-for="event in results" :key="event.id" class="bg-surface-2 result-card">
+          <q-card-section>
+            <div class="row items-center q-gutter-sm">
+              <q-chip dense outline color="accent">Kind {{ event.kind }}</q-chip>
+              <span class="text-caption text-2">{{ formatTimestamp(event.created_at) }}</span>
+              <span class="text-caption text-2">{{ shorten(event.id) }}</span>
+            </div>
+          </q-card-section>
+          <q-separator inset />
+          <q-card-section v-if="event.kind === 0">
+            <div class="row q-col-gutter-md">
+              <div class="col-auto">
+                <q-avatar size="64px" square>
+                  <img :src="profileDetails(event).picture" alt="Profile picture" />
+                </q-avatar>
+              </div>
+              <div class="col column q-gutter-xs">
+                <div class="text-subtitle1 text-1">{{ profileDetails(event).name || 'Unnamed profile' }}</div>
+                <div class="text-caption text-2" v-if="profileDetails(event).about">
+                  {{ profileDetails(event).about }}
+                </div>
+                <div class="text-caption text-2" v-if="profileDetails(event).nip05">
+                  {{ profileDetails(event).nip05 }}
+                </div>
+              </div>
+            </div>
+          </q-card-section>
+          <q-card-section v-else>
+            <div class="text-body2 text-1 whitespace-pre-wrap">{{ event.content }}</div>
+          </q-card-section>
+          <q-separator inset />
+          <q-card-actions align="between" class="text-caption text-2">
+            <span>Author: {{ shorten(event.pubkey) }}</span>
+            <span v-if="resultRelays[event.id]?.length">
+              Relays: {{ resultRelays[event.id].join(', ') }}
+            </span>
+          </q-card-actions>
+        </q-card>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref } from 'vue';
+import { nip19 } from 'nostr-tools';
+import type { Event as NostrEvent, Filter as NostrFilter } from 'nostr-tools';
+import { multiRelaySearch, mergeRelayHints } from './multiRelaySearch';
+import { sanitizeRelayUrls } from 'src/utils/relay';
+
+const DEFAULT_RELAYS = ['wss://relay.fundstr.me', 'wss://relay.damus.io'];
+
+const query = ref('');
+const mode = ref<'profiles' | 'notes' | 'address'>('profiles');
+const limit = ref<number>(20);
+const daysBack = ref<number>(7);
+const relayInput = ref(DEFAULT_RELAYS.join('\n'));
+const loading = ref(false);
+const timedOut = ref(false);
+const errorMessage = ref('');
+const pointerSummary = ref('');
+const results = ref<NostrEvent[]>([]);
+const activeRelays = ref<string[]>(sanitizeRelayUrls(DEFAULT_RELAYS));
+const resultRelays = reactive<Record<string, string[]>>({});
+
+const modeOptions = [
+  { label: 'Profiles', value: 'profiles' },
+  { label: 'Notes', value: 'notes' },
+  { label: 'Addressable', value: 'address' },
+];
+
+const HEX_64 = /^[0-9a-f]{64}$/i;
+
+const sanitizedRelayList = computed(() => sanitizeRelayUrls(relayInput.value.split(/[\s,]+/).filter(Boolean)));
+
+const canSearch = computed(() => Boolean(query.value.trim()) || sanitizedRelayList.value.length > 0);
+
+function shorten(value: string): string {
+  if (!value) return '';
+  return `${value.slice(0, 8)}…${value.slice(-6)}`;
+}
+
+function formatTimestamp(ts?: number): string {
+  if (!ts) return 'Unknown time';
+  return new Date(ts * 1000).toLocaleString();
+}
+
+function parseProfileContent(event: NostrEvent): { name: string; about: string; picture: string; nip05: string } {
+  try {
+    const data = JSON.parse(event.content ?? '{}');
+    return {
+      name: data.name || data.display_name || '',
+      about: data.about || '',
+      picture: data.picture || data.image || '',
+      nip05: data.nip05 || '',
+    };
+  } catch {
+    return { name: '', about: '', picture: '', nip05: '' };
+  }
+}
+
+const profileCache = new Map<string, { name: string; about: string; picture: string; nip05: string }>();
+
+function profileDetails(event: NostrEvent) {
+  if (!profileCache.has(event.id)) {
+    profileCache.set(event.id, parseProfileContent(event));
+  }
+  return profileCache.get(event.id)!;
+}
+
+type Nip05Result = { pubkey: string; relays: string[] } | null;
+
+async function resolveNip05(identifier: string): Promise<Nip05Result> {
+  const trimmed = identifier.trim();
+  const parts = trimmed.split('@');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return null;
+  }
+  const [name, domain] = parts;
+  const url = `https://${domain}/.well-known/nostr.json?name=${encodeURIComponent(name.toLowerCase())}`;
+  try {
+    const response = await fetch(url, { headers: { accept: 'application/json' } });
+    if (!response.ok) {
+      return null;
+    }
+    const payload = await response.json();
+    const lowerName = name.toLowerCase();
+    const pubkey = payload?.names?.[lowerName];
+    if (!pubkey || typeof pubkey !== 'string') {
+      return null;
+    }
+    const relays = Array.isArray(payload?.relays?.[pubkey])
+      ? sanitizeRelayUrls(payload.relays[pubkey] as string[])
+      : [];
+    return { pubkey, relays };
+  } catch (err) {
+    console.warn('Failed to resolve NIP-05 identifier', err);
+    return null;
+  }
+}
+
+async function buildFilters(): Promise<{
+  filters: NostrFilter[];
+  pointer?: unknown;
+  pointerRelays: string[];
+  forcedMode: typeof mode.value;
+}> {
+  const trimmed = query.value.trim();
+  const since = daysBack.value > 0 ? Math.floor(Date.now() / 1000) - daysBack.value * 86400 : undefined;
+  const limitValue = limit.value > 0 ? Math.min(Math.floor(limit.value), 500) : 50;
+  const filters: NostrFilter[] = [];
+  let pointer: unknown;
+  let pointerRelays: string[] = [];
+  let authors: string[] | undefined;
+  let ids: string[] | undefined;
+  let identifier: string | undefined;
+  let forcedMode = mode.value;
+
+  if (trimmed) {
+    try {
+      const decoded = nip19.decode(trimmed);
+      pointer = decoded;
+      switch (decoded.type) {
+        case 'npub':
+          authors = [decoded.data as string];
+          break;
+        case 'nprofile':
+          authors = [decoded.data.pubkey];
+          pointerRelays = sanitizeRelayUrls(decoded.data.relays || []);
+          break;
+        case 'note':
+          ids = [decoded.data as string];
+          forcedMode = 'notes';
+          break;
+        case 'nevent':
+          ids = [decoded.data.id];
+          pointerRelays = sanitizeRelayUrls(decoded.data.relays || []);
+          forcedMode = 'notes';
+          break;
+        case 'naddr':
+          authors = [decoded.data.pubkey];
+          identifier = decoded.data.identifier;
+          pointerRelays = sanitizeRelayUrls(decoded.data.relays || []);
+          forcedMode = 'address';
+          filters.push({
+            kinds: [decoded.data.kind],
+            authors,
+            '#d': [identifier],
+            limit: limitValue,
+            ...(since ? { since } : {}),
+          });
+          return { filters, pointer, pointerRelays, forcedMode };
+        default:
+          break;
+      }
+    } catch {
+      if (trimmed.includes('@')) {
+        const nip05 = await resolveNip05(trimmed);
+        if (nip05) {
+          authors = [nip05.pubkey];
+          pointerRelays = nip05.relays;
+        }
+      } else if (HEX_64.test(trimmed)) {
+        if (mode.value === 'notes') {
+          ids = [trimmed.toLowerCase()];
+        } else {
+          authors = [trimmed.toLowerCase()];
+        }
+      }
+    }
+  }
+
+  const kinds =
+    forcedMode === 'profiles' ? [0] : forcedMode === 'notes' ? [1] : identifier ? [] : [30019, 30000];
+
+  if (forcedMode === 'address' && !identifier && !pointer) {
+    throw new Error('Addressable mode requires an naddr pointer.');
+  }
+
+  const baseFilter: NostrFilter = { kinds, limit: limitValue };
+  if (authors?.length) baseFilter.authors = authors;
+  if (ids?.length) baseFilter.ids = ids;
+  if (identifier) baseFilter['#d'] = [identifier];
+  if (since) baseFilter.since = since;
+
+  filters.push(baseFilter);
+  return { filters, pointer, pointerRelays, forcedMode };
+}
+
+async function runSearch(): Promise<void> {
+  loading.value = true;
+  errorMessage.value = '';
+  timedOut.value = false;
+  pointerSummary.value = '';
+  profileCache.clear();
+  Object.keys(resultRelays).forEach(key => delete resultRelays[key]);
+
+  try {
+    const { filters, pointer, pointerRelays, forcedMode } = await buildFilters();
+    if (!filters.length) {
+      results.value = [];
+      activeRelays.value = sanitizedRelayList.value;
+      return;
+    }
+
+    pointerSummary.value = forcedMode !== mode.value ? `${forcedMode} via pointer` : '';
+
+    const mergedRelays = mergeRelayHints(sanitizedRelayList.value, pointer, pointerRelays);
+    activeRelays.value = mergedRelays;
+
+    const response = await multiRelaySearch({
+      filters,
+      relays: sanitizedRelayList.value,
+      pointer,
+      additionalRelays: pointerRelays,
+      timeoutMs: 5000,
+      onEvent: (event, relay) => {
+        if (!relay) return;
+        if (!resultRelays[event.id]) {
+          resultRelays[event.id] = [];
+        }
+        if (!resultRelays[event.id].includes(relay)) {
+          resultRelays[event.id].push(relay);
+        }
+      },
+    });
+
+    results.value = response.events;
+    timedOut.value = response.timedOut;
+    if (!response.events.length) {
+      pointerSummary.value = pointerSummary.value || 'No matching events.';
+    }
+  } catch (err) {
+    errorMessage.value = err instanceof Error ? err.message : 'Search failed.';
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.explorer-v2 {
+  border-radius: 12px;
+}
+
+.mode-toggle {
+  min-width: 200px;
+}
+
+.result-card {
+  border: 1px solid var(--surface-contrast-border, rgba(255, 255, 255, 0.08));
+}
+
+.whitespace-pre-wrap {
+  white-space: pre-wrap;
+}
+</style>

--- a/src/nutzap/onepage/__tests__/multiRelaySearch.spec.ts
+++ b/src/nutzap/onepage/__tests__/multiRelaySearch.spec.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Event as NostrEvent, Filter as NostrFilter } from 'nostr-tools';
+import { multiRelaySearch, mergeRelayHints } from '../multiRelaySearch';
+
+const poolState = {
+  onSubscribe: undefined as ((params: any) => void) | undefined,
+  subscribeCalls: [] as Array<{ relays: string[]; filters: NostrFilter[]; params: any }>,
+};
+
+vi.mock('nostr-tools', async () => {
+  const actual = await vi.importActual<typeof import('nostr-tools')>('nostr-tools');
+  class MockSimplePool {
+    subscribeMany(relays: string[], filters: NostrFilter[], params: any) {
+      poolState.subscribeCalls.push({ relays, filters, params });
+      poolState.onSubscribe?.(params);
+      return {
+        close: vi.fn(),
+      };
+    }
+    destroy() {
+      /* noop */
+    }
+  }
+  return { ...actual, SimplePool: MockSimplePool };
+});
+
+describe('multiRelaySearch', () => {
+  const sampleEvent: NostrEvent = {
+    id: 'abc123',
+    kind: 1,
+    pubkey: 'pubkey1',
+    created_at: 100,
+    content: 'hello',
+    tags: [],
+    sig: 'sig',
+  };
+
+beforeEach(() => {
+  poolState.onSubscribe = undefined;
+  poolState.subscribeCalls.length = 0;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+  it('deduplicates events from multiple relays', async () => {
+    poolState.onSubscribe = params => {
+      params.onevent?.(sampleEvent, 'wss://relay.one');
+      params.onevent?.({ ...sampleEvent }, 'wss://relay.two');
+      params.oneose?.();
+    };
+
+    const result = await multiRelaySearch({
+      filters: [{ kinds: [1], limit: 5 }],
+      relays: ['wss://relay.one', 'wss://relay.two'],
+    });
+
+    expect(result.events).toHaveLength(1);
+    expect(poolState.subscribeCalls).toHaveLength(1);
+    expect(poolState.subscribeCalls[0].relays).toEqual([
+      'wss://relay.one',
+      'wss://relay.two',
+    ]);
+  });
+
+  it('resolves when the timeout triggers', async () => {
+    vi.useFakeTimers();
+    poolState.onSubscribe = () => {
+      // no events, no EOSE -> rely on timeout
+    };
+
+    const promise = multiRelaySearch({
+      filters: [{ kinds: [1], limit: 5 }],
+      relays: ['wss://relay.one'],
+      timeoutMs: 1500,
+    });
+
+    vi.advanceTimersByTime(1500);
+    const result = await promise;
+    expect(result.timedOut).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('merges pointer relays with base relays', async () => {
+    poolState.onSubscribe = params => {
+      params.oneose?.();
+    };
+    const pointer = { relays: ['wss://relay.three'] };
+
+    await multiRelaySearch({
+      filters: [{ kinds: [0], limit: 1 }],
+      relays: ['wss://relay.one'],
+      pointer,
+    });
+
+    expect(poolState.subscribeCalls[0].relays).toContain('wss://relay.three');
+  });
+});
+
+describe('mergeRelayHints', () => {
+  it('normalizes and merges multiple relay sources', () => {
+    const result = mergeRelayHints(
+      ['wss://relay.one/'],
+      { data: { relays: ['wss://relay.two'] } },
+      ['relay.three'],
+    );
+    expect(result).toEqual([
+      'wss://relay.one',
+      'wss://relay.two',
+      'wss://relay.three',
+    ]);
+  });
+});

--- a/src/nutzap/onepage/multiRelaySearch.ts
+++ b/src/nutzap/onepage/multiRelaySearch.ts
@@ -1,0 +1,354 @@
+import { SimplePool, type Event as NostrEvent, type Filter as NostrFilter } from 'nostr-tools';
+import { sanitizeRelayUrls } from 'src/utils/relay';
+
+type PointerLike = {
+  relays?: unknown;
+  data?: unknown;
+};
+
+type Closeable = {
+  close(reason?: string): Promise<void> | void;
+};
+
+type PoolFactory = () => Pick<SimplePool, 'subscribeMany' | 'destroy'>;
+
+type WebSocketCtor = new (url: string, protocols?: string | string[]) => WebSocket;
+
+type ManualSocketFactory = () => WebSocketCtor | undefined;
+
+export type MultiRelaySearchOptions = {
+  filters: NostrFilter[];
+  relays: string[];
+  pointer?: PointerLike | null;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  onEvent?: (event: NostrEvent, relay?: string) => void;
+  forceMode?: 'pool' | 'manual';
+  poolFactory?: PoolFactory;
+  websocketFactory?: ManualSocketFactory;
+  additionalRelays?: string[];
+};
+
+export type MultiRelaySearchResult = {
+  events: NostrEvent[];
+  usedRelays: string[];
+  timedOut: boolean;
+};
+
+const DEFAULT_TIMEOUT_MS = 7000;
+const SUBSCRIPTION_PREFIX = 'multi-relay';
+
+function normalizeRelay(url: string): string {
+  return url.trim().replace(/\s+/g, '').replace(/\/+$/, '').toLowerCase();
+}
+
+function collectPointerRelays(pointer: unknown): string[] {
+  if (!pointer || typeof pointer !== 'object') {
+    return [];
+  }
+
+  const relays = (pointer as PointerLike).relays;
+  if (Array.isArray(relays)) {
+    return sanitizeRelayUrls(relays as string[]);
+  }
+
+  const nested = (pointer as PointerLike).data;
+  if (nested && typeof nested === 'object') {
+    return collectPointerRelays(nested);
+  }
+
+  return [];
+}
+
+export function mergeRelayHints(
+  baseRelays: string[],
+  pointer?: PointerLike | null,
+  additional: string[] = [],
+): string[] {
+  const merged = new Set<string>();
+  for (const url of sanitizeRelayUrls(baseRelays)) {
+    merged.add(normalizeRelay(url));
+  }
+  for (const url of collectPointerRelays(pointer)) {
+    merged.add(normalizeRelay(url));
+  }
+  for (const url of sanitizeRelayUrls(additional)) {
+    merged.add(normalizeRelay(url));
+  }
+  return Array.from(merged);
+}
+
+function createSubId(): string {
+  return `${SUBSCRIPTION_PREFIX}-${Math.random().toString(36).slice(2)}`;
+}
+
+function sortEvents(events: NostrEvent[]): NostrEvent[] {
+  return [...events].sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0));
+}
+
+function isSimplePoolAvailable(): boolean {
+  return typeof SimplePool === 'function';
+}
+
+async function searchWithPool(
+  options: Required<Pick<MultiRelaySearchOptions, 'filters' | 'timeoutMs' | 'onEvent'>> & {
+    relays: string[];
+    signal?: AbortSignal;
+    poolFactory?: PoolFactory;
+  },
+): Promise<MultiRelaySearchResult> {
+  const { filters, relays, timeoutMs, signal, onEvent, poolFactory } = options;
+  const pool = poolFactory ? poolFactory() : new SimplePool();
+  let closer: Closeable | undefined;
+
+  try {
+    const seen = new Map<string, NostrEvent>();
+    const ordered: NostrEvent[] = [];
+
+    return await new Promise<MultiRelaySearchResult>(resolve => {
+      let resolved = false;
+      let timedOut = false;
+      const finalize = (timeoutTriggered: boolean) => {
+        if (resolved) {
+          return;
+        }
+        resolved = true;
+        timedOut = timeoutTriggered;
+        clearTimeout(timer);
+        signal?.removeEventListener('abort', onAbort);
+        if (closer) {
+          Promise.resolve(closer.close('completed')).catch(() => undefined);
+        }
+        resolve({ events: sortEvents(ordered), usedRelays: relays, timedOut });
+      };
+
+      const timer = setTimeout(() => finalize(true), timeoutMs);
+
+      const onAbort = () => finalize(false);
+      if (signal) {
+        if (signal.aborted) {
+          finalize(false);
+          return;
+        }
+        signal.addEventListener('abort', onAbort, { once: true });
+      }
+
+      try {
+        closer = pool.subscribeMany(relays, filters, {
+          maxWait: timeoutMs,
+          alreadyHaveEvent: id => seen.has(id),
+          onevent: (event: NostrEvent, relay?: string) => {
+            if (!event || typeof event.id !== 'string') {
+              return;
+            }
+            if (seen.has(event.id)) {
+              return;
+            }
+            seen.set(event.id, event);
+            ordered.push(event);
+            onEvent(event, relay);
+          },
+          oneose: () => finalize(false),
+          onclose: () => finalize(false),
+        });
+      } catch (err) {
+        finalize(false);
+        throw err;
+      }
+    });
+  } finally {
+    if (typeof pool.destroy === 'function') {
+      pool.destroy();
+    }
+  }
+}
+
+async function searchWithManual(
+  options: Required<Pick<MultiRelaySearchOptions, 'filters' | 'timeoutMs' | 'onEvent'>> & {
+    relays: string[];
+    signal?: AbortSignal;
+    websocketFactory?: ManualSocketFactory;
+  },
+): Promise<MultiRelaySearchResult> {
+  const { filters, relays, timeoutMs, signal, onEvent, websocketFactory } = options;
+  const resolveCtor: ManualSocketFactory = websocketFactory
+    ? websocketFactory
+    : () => {
+        const ctor =
+          typeof WebSocket !== 'undefined'
+            ? WebSocket
+            : (globalThis as unknown as { WebSocket?: WebSocketCtor }).WebSocket;
+        return ctor as WebSocketCtor | undefined;
+      };
+
+  if (!relays.length) {
+    return { events: [], usedRelays: [], timedOut: false };
+  }
+
+  const seen = new Map<string, NostrEvent>();
+  const ordered: NostrEvent[] = [];
+  const sockets: WebSocket[] = [];
+  const eoseRelays = new Set<string>();
+  const subId = createSubId();
+
+  return new Promise(resolve => {
+    let resolved = false;
+    let timedOut = false;
+
+    const finalize = (timeoutTriggered: boolean) => {
+      if (resolved) {
+        return;
+      }
+      resolved = true;
+      timedOut = timeoutTriggered;
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      for (const socket of sockets) {
+        try {
+          socket.close();
+        } catch (err) {
+          console.warn('Failed to close relay socket', err);
+        }
+      }
+      resolve({ events: sortEvents(ordered), usedRelays: relays, timedOut });
+    };
+
+    const timer = setTimeout(() => finalize(true), timeoutMs);
+
+    const onAbort = () => finalize(false);
+    if (signal) {
+      if (signal.aborted) {
+        finalize(false);
+        return;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    const payload = JSON.stringify(['REQ', subId, ...filters]);
+
+    for (const relay of relays) {
+      let socket: WebSocket | undefined;
+      const Impl = resolveCtor();
+      if (!Impl) {
+        continue;
+      }
+      try {
+        socket = new Impl(relay);
+      } catch (err) {
+        console.warn('Failed to create WebSocket for relay', relay, err);
+        continue;
+      }
+      if (!socket) {
+        continue;
+      }
+      sockets.push(socket);
+      const relayUrl = relay;
+
+      socket.onopen = () => {
+        try {
+          socket?.send(payload);
+        } catch (err) {
+          console.warn('Failed to send REQ to relay', relayUrl, err);
+        }
+      };
+
+      socket.onerror = () => {
+        eoseRelays.add(relayUrl);
+        if (eoseRelays.size >= relays.length) {
+          finalize(false);
+        }
+      };
+
+      socket.onclose = () => {
+        eoseRelays.add(relayUrl);
+        if (eoseRelays.size >= relays.length) {
+          finalize(false);
+        }
+      };
+
+      socket.onmessage = evt => {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(String((evt as MessageEvent).data));
+        } catch (err) {
+          console.warn('Failed to parse relay message', err);
+          return;
+        }
+        if (!Array.isArray(parsed)) {
+          return;
+        }
+        const [type, ...rest] = parsed as [string, ...any[]];
+        if (type === 'EVENT') {
+          const [id, event] = rest;
+          if (id !== subId || !event || typeof event.id !== 'string') {
+            return;
+          }
+          if (seen.has(event.id)) {
+            return;
+          }
+          seen.set(event.id, event);
+          ordered.push(event);
+          onEvent(event, relayUrl);
+        } else if (type === 'EOSE') {
+          const [id] = rest;
+          if (id === subId) {
+            eoseRelays.add(relayUrl);
+            if (eoseRelays.size >= relays.length) {
+              finalize(false);
+            }
+          }
+        }
+      };
+    }
+
+    if (!sockets.length) {
+      finalize(false);
+    }
+  });
+}
+
+export async function multiRelaySearch(options: MultiRelaySearchOptions): Promise<MultiRelaySearchResult> {
+  const {
+    filters,
+    relays,
+    pointer,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    signal,
+    onEvent = () => undefined,
+    forceMode,
+    poolFactory,
+    websocketFactory,
+    additionalRelays = [],
+  } = options;
+
+  const mergedRelays = mergeRelayHints(relays, pointer, additionalRelays);
+
+  if (!filters.length || !mergedRelays.length) {
+    return { events: [], usedRelays: mergedRelays, timedOut: false };
+  }
+
+  const poolAllowed = forceMode !== 'manual' && isSimplePoolAvailable();
+
+  if (poolAllowed) {
+    try {
+      return await searchWithPool({ filters, relays: mergedRelays, timeoutMs, signal, onEvent, poolFactory });
+    } catch (err) {
+      if (forceMode === 'pool') {
+        throw err;
+      }
+      console.warn('SimplePool search failed, falling back to manual sockets', err);
+    }
+  }
+
+  return searchWithManual({
+    filters,
+    relays: mergedRelays,
+    timeoutMs,
+    signal,
+    onEvent,
+    websocketFactory,
+  });
+}
+
+export type { NostrEvent, NostrFilter };
+

--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -161,6 +161,19 @@
         </q-card-section>
       </q-card>
 
+      <q-card class="grid-card explorer-card">
+        <q-card-section class="q-gutter-xs">
+          <div class="text-h6">Explorer v2</div>
+          <div class="text-caption text-2">
+            Query profiles, notes, or parameterized events across multiple relays.
+          </div>
+        </q-card-section>
+        <q-separator />
+        <q-card-section>
+          <NutzapExplorerSearch />
+        </q-card-section>
+      </q-card>
+
       <q-card class="grid-card publisher-card">
         <q-card-section class="q-gutter-xs">
           <div class="text-h6">Publisher</div>
@@ -343,6 +356,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { v4 as uuidv4 } from 'uuid';
 import RelayStatusIndicator from 'src/nutzap/RelayStatusIndicator.vue';
+import NutzapExplorerSearch from 'src/nutzap/onepage/NutzapExplorerSearch.vue';
 import { notifyError, notifySuccess, notifyWarning } from 'src/js/notify';
 import type { Tier } from 'src/nutzap/types';
 import { useActiveNutzapSigner } from 'src/nutzap/signer';


### PR DESCRIPTION
## Summary
- add a shared multi-relay search helper that deduplicates results, merges pointer relays, and falls back to manual sockets when SimplePool is unavailable
- build an Explorer v2 section with query, filters, pointer decoding, and relay results inside the Nutzap profile page
- add Vitest coverage for the search helper including timeout behaviour and pointer relay merging

## Testing
- pnpm vitest run src/nutzap/onepage/__tests__/multiRelaySearch.spec.ts
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d59bf18be88330a5e69c4c95767b67