### PR TITLE
Log relay endpoints and tolerate HTML fallback responses

### DIFF
--- a/src/nutzap/relayClient.ts
+++ b/src/nutzap/relayClient.ts
@@ -840,9 +840,13 @@ export class FundstrRelayClient {
     if (!isJson) {
       const snippet = normalizeSnippet(bodyText) || '[empty response body]';
       const typeLabel = contentType || 'unknown content-type';
-      throw new Error(
-        `Unexpected response (${response.status}, ${typeLabel}): ${snippet}`
-      );
+      this.pushLog('warn', 'HTTP fallback returned non-JSON payload', {
+        status: response.status,
+        contentType: typeLabel,
+        snippet,
+        url: requestUrl,
+      });
+      return [];
     }
 
     let data: any = null;

--- a/test/requestOnceViaHttp.htmlResponse.spec.ts
+++ b/test/requestOnceViaHttp.htmlResponse.spec.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  FundstrRelayClient,
+  type FundstrRelayLogEntry,
+} from '../src/nutzap/relayClient';
+
+const originalFetch = globalThis.fetch;
+
+describe('requestOnceViaHttp', () => {
+  afterEach(() => {
+    if (originalFetch) {
+      (globalThis as any).fetch = originalFetch;
+    } else {
+      delete (globalThis as any).fetch;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('treats HTML payloads as empty results with a warning', async () => {
+    const response = new Response('<html><body>Relay</body></html>', {
+      status: 200,
+      headers: { 'Content-Type': 'text/html; charset=utf-8' },
+    });
+
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new FundstrRelayClient('wss://relay.example');
+    const logs: FundstrRelayLogEntry[] = [];
+    const stop = client.onLog(entry => {
+      logs.push(entry);
+    });
+
+    const result = await (client as any).requestOnceViaHttp(
+      [{ kinds: [1] }],
+      { url: 'https://relay.example/req' },
+    );
+
+    expect(result).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(
+      logs.some(
+        entry =>
+          entry.level === 'warn' &&
+          entry.message === 'HTTP fallback returned non-JSON payload',
+      ),
+    ).toBe(true);
+
+    stop();
+    client.clearForTests();
+  });
+});


### PR DESCRIPTION
## Summary
- log resolved relay endpoints when establishing a relay connection to confirm production builds target relay.fundstr.me
- treat successful non-JSON HTTP fallback responses as empty results and emit a warning instead of throwing
- add a unit test that stubs an HTML response to ensure the fallback path logs the warning and returns no events

## Testing
- pnpm test -- requestOnceViaHttp

------
https://chatgpt.com/codex/tasks/task_e_68d64bb657448330885ddc02545d7b78