### PR TITLE
Fix staging SPA deployment for Nutzap profile chunk

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
-      - name: Build (Quasar PWA)
-        run: pnpm run build
+      - name: Build (Quasar SPA)
+        run: pnpm quasar build -m spa
 
       - name: Add SSH key
         uses: webfactory/ssh-agent@v0.9.0
@@ -45,5 +45,5 @@ jobs:
         run: |
           rsync -avz --delete \
             -e "ssh -p ${{ secrets.SSH_PORT }}" \
-            dist/pwa/ \
+            dist/spa/ \
             "${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }}:${{ secrets.SSH_TARGET_STAGING }}/"

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -14,3 +14,6 @@
     Header set Expires "0"
   </FilesMatch>
 </IfModule>
+<IfModule mod_mime.c>
+  AddType application/javascript .js
+</IfModule>

--- a/src/nostr/nutzapProfile.ts
+++ b/src/nostr/nutzapProfile.ts
@@ -1,11 +1,75 @@
-import { z } from "zod";
+export interface NutzapProfilePayload {
+  p2pk: string;
+  mints: string[];
+  relays?: string[];
+  tierAddr?: string;
+  v?: number;
+}
 
-export const NutzapProfileSchema = z.object({
-  p2pk: z.string(),
-  mints: z.array(z.string()),
-  relays: z.array(z.string()).optional(),
-  tierAddr: z.string().optional(),
-  v: z.number().optional(),
-});
+type SafeParseResult =
+  | { success: true; data: NutzapProfilePayload }
+  | { success: false; error: Error };
 
-export type NutzapProfilePayload = z.infer<typeof NutzapProfileSchema>;
+function validateNutzapProfile(input: unknown): SafeParseResult {
+  if (typeof input !== "object" || input === null) {
+    return { success: false, error: new Error("Profile payload must be an object") };
+  }
+
+  const candidate = input as Record<string, unknown>;
+
+  if (typeof candidate.p2pk !== "string" || candidate.p2pk.length === 0) {
+    return { success: false, error: new Error("Profile payload missing p2pk string") };
+  }
+
+  if (!Array.isArray(candidate.mints)) {
+    return { success: false, error: new Error("Profile payload mints must be an array") };
+  }
+  const mintsSource = candidate.mints.every(
+    (item) => typeof item === "string" && item.length > 0,
+  )
+    ? (candidate.mints as string[])
+    : undefined;
+  if (!mintsSource) {
+    return { success: false, error: new Error("Profile payload mints must be strings") };
+  }
+  const mints = [...mintsSource];
+
+  let relays: string[] | undefined;
+  if (candidate.relays !== undefined) {
+    if (!Array.isArray(candidate.relays)) {
+      return { success: false, error: new Error("Profile payload relays must be an array") };
+    }
+    if (!candidate.relays.every((item) => typeof item === "string" && item.length > 0)) {
+      return { success: false, error: new Error("Profile payload relays must be strings") };
+    }
+    relays = [...(candidate.relays as string[])];
+  }
+  const tierAddr = typeof candidate.tierAddr === "string" && candidate.tierAddr.length > 0
+    ? candidate.tierAddr
+    : undefined;
+  const version = typeof candidate.v === "number" ? candidate.v : undefined;
+
+  return {
+    success: true,
+    data: {
+      p2pk: candidate.p2pk,
+      mints,
+      relays,
+      tierAddr,
+      v: version,
+    },
+  };
+}
+
+export const NutzapProfileSchema = {
+  parse(input: unknown): NutzapProfilePayload {
+    const result = validateNutzapProfile(input);
+    if (!result.success) {
+      throw result.error;
+    }
+    return result.data;
+  },
+  safeParse(input: unknown): SafeParseResult {
+    return validateNutzapProfile(input);
+  },
+};


### PR DESCRIPTION
## Summary
- replace the zod-based Nutzap profile schema with a local validator and keep encryption helpers working via WebCrypto
- update the staging workflow to build the SPA output and deploy the generated assets, including the new NutzapProfilePage chunk
- ensure Hostinger serves `.js` files with `application/javascript` via `.htaccess`

## Testing
- `pnpm quasar build -m spa`


------
https://chatgpt.com/codex/tasks/task_e_68d62ca580788330adfc8030d590a823