### PR TITLE
Fix tiers readiness declarations order in Nutzap profile page

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -1332,6 +1332,13 @@ const tierKindLabel = computed(() =>
   tierKind.value === 30019 ? 'Canonical (30019)' : 'Legacy (30000)'
 );
 
+const tierValidationResults = ref<TierFieldErrors[]>([]);
+const tiersHaveErrors = computed(() =>
+  tierValidationResults.value.some(result => hasTierErrors(result))
+);
+
+const tiersReady = computed(() => tiers.value.length > 0 && !tiersHaveErrors.value);
+
 watch(
   identityBasicsComplete,
   complete => {
@@ -1528,13 +1535,6 @@ const tierFrequencyOptions = computed(() =>
           : 'Yearly',
   }))
 );
-
-const tierValidationResults = ref<TierFieldErrors[]>([]);
-const tiersHaveErrors = computed(() =>
-  tierValidationResults.value.some(result => hasTierErrors(result))
-);
-
-const tiersReady = computed(() => tiers.value.length > 0 && !tiersHaveErrors.value);
 
 const authorKeyReady = computed(() => authorInput.value.trim().length > 0);
 


### PR DESCRIPTION
## Summary
- move the tier validation state/computed declarations above the watcher that consumes them to avoid the runtime ReferenceError

## Testing
- pnpm run build:pwa

------
https://chatgpt.com/codex/tasks/task_e_68d9015962e48330a60a81918274c075