### PR TITLE
Add P2PK key tools and tier JSON editor to Nutzap publisher

### DIFF
--- a/src/nutzap/onepage/useRelayConnection.ts
+++ b/src/nutzap/onepage/useRelayConnection.ts
@@ -459,6 +459,9 @@ const handleOpen = () => {
     clearActivity() {
       activityLog.value = [];
     },
+    logActivity(level: RelayActivityLevel, message: string, context?: string) {
+      appendActivity(level, message, context);
+    },
     isSupported: !!wsImpl,
     isConnected: computed(() => status.value === 'connected'),
   };


### PR DESCRIPTION
## Summary
- add UI controls for deriving and generating P2PK key pairs when composing publisher payloads and tag the derived public key on publish
- add a synchronized tiers JSON editor with validation that blocks publishing, reports errors in the activity log, and surfaces Quasar notifications
- expose a relay log helper so manual validation errors appear alongside relay activity

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d6266098948330899828417c688b5a