### PR TITLE
Guard multi-relay socket closes

### DIFF
--- a/src/nutzap/onepage/__tests__/multiRelaySearch.spec.ts
+++ b/src/nutzap/onepage/__tests__/multiRelaySearch.spec.ts
@@ -5,6 +5,7 @@ import { multiRelaySearch, mergeRelayHints } from '../multiRelaySearch';
 const poolState = {
   onSubscribe: undefined as ((params: any) => void) | undefined,
   subscribeCalls: [] as Array<{ relays: string[]; filters: NostrFilter[]; params: any }>,
+  closeImpl: undefined as ((reason?: string) => void | Promise<void>) | undefined,
 };
 
 vi.mock('nostr-tools', async () => {
@@ -14,7 +15,7 @@ vi.mock('nostr-tools', async () => {
       poolState.subscribeCalls.push({ relays, filters, params });
       poolState.onSubscribe?.(params);
       return {
-        close: vi.fn(),
+        close: vi.fn((reason?: string) => poolState.closeImpl?.(reason)),
       };
     }
     destroy() {
@@ -38,6 +39,7 @@ describe('multiRelaySearch', () => {
 beforeEach(() => {
   poolState.onSubscribe = undefined;
   poolState.subscribeCalls.length = 0;
+  poolState.closeImpl = undefined;
 });
 
 afterEach(() => {
@@ -96,6 +98,76 @@ afterEach(() => {
     });
 
     expect(poolState.subscribeCalls[0].relays).toContain('wss://relay.three');
+  });
+
+  it('ignores closing errors when the pool subscription is already closing', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    poolState.closeImpl = () => {
+      throw new Error('WebSocket is not open: readyState 2 (CLOSING)');
+    };
+    poolState.onSubscribe = params => {
+      params.oneose?.();
+    };
+
+    try {
+      await multiRelaySearch({
+        filters: [{ kinds: [1], limit: 1 }],
+        relays: ['wss://relay.one'],
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not warn when manual sockets are already closing during finalize', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sockets: MockWebSocket[] = [];
+
+    class MockWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      readyState = MockWebSocket.OPEN;
+      onopen: (() => void) | null = null;
+      onclose: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onmessage: ((evt: { data: string }) => void) | null = null;
+      send = vi.fn();
+      close = vi.fn(() => {
+        if (this.readyState >= MockWebSocket.CLOSING) {
+          throw new Error('WebSocket is not open: readyState 2 (CLOSING)');
+        }
+        this.readyState = MockWebSocket.CLOSING;
+      });
+
+      constructor(public url: string) {
+        sockets.push(this);
+      }
+    }
+
+    try {
+      const promise = multiRelaySearch({
+        filters: [{ kinds: [1], limit: 1 }],
+        relays: ['wss://relay.manual'],
+        timeoutMs: 1000,
+        forceMode: 'manual',
+        websocketFactory: () => MockWebSocket as unknown as typeof WebSocket,
+      });
+
+      const [socket] = sockets;
+      expect(socket).toBeDefined();
+      socket.readyState = MockWebSocket.CLOSING;
+      socket.onclose?.();
+
+      await promise;
+
+      expect(socket.close).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- guard SimplePool subscription cleanup against CLOSING/CLOSED errors
- skip closing manual relay sockets that have already begun shutting down
- add regression tests covering pool/manual socket shutdown without warnings

## Testing
- pnpm test
- pnpm exec vitest run src/nutzap/onepage/__tests__/multiRelaySearch.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6437fd314833091b596a201fe5887