### PR TITLE
Replace @scure/base usage with internal base64 helper

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -28,7 +28,7 @@ import {
 } from "nostr-tools";
 import { bytesToHex, hexToBytes, randomBytes } from "@noble/hashes/utils"; // already an installed dependency
 import { sha256 } from "@noble/hashes/sha256";
-import { base64 } from "@scure/base";
+import { decodeBase64, encodeBase64 } from "src/utils/base64";
 import { ensureCompressed } from "src/utils/ecash";
 import { useWalletStore } from "./wallet";
 import { generateSecretKey, getPublicKey } from "nostr-tools";
@@ -485,8 +485,8 @@ async function encryptWithSharedSecret(
   const iv = randomBytes(AES_BLOCK_SIZE);
   const plaintext = new TextEncoder().encode(message);
   const ciphertext = await aesCbcEncrypt(key, iv, plaintext);
-  const ctb64 = base64.encode(ciphertext);
-  const ivb64 = base64.encode(iv);
+  const ctb64 = encodeBase64(ciphertext);
+  const ivb64 = encodeBase64(iv);
   return `${ctb64}?iv=${ivb64}`;
 }
 
@@ -497,8 +497,8 @@ async function decryptWithSharedSecret(
   const ss = typeof shared === "string" ? hexToBytes(shared) : shared;
   const key = ss.length === 32 ? ss : ss.slice(1, 33);
   const [ctb64, ivb64] = data.split("?iv=");
-  const iv = base64.decode(ivb64);
-  const ciphertext = base64.decode(ctb64);
+  const iv = decodeBase64(ivb64);
+  const ciphertext = decodeBase64(ctb64);
   const plaintext = await aesCbcDecrypt(key, iv, ciphertext);
   return new TextDecoder().decode(plaintext);
 }

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,0 +1,35 @@
+export function encodeBase64(data: Uint8Array): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(data).toString("base64");
+  }
+
+  if (typeof btoa !== "undefined") {
+    let binary = "";
+    data.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+
+    return btoa(binary);
+  }
+
+  throw new Error("No base64 encoder available");
+}
+
+export function decodeBase64(value: string): Uint8Array {
+  if (typeof Buffer !== "undefined") {
+    return new Uint8Array(Buffer.from(value, "base64"));
+  }
+
+  if (typeof atob === "undefined") {
+    throw new Error("No base64 decoder available");
+  }
+
+  const binary = atob(value);
+  const result = new Uint8Array(binary.length);
+
+  for (let i = 0; i < binary.length; i += 1) {
+    result[i] = binary.charCodeAt(i);
+  }
+
+  return result;
+}

--- a/test/mocks/base.js
+++ b/test/mocks/base.js
@@ -1,1 +1,0 @@
-export const base64 = { encode: () => '', decode: () => new Uint8Array() };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -46,7 +46,6 @@ export default defineConfig({
         "src/lib/cashu-ts/src/index.ts",
       ),
       "@noble/ciphers/aes.js": path.resolve(__dirname, "test/mocks/aes.js"),
-      "@scure/base": path.resolve(__dirname, "test/mocks/base.js"),
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary
- add an internal base64 encoder/decoder utility so we no longer depend on `@scure/base`
- wire the nostr store to the new helper for encrypt/decrypt flows that use shared secrets
- remove the Vitest alias for `@scure/base` and drop the now-unused mock file

## Testing
- `pnpm dev` *(fails: quasar CLI is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d636f29e8883308a63d146588a34e5