### PR TITLE
Align build workflow with SPA output

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Fundstr can be installed like a native app on browsers that support service work
   ```bash
   pnpm install
   pnpm dev                      # start dev server with service worker
-  pnpm dlx @quasar/cli build -m pwa
+  pnpm build                    # SPA bundle (Quasar build -m spa)
   ```
 
 Troubleshooting: Some browsers block the `beforeinstallprompt` event. If no install prompt appears, ensure pop-ups aren't blocked, confirm you're not in private/incognito mode, or install manually through the browser menu.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "type": "module",
   "scripts": {
     "dev": "quasar dev",
-    "build": "node scripts/update-featured-creators.js && quasar build -m pwa",
+    "build": "node scripts/update-featured-creators.js && quasar build -m spa",
+    "build:spa": "quasar build -m spa",
     "build:pwa": "quasar build -m pwa",
     "quasar": "quasar",
     "lint": "eslint .",

--- a/src/components/ChooseMint.vue
+++ b/src/components/ChooseMint.vue
@@ -97,7 +97,6 @@ import { mapActions, mapState, mapWritableState } from "pinia";
 import { useMintsStore } from "stores/mints";
 import { MintClass } from "stores/mints";
 import { i18n } from "../boot/i18n";
-import { title } from "process";
 
 export default defineComponent({
   name: "ChooseMint",


### PR DESCRIPTION
## Summary
- switch the default build script to run the SPA quasar build and add a build:spa alias
- refresh developer docs to reference the SPA build command
- clean up an unused import exposed by the SPA build

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d65421fef8833080a5dc8ee7de72f0