### PR TITLE
Normalize Nutzap relay env fallback

### DIFF
--- a/src/nutzap/relayConfig.ts
+++ b/src/nutzap/relayConfig.ts
@@ -1,8 +1,22 @@
-export const NUTZAP_RELAY_WSS =
-  import.meta.env.VITE_NUTZAP_PRIMARY_RELAY_WSS ?? 'wss://relay.fundstr.me';
+function pickRelayEnv(value: unknown, fallback: string): string {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return fallback;
+}
 
-export const NUTZAP_RELAY_HTTP =
-  import.meta.env.VITE_NUTZAP_PRIMARY_RELAY_HTTP ?? 'https://relay.fundstr.me';
+export const NUTZAP_RELAY_WSS = pickRelayEnv(
+  import.meta.env.VITE_NUTZAP_PRIMARY_RELAY_WSS,
+  'wss://relay.fundstr.me',
+);
+
+export const NUTZAP_RELAY_HTTP = pickRelayEnv(
+  import.meta.env.VITE_NUTZAP_PRIMARY_RELAY_HTTP,
+  'https://relay.fundstr.me',
+);
 
 export const NUTZAP_ALLOW_WSS_WRITES =
   (import.meta.env.VITE_NUTZAP_ALLOW_WSS_WRITES ?? 'false') === 'true';


### PR DESCRIPTION
## Summary
- trim Nutzap relay relay host env vars and fall back to defaults when blank
- cover default relay endpoint behavior in nostr helpers tests

## Testing
- pnpm vitest run src/pages/nutzap-profile/__tests__/nostrHelpers.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d63e9770408330b1001b3f3b50fb03