### PR TITLE
Add component tests for creator discovery and public profile pages

### DIFF
--- a/test/findCreators.profile.spec.ts
+++ b/test/findCreators.profile.spec.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createMemoryHistory, createRouter } from "vue-router";
+import { createPinia, setActivePinia } from "pinia";
+import { reactive, nextTick, defineComponent } from "vue";
+import FindCreators from "src/pages/FindCreators.vue";
+
+const queryNutzapProfile = vi.fn();
+const toHex = vi.fn((value: string) => value);
+const fallbackDiscoverRelays = vi.fn();
+
+vi.mock("@/nostr/relayClient", () => ({
+  queryNutzapProfile: (...args: any[]) => queryNutzapProfile(...args),
+  toHex: (...args: any[]) => toHex(...args),
+}));
+
+vi.mock("@/nostr/discovery", () => ({
+  fallbackDiscoverRelays: (...args: any[]) => fallbackDiscoverRelays(...args),
+}));
+
+vi.mock("components/DonateDialog.vue", () => ({
+  default: { name: "DonateDialog", template: "<div />" },
+}));
+vi.mock("components/SubscribeDialog.vue", () => ({
+  default: { name: "SubscribeDialog", template: "<div />" },
+}));
+vi.mock("components/SendTokenDialog.vue", () => ({
+  default: { name: "SendTokenDialog", template: "<div />" },
+}));
+vi.mock("components/MediaPreview.vue", () => ({
+  default: { name: "MediaPreview", template: "<div />" },
+}));
+vi.mock("components/NostrRelayErrorBanner.vue", () => ({
+  default: { name: "NostrRelayErrorBanner", template: "<div />" },
+}));
+
+const sendTokensStore = { clearSendData: vi.fn(), sendData: {}, showSendTokens: false };
+vi.mock("stores/sendTokensStore", () => ({
+  useSendTokensStore: () => sendTokensStore,
+}));
+
+const donationStore = { createDonationPreset: vi.fn() };
+vi.mock("stores/donationPresets", () => ({
+  useDonationPresetsStore: () => donationStore,
+}));
+
+let creatorsStore: any;
+let fetchTierDefinitions: ReturnType<typeof vi.fn>;
+
+vi.mock("stores/creators", () => ({
+  useCreatorsStore: () => creatorsStore,
+}));
+
+const nostrStore = {
+  pubkey: "",
+  initNdkReadOnly: vi.fn().mockResolvedValue(undefined),
+  resolvePubkey: (k: string) => k,
+  hasIdentity: true,
+};
+vi.mock("stores/nostr", () => ({
+  useNostrStore: () => nostrStore,
+}));
+
+const messengerStore = {
+  started: false,
+  startChat: vi.fn(),
+  ensureChatSubscription: vi.fn(),
+};
+vi.mock("stores/messenger", () => ({
+  useMessengerStore: () => messengerStore,
+}));
+
+vi.mock("src/js/notify", () => ({
+  notifyWarning: vi.fn(),
+}));
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock("quasar", () => {
+  const createStub = (name: string) =>
+    defineComponent({
+      name,
+      template: "<div><slot /><slot name=\"action\"></slot></div>",
+    });
+  return {
+    useQuasar: () => ({
+      dark: {
+        isActive: false,
+      },
+    }),
+    QDialog: defineComponent({
+      name: "QDialog",
+      props: { modelValue: { type: Boolean, default: false } },
+      emits: ["update:modelValue"],
+      template: `<div v-if=\"modelValue\" class=\"q-dialog\"><slot /></div>`,
+    }),
+    QCard: createStub("QCard"),
+    QCardSection: createStub("QCardSection"),
+    QCardActions: createStub("QCardActions"),
+    QSeparator: createStub("QSeparator"),
+    QBtn: defineComponent({
+      name: "QBtn",
+      props: { label: { type: String, default: "" } },
+      emits: ["click"],
+      template: `<button class=\"q-btn\" @click=\"$emit('click')\"><slot />{{ label }}</button>`,
+    }),
+    QBanner: createStub("QBanner"),
+    QSpinnerHourglass: createStub("QSpinnerHourglass"),
+  };
+});
+
+const SimpleStub = (name: string) =>
+  defineComponent({
+    name,
+    template: "<div><slot /><slot name=\"action\"></slot></div>",
+  });
+
+const QDialogStub = defineComponent({
+  name: "QDialog",
+  props: { modelValue: { type: Boolean, default: false } },
+  emits: ["update:modelValue"],
+  template: `<div v-if="modelValue" class="q-dialog"><slot /></div>`,
+});
+
+const QBtnStub = defineComponent({
+  name: "QBtn",
+  props: {
+    label: { type: String, default: "" },
+  },
+  emits: ["click"],
+  template: `<button class="q-btn" @click="$emit('click')"><slot />{{ label }}</button>`,
+});
+
+const QCardStub = SimpleStub("QCard");
+const QCardSectionStub = SimpleStub("QCardSection");
+const QCardActionsStub = SimpleStub("QCardActions");
+const QSeparatorStub = SimpleStub("QSeparator");
+const QBannerStub = SimpleStub("QBanner");
+const QSpinnerStub = SimpleStub("QSpinnerHourglass");
+
+describe("FindCreators component behaviour", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchTierDefinitions = vi.fn().mockResolvedValue(undefined);
+    creatorsStore = reactive({
+      tiersMap: reactive({}),
+      tierFetchError: false,
+      fetchTierDefinitions,
+    });
+    toHex.mockImplementation((val: string) => val);
+    fallbackDiscoverRelays.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function mountComponent(props: Record<string, any> = {}) {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: "/", component: { template: "<div />" } }],
+    });
+    return mount(FindCreators, {
+      props,
+      global: {
+        plugins: [router, pinia],
+        stubs: {
+          QDialog: QDialogStub,
+          QCard: QCardStub,
+          QCardSection: QCardSectionStub,
+          QCardActions: QCardActionsStub,
+          QSeparator: QSeparatorStub,
+          QBtn: QBtnStub,
+          QBanner: QBannerStub,
+          QSpinnerHourglass: QSpinnerStub,
+        },
+      },
+    });
+  }
+
+  it("fans out relay hints using discovery results and profile content", async () => {
+    toHex.mockImplementation((val: string) => {
+      if (val === "npub123") return "hex123";
+      throw new Error("bad");
+    });
+    queryNutzapProfile
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        tags: [
+          ["relay", "wss://tag-relay"],
+          ["relay", "wss://tag-relay"],
+        ],
+        content: JSON.stringify({
+          p2pk: "p2pk",
+          mints: ["mint1"],
+          relays: ["wss://content-relay"],
+        }),
+      });
+    fallbackDiscoverRelays.mockResolvedValue(["wss://fallback-relay"]);
+
+    const wrapper = mountComponent({ npubOrHex: "npub123" });
+    await flushPromises();
+
+    expect(queryNutzapProfile).toHaveBeenNthCalledWith(1, "hex123");
+    expect(queryNutzapProfile).toHaveBeenNthCalledWith(2, "hex123", {
+      fanout: ["wss://fallback-relay"],
+    });
+
+    expect(fetchTierDefinitions).toHaveBeenCalledWith("hex123", {
+      relayHints: expect.arrayContaining([
+        "wss://fallback-relay",
+        "wss://tag-relay",
+        "wss://content-relay",
+      ]),
+    });
+
+    const hintsArg = fetchTierDefinitions.mock.calls[0][1].relayHints;
+    expect(new Set(hintsArg)).toEqual(
+      new Set(["wss://fallback-relay", "wss://tag-relay", "wss://content-relay"]),
+    );
+    expect(wrapper.vm.loadingProfile).toBe(false);
+  });
+
+  it("stops loading when provided pubkey cannot be converted to hex", async () => {
+    toHex.mockImplementation(() => {
+      throw new Error("invalid npub");
+    });
+
+    const wrapper = mountComponent({ npubOrHex: "badnpub" });
+    await flushPromises();
+
+    expect(queryNutzapProfile).not.toHaveBeenCalled();
+    expect(fetchTierDefinitions).not.toHaveBeenCalled();
+    expect(wrapper.vm.loadingProfile).toBe(false);
+    expect(wrapper.vm.loadingTiers).toBe(false);
+  });
+
+  it("surfaces tier fetch failures and retries with relay hints", async () => {
+    toHex.mockReturnValue("hex456");
+    creatorsStore.tiersMap["hex456"] = [];
+    queryNutzapProfile.mockResolvedValue({
+      tags: [],
+      content: JSON.stringify({ relays: [] }),
+    });
+    fallbackDiscoverRelays.mockResolvedValue([]);
+
+    const wrapper = mountComponent({ npubOrHex: "npub456" });
+    await flushPromises();
+
+    creatorsStore.tierFetchError = true;
+    await nextTick();
+
+    vi.useFakeTimers();
+    fetchTierDefinitions.mockImplementationOnce(() => new Promise(() => {}));
+    await wrapper
+      .findAll("button")
+      .find((btn) => btn.text() === "Retry")
+      ?.trigger("click");
+    expect(fetchTierDefinitions).toHaveBeenLastCalledWith("hex456", {
+      relayHints: expect.any(Array),
+    });
+
+    expect(wrapper.vm.loadingTiers).toBe(true);
+    vi.advanceTimersByTime(5000);
+    expect(wrapper.vm.loadingTiers).toBe(false);
+  });
+});

--- a/test/publicCreatorProfilePage.spec.ts
+++ b/test/publicCreatorProfilePage.spec.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createMemoryHistory, createRouter } from "vue-router";
+import { createPinia, setActivePinia } from "pinia";
+import { reactive, defineComponent, nextTick } from "vue";
+import { nip19 } from "nostr-tools";
+
+const copy = vi.fn();
+const buildProfileUrl = vi.fn(() => "https://profile/url");
+
+vi.mock("components/SubscribeDialog.vue", () => ({
+  default: defineComponent({
+    name: "SubscribeDialog",
+    props: { modelValue: { type: Boolean, default: false }, tier: { type: Object, default: null } },
+    emits: ["update:modelValue", "confirm"],
+    template: `<div v-if="modelValue" class="subscribe-dialog"><slot /></div>`,
+  }),
+}));
+vi.mock("components/SetupRequiredDialog.vue", () => ({
+  default: defineComponent({
+    name: "SetupRequiredDialog",
+    props: { modelValue: { type: Boolean, default: false } },
+    emits: ["update:modelValue"],
+    template: `<div v-if="modelValue" class="setup-dialog"><slot /></div>`,
+  }),
+}));
+vi.mock("components/SubscriptionReceipt.vue", () => ({
+  default: defineComponent({ name: "SubscriptionReceipt", template: `<div class="receipt" />` }),
+}));
+vi.mock("components/PaywalledContent.vue", () => ({
+  default: defineComponent({ name: "PaywalledContent", template: `<div class="paywalled"><slot /></div>` }),
+}));
+vi.mock("components/MediaPreview.vue", () => ({
+  default: defineComponent({ name: "MediaPreview", template: `<div class="media" />` }),
+}));
+
+vi.mock("src/utils/profileUrl", () => ({
+  buildProfileUrl: (...args: any[]) => buildProfileUrl(...args),
+}));
+vi.mock("src/utils/sanitize-url", () => ({
+  isTrustedUrl: () => true,
+}));
+vi.mock("src/composables/useClipboard", () => ({
+  useClipboard: () => ({ copy }),
+}));
+
+let creatorsStore: any;
+let fetchTierDefinitions: ReturnType<typeof vi.fn>;
+const priceStore = reactive({ bitcoinPrice: 0 });
+const uiStore = { formatCurrency: vi.fn(() => "$0.00") };
+const welcomeStore = reactive({ welcomeCompleted: true });
+const nostrStore = {
+  hasIdentity: true,
+  initNdkReadOnly: vi.fn().mockResolvedValue(undefined),
+  getProfile: vi.fn().mockResolvedValue({ display_name: "Creator" }),
+  fetchFollowerCount: vi.fn().mockResolvedValue(5),
+  fetchFollowingCount: vi.fn().mockResolvedValue(3),
+};
+
+vi.mock("stores/creators", () => ({
+  useCreatorsStore: () => creatorsStore,
+}));
+vi.mock("stores/price", () => ({
+  usePriceStore: () => priceStore,
+}));
+vi.mock("stores/ui", () => ({
+  useUiStore: () => uiStore,
+}));
+vi.mock("stores/welcome", () => ({
+  useWelcomeStore: () => welcomeStore,
+}));
+vi.mock("stores/nostr", () => ({
+  useNostrStore: () => nostrStore,
+}));
+vi.mock("vue-i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+import PublicCreatorProfilePage from "src/pages/PublicCreatorProfilePage.vue";
+
+const SubscribeDialogGlobalStub = defineComponent({
+  name: "SubscribeDialog",
+  props: { modelValue: { type: Boolean, default: false } },
+  emits: ["update:modelValue"],
+  template: `<div v-if="modelValue" class="subscribe-dialog"><slot /></div>`,
+});
+
+const QBtnStub = defineComponent({
+  name: "QBtn",
+  props: {
+    label: { type: String, default: "" },
+    icon: { type: String, default: "" },
+    disable: { type: Boolean, default: false },
+    to: { type: [String, Object], default: null },
+  },
+  emits: ["click"],
+  template: `<button class="q-btn" :data-icon="icon" :disabled="disable" @click="$emit('click')"><slot />{{ label }}</button>`,
+});
+
+const SimpleStub = (name: string, extraClass = "") =>
+  defineComponent({
+    name,
+    props: { modelValue: { type: Boolean, default: false } },
+    emits: ["update:modelValue"],
+    template: `<div :class="['${extraClass}']"><slot /><slot name=\"header\"></slot><slot name=\"action\"></slot></div>`,
+  });
+
+const QDialogStub = defineComponent({
+  name: "QDialog",
+  props: { modelValue: { type: Boolean, default: false } },
+  emits: ["update:modelValue"],
+  template: `<div v-if="modelValue" class="q-dialog"><slot /></div>`,
+});
+
+const QExpansionItemStub = defineComponent({
+  name: "QExpansionItem",
+  template: `<div class="q-expansion-item"><slot name=\"header\"></slot><slot /></div>`,
+});
+
+const QBannerStub = defineComponent({
+  name: "QBanner",
+  template: `<div class="q-banner"><slot /><slot name=\"action\"></slot></div>`,
+});
+
+const QTooltipStub = defineComponent({
+  name: "QTooltip",
+  template: `<span class="q-tooltip"><slot /></span>`,
+});
+
+const QSpinnerStub = defineComponent({
+  name: "QSpinnerHourglass",
+  template: `<div class="q-spinner"></div>`,
+});
+
+describe("PublicCreatorProfilePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchTierDefinitions = vi.fn().mockImplementation(async (pubkey: string) => {
+      creatorsStore.tiersMap[pubkey] = [
+        {
+          id: "tier-1",
+          name: "Tier 1",
+          description: "Tier description",
+          benefits: ["Benefit"],
+          media: [],
+        },
+      ];
+    });
+    creatorsStore = reactive({
+      tiersMap: reactive({}),
+      tierFetchError: false,
+      fetchTierDefinitions,
+    });
+    priceStore.bitcoinPrice = 0;
+    welcomeStore.welcomeCompleted = true;
+    nostrStore.hasIdentity = true;
+    copy.mockClear();
+    buildProfileUrl.mockReturnValue("https://profile/url");
+  });
+
+  function mountPage(router: ReturnType<typeof createRouter>) {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    return mount(PublicCreatorProfilePage, {
+      global: {
+        plugins: [router, pinia],
+        mocks: {
+          $t: (key: string) => key,
+        },
+        stubs: {
+          SubscribeDialog: SubscribeDialogGlobalStub,
+          QBtn: QBtnStub,
+          QBanner: QBannerStub,
+          QDialog: QDialogStub,
+          QCard: SimpleStub("QCard"),
+          QCardSection: SimpleStub("QCardSection"),
+          QCardActions: SimpleStub("QCardActions"),
+          QExpansionItem: QExpansionItemStub,
+          QTooltip: QTooltipStub,
+          QSpinnerHourglass: QSpinnerStub,
+        },
+      },
+    });
+  }
+
+  it("opens the requested tier when tierId query param is provided", async () => {
+    const sampleHex = "a".repeat(64);
+    const sampleNpub = nip19.npubEncode(sampleHex);
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: "/creator/:npubOrHex", name: "PublicCreatorProfile", component: PublicCreatorProfilePage },
+      ],
+    });
+    router.push({ name: "PublicCreatorProfile", params: { npubOrHex: sampleNpub }, query: { tierId: "tier-1" } });
+    await router.isReady();
+
+    const wrapper = mountPage(router);
+    await flushPromises();
+    await nextTick();
+
+    expect(fetchTierDefinitions).toHaveBeenCalled();
+    expect(fetchTierDefinitions.mock.calls[0][0]).toBe(sampleHex);
+    expect(wrapper.vm.selectedTier?.id).toBe("tier-1");
+    expect(wrapper.vm.showSubscribeDialog).toBe(true);
+    expect(router.currentRoute.value.query.tierId).toBeUndefined();
+  });
+
+  it("copies the profile URL when the copy button is clicked", async () => {
+    const sampleHex = "b".repeat(64);
+    const sampleNpub = nip19.npubEncode(sampleHex);
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: "/creator/:npubOrHex", name: "PublicCreatorProfile", component: PublicCreatorProfilePage },
+      ],
+    });
+    router.push({ name: "PublicCreatorProfile", params: { npubOrHex: sampleNpub } });
+    await router.isReady();
+
+    const wrapper = mountPage(router);
+    await flushPromises();
+    await nextTick();
+
+    const copyButton = wrapper.find('[data-icon="content_copy"]');
+    expect(copyButton.exists()).toBe(true);
+    await copyButton.trigger("click");
+
+    expect(copy).toHaveBeenCalledWith("https://profile/url");
+  });
+
+  it("shows tier error banner and retries fetch when retry button is clicked", async () => {
+    const sampleHex = "c".repeat(64);
+    const sampleNpub = nip19.npubEncode(sampleHex);
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: "/creator/:npubOrHex", name: "PublicCreatorProfile", component: PublicCreatorProfilePage },
+      ],
+    });
+    router.push({ name: "PublicCreatorProfile", params: { npubOrHex: sampleNpub } });
+    await router.isReady();
+
+    const wrapper = mountPage(router);
+    await flushPromises();
+    await nextTick();
+
+    creatorsStore.tierFetchError = true;
+    await nextTick();
+
+    const banner = wrapper.find(".q-banner");
+    expect(banner.exists()).toBe(true);
+
+    await wrapper
+      .findAll("button")
+      .find((btn) => btn.text() === "Retry")
+      ?.trigger("click");
+
+    expect(fetchTierDefinitions).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add FindCreators component tests covering relay discovery fan-out, invalid npub handling, and retry timeout behaviour
- add PublicCreatorProfilePage tests to auto-open tiers from query params, verify copy link actions, and surface tier load failures

## Testing
- pnpm exec vitest run test/findCreators.profile.spec.ts test/publicCreatorProfilePage.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7a19c8c548330b26d033aecfa62d9