### PR TITLE
Add asset validation step to staging deploy workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,6 +31,36 @@ jobs:
       - name: Build (Quasar SPA)
         run: pnpm quasar build -m spa
 
+      - name: Validate built asset references
+        run: |
+          set -euo pipefail
+          mapfile -t assets < <(
+            grep -oE '(src|href)="/assets/[^"]+' dist/spa/index.html |
+              sed -E 's/^(src|href)="//' |
+              sort -u || true
+          )
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "No /assets references found in dist/spa/index.html"
+            exit 0
+          fi
+
+          echo "Assets referenced in index.html:"
+          for asset in "${assets[@]}"; do
+            echo "  $asset"
+          done
+
+          missing=0
+          for asset in "${assets[@]}"; do
+            if [ ! -f "dist/spa${asset}" ]; then
+              echo "Missing asset referenced in index.html: dist/spa${asset}" >&2
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
       - name: Add SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:


### PR DESCRIPTION
## Summary
- add a validation step that parses dist/spa/index.html for /assets references
- log the referenced assets and fail the job when any file is missing to prevent invalid deploys

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d650f0e0608330aa0427188b3b966e