### PR TITLE
Create Nutzap diagnostics workspace

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -137,6 +137,14 @@
           <q-item-label>Nutzap Profile</q-item-label>
         </q-item-section>
       </q-item>
+      <q-item v-if="!isGuest" clickable @click="gotoNutzapDiagnostics">
+        <q-item-section avatar>
+          <q-icon name="tune" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>Advanced diagnostics</q-item-label>
+        </q-item-section>
+      </q-item>
       <q-item v-if="!isGuest" clickable @click="gotoChats">
         <q-item-section avatar>
           <q-icon name="chat" />
@@ -230,6 +238,7 @@ const gotoMyProfile = () => goto("/my-profile");
 const gotoBuckets = () => goto("/buckets");
 const gotoSubscriptions = () => goto("/subscriptions");
 const gotoNutzapProfile = () => goto("/nutzap-profile");
+const gotoNutzapDiagnostics = () => goto("/nutzap-tools");
 const gotoChats = () => goto("/nostr-messenger");
 const gotoNostrLogin = () => goto("/nostr-login");
 const gotoTerms = () => goto("/terms");

--- a/src/pages/NutzapDiagnosticsPage.vue
+++ b/src/pages/NutzapDiagnosticsPage.vue
@@ -1,0 +1,67 @@
+<template>
+  <q-page class="nutzap-diagnostics-page bg-surface-1 q-pa-lg">
+    <div class="page-header q-mb-lg">
+      <div class="text-h5 text-1">Advanced diagnostics</div>
+      <div class="text-body2 text-2">
+        Deep-dive tools for isolating Nutzap relay issues and validating browser capabilities.
+      </div>
+    </div>
+
+    <div class="diagnostic-grid">
+      <q-card class="diagnostic-card">
+        <q-card-section class="q-gutter-xs">
+          <div class="text-h6">Legacy Explorer</div>
+          <div class="text-caption text-2">
+            Issue single-relay REQ subscriptions and inspect EOSE vs timeout behaviour.
+          </div>
+        </q-card-section>
+        <q-separator />
+        <q-card-section>
+          <NutzapLegacyExplorer />
+        </q-card-section>
+      </q-card>
+
+      <q-card class="diagnostic-card">
+        <q-card-section class="q-gutter-xs">
+          <div class="text-h6">Client Self-tests</div>
+          <div class="text-caption text-2">
+            Verify browser capabilities required for Nutzap authoring without hitting the network.
+          </div>
+        </q-card-section>
+        <q-separator />
+        <q-card-section>
+          <NutzapSelfTests />
+        </q-card-section>
+      </q-card>
+    </div>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import NutzapLegacyExplorer from 'src/nutzap/onepage/NutzapLegacyExplorer.vue';
+import NutzapSelfTests from 'src/nutzap/onepage/NutzapSelfTests.vue';
+</script>
+
+<style scoped>
+.nutzap-diagnostics-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.diagnostic-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.diagnostic-card {
+  height: 100%;
+}
+</style>

--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -386,32 +386,18 @@
         </q-tab-panel>
 
         <q-tab-panel name="diagnostics" class="profile-panel">
-          <div class="panel-grid">
-            <q-card class="grid-card diagnostic-card">
-              <q-card-section class="q-gutter-xs">
-                <div class="text-h6">Legacy Explorer</div>
-                <div class="text-caption text-2">
-                  Issue single-relay REQ subscriptions and inspect EOSE vs timeout behaviour.
+          <div class="diagnostics-banner-wrapper">
+            <q-banner dense rounded class="diagnostics-banner bg-surface-2 text-2">
+              <div class="row items-center justify-between q-gutter-md no-wrap">
+                <div class="column q-gutter-xs">
+                  <div class="text-body1 text-1">Need deeper troubleshooting?</div>
+                  <div class="text-caption text-2">
+                    Jump to the dedicated diagnostics workspace for relay inspectors and self-tests.
+                  </div>
                 </div>
-              </q-card-section>
-              <q-separator />
-              <q-card-section>
-                <NutzapLegacyExplorer />
-              </q-card-section>
-            </q-card>
-
-            <q-card class="grid-card diagnostic-card">
-              <q-card-section class="q-gutter-xs">
-                <div class="text-h6">Client Self-tests</div>
-                <div class="text-caption text-2">
-                  Verify browser capabilities required for Nutzap authoring without hitting the network.
-                </div>
-              </q-card-section>
-              <q-separator />
-              <q-card-section>
-                <NutzapSelfTests />
-              </q-card-section>
-            </q-card>
+                <q-btn color="primary" label="Open tools" to="/nutzap-tools" />
+              </div>
+            </q-banner>
           </div>
         </q-tab-panel>
       </q-tab-panels>
@@ -427,8 +413,6 @@ import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { getPublicKey as getSecpPublicKey, utils as secpUtils } from '@noble/secp256k1';
 import RelayStatusIndicator from 'src/nutzap/RelayStatusIndicator.vue';
 import NutzapExplorerPanel from 'src/nutzap/onepage/NutzapExplorerPanel.vue';
-import NutzapLegacyExplorer from 'src/nutzap/onepage/NutzapLegacyExplorer.vue';
-import NutzapSelfTests from 'src/nutzap/onepage/NutzapSelfTests.vue';
 import TierComposer from './nutzap-profile/TierComposer.vue';
 import { notifyError, notifySuccess, notifyWarning } from 'src/js/notify';
 import type { Tier } from 'src/nutzap/types';
@@ -1641,6 +1625,14 @@ onBeforeUnmount(() => {
 
 .grid-card {
   height: 100%;
+}
+
+.diagnostics-banner-wrapper {
+  padding: 16px;
+}
+
+.diagnostics-banner {
+  border: 1px solid var(--surface-contrast-border);
 }
 
 .relay-card,

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -79,6 +79,17 @@ const routes = [
     ],
   },
   {
+    path: "/nutzap-tools",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      {
+        path: "",
+        name: "NutzapDiagnostics",
+        component: () => import("src/pages/NutzapDiagnosticsPage.vue"),
+      },
+    ],
+  },
+  {
     path: "/buckets",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [


### PR DESCRIPTION
## Summary
- add a dedicated Nutzap diagnostics page consolidating the legacy explorer and self-tests
- register the new page on /nutzap-tools and expose it through the main navigation drawer
- replace the profile diagnostics tab content with a banner linking to the standalone tools

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7b76b85808330bd2b9c5b242198e8