### PR TITLE
Revamp Nutzap tier composer UX

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -612,6 +612,7 @@
                   <TierComposer
                     v-model:tiers="tiers"
                     :frequency-options="tierFrequencyOptions"
+                    :show-errors="showTierValidation"
                     @validation-changed="handleTierValidation"
                   />
                 </div>
@@ -1328,11 +1329,22 @@ const tierKindLabel = computed(() =>
 );
 
 const tierValidationResults = ref<TierFieldErrors[]>([]);
+const showTierValidation = ref(false);
 const tiersHaveErrors = computed(() =>
   tierValidationResults.value.some(result => hasTierErrors(result))
 );
 
 const tiersReady = computed(() => tiers.value.length > 0 && !tiersHaveErrors.value);
+
+watch(
+  tiersHaveErrors,
+  hasErrors => {
+    if (!hasErrors) {
+      showTierValidation.value = false;
+    }
+  },
+  { immediate: true }
+);
 
 watch(
   optionalMetadataComplete,
@@ -1899,6 +1911,7 @@ async function publishTiers() {
     return;
   }
 
+  showTierValidation.value = true;
   if (tiers.value.length === 0) {
     notifyError('Add at least one tier before publishing.');
     return;
@@ -1907,6 +1920,8 @@ async function publishTiers() {
     notifyError('Fix tier validation errors before publishing tiers.');
     return;
   }
+
+  showTierValidation.value = false;
 
   publishingTiers.value = true;
   try {

--- a/src/pages/nutzap-profile/TierComposer.vue
+++ b/src/pages/nutzap-profile/TierComposer.vue
@@ -6,6 +6,25 @@
     </div>
 
     <div v-if="entries.length" class="column q-gutter-md">
+      <div class="tier-composer__summary bg-surface-2 q-pa-md q-gutter-sm column">
+        <div class="text-caption text-2 text-uppercase">Quick preview</div>
+        <div class="column q-gutter-xs">
+          <div
+            v-for="(summary, index) in tierSummaries"
+            :key="summary.id"
+            :class="['tier-composer__summary-row row items-center justify-between', { 'has-error': cardHasVisibleErrors(index) }]"
+          >
+            <div class="column">
+              <div class="text-body2 text-1 text-weight-medium">
+                Tier {{ index + 1 }} — {{ summary.title }}
+              </div>
+              <div class="text-caption text-2">{{ summary.caption }}</div>
+            </div>
+            <div class="text-body2 text-1 tier-composer__summary-price">{{ summary.priceLabel }}</div>
+          </div>
+        </div>
+      </div>
+
       <q-card v-for="(tier, index) in entries" :key="tier.id" class="tier-composer__card">
         <q-card-section class="row items-center justify-between">
           <div class="text-subtitle2 text-1">
@@ -13,7 +32,7 @@
             <span v-if="tier.title" class="text-weight-medium">— {{ tier.title }}</span>
           </div>
           <div class="row items-center q-gutter-xs">
-            <q-chip v-if="cardHasErrors(index)" color="negative" text-color="white" dense>
+            <q-chip v-if="cardHasVisibleErrors(index)" color="negative" text-color="white" dense>
               Fix errors
             </q-chip>
             <q-btn dense flat round icon="delete" color="negative" @click="removeTier(index)" />
@@ -26,8 +45,10 @@
             label="Title"
             dense
             filled
-            :error="!!validationAt(index).title"
-            :error-message="validationAt(index).title"
+            @update:model-value="markTouched(tier.id, 'title')"
+            @blur="markTouched(tier.id, 'title')"
+            :error="shouldShowFieldError(index, 'title')"
+            :error-message="shouldShowFieldError(index, 'title') ? validationAt(index).title : ''"
           />
           <div class="row q-col-gutter-md">
             <div class="col-12 col-sm-6">
@@ -38,8 +59,10 @@
                 dense
                 filled
                 min="0"
-                :error="!!validationAt(index).price"
-                :error-message="validationAt(index).price"
+                @update:model-value="markTouched(tier.id, 'price')"
+                @blur="markTouched(tier.id, 'price')"
+                :error="shouldShowFieldError(index, 'price')"
+                :error-message="shouldShowFieldError(index, 'price') ? validationAt(index).price : ''"
               />
             </div>
             <div class="col-12 col-sm-6">
@@ -51,46 +74,84 @@
                 label="Frequency"
                 dense
                 filled
-                :error="!!validationAt(index).frequency"
-                :error-message="validationAt(index).frequency"
+                @update:model-value="markTouched(tier.id, 'frequency')"
+                :error="shouldShowFieldError(index, 'frequency')"
+                :error-message="shouldShowFieldError(index, 'frequency') ? validationAt(index).frequency : ''"
               />
             </div>
           </div>
-          <q-input
-            v-model="tier.description"
-            type="textarea"
-            label="Description"
-            dense
-            filled
-            autogrow
-          />
-          <div class="column q-gutter-sm">
-            <div class="row items-center justify-between">
-              <div class="text-body2 text-2">Media</div>
-              <q-btn dense flat color="primary" icon="add" label="Add Media" @click="addMedia(index)" />
-            </div>
-            <div v-if="tier.media.length" class="column q-gutter-sm">
-              <div
-                v-for="(mediaUrl, mediaIndex) in tier.media"
-                :key="`${tier.id}-media-${mediaIndex}`"
-                class="row items-center q-gutter-sm"
+
+          <div class="tier-composer__presets column q-gutter-xs">
+            <div class="text-caption text-2">Quick templates</div>
+            <div class="row wrap items-center q-gutter-xs">
+              <q-chip
+                v-for="preset in tierPresets"
+                :key="preset.label"
+                clickable
+                dense
+                color="primary"
+                text-color="white"
+                outline
+                @click="applyPreset(index, preset)"
               >
-                <div class="col">
-                  <q-input
-                    v-model="tier.media[mediaIndex]"
-                    label="Media URL"
-                    dense
-                    filled
-                    :error="!!mediaError(index, mediaIndex)"
-                    :error-message="mediaError(index, mediaIndex) || ''"
-                  />
+                {{ preset.label }}
+              </q-chip>
+            </div>
+          </div>
+
+          <div class="tier-optional column q-gutter-sm">
+            <q-btn
+              flat
+              dense
+              class="tier-optional__toggle"
+              :icon="isOptionalOpen(tier.id) ? 'expand_less' : 'expand_more'"
+              :label="isOptionalOpen(tier.id) ? 'Hide optional details' : 'Add optional details'"
+              @click="toggleOptional(tier.id)"
+            />
+            <q-slide-transition>
+              <div v-show="isOptionalOpen(tier.id)" class="column q-gutter-md">
+                <q-input
+                  v-model="tier.description"
+                  type="textarea"
+                  label="Description (optional)"
+                  dense
+                  filled
+                  autogrow
+                  @update:model-value="markTouched(tier.id, 'description')"
+                  @blur="markTouched(tier.id, 'description')"
+                />
+                <div class="column q-gutter-sm">
+                  <div class="row items-center justify-between">
+                    <div class="text-body2 text-2">Media (optional)</div>
+                    <q-btn dense flat color="primary" icon="add" label="Add Media" @click="addMedia(index)" />
+                  </div>
+                  <div v-if="tier.media.length" class="column q-gutter-sm">
+                    <div
+                      v-for="(mediaUrl, mediaIndex) in tier.media"
+                      :key="`${tier.id}-media-${mediaIndex}`"
+                      class="row items-center q-gutter-sm"
+                    >
+                      <div class="col">
+                        <q-input
+                          v-model="tier.media[mediaIndex]"
+                          label="Media URL"
+                          dense
+                          filled
+                          @update:model-value="markTouched(tier.id, 'media', mediaIndex)"
+                          @blur="markTouched(tier.id, 'media', mediaIndex)"
+                          :error="shouldShowMediaError(index, mediaIndex)"
+                          :error-message="shouldShowMediaError(index, mediaIndex) ? mediaError(index, mediaIndex) || '' : ''"
+                        />
+                      </div>
+                      <q-btn dense flat round icon="delete" color="negative" @click="removeMedia(index, mediaIndex)" />
+                    </div>
+                  </div>
+                  <div v-else class="text-caption text-2">
+                    No media added. Click "Add Media" to attach optional links.
+                  </div>
                 </div>
-                <q-btn dense flat round icon="delete" color="negative" @click="removeMedia(index, mediaIndex)" />
               </div>
-            </div>
-            <div v-else class="text-caption text-2">
-              No media added. Click "Add Media" to attach optional links.
-            </div>
+            </q-slide-transition>
           </div>
         </q-card-section>
       </q-card>
@@ -102,7 +163,7 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref, watch } from 'vue';
+import { computed, nextTick, reactive, ref, watch } from 'vue';
 import { v4 as uuidv4 } from 'uuid';
 import type { Tier } from 'src/nutzap/types';
 import {
@@ -118,6 +179,7 @@ import {
 const props = defineProps<{
   tiers: Tier[];
   frequencyOptions: { value: Tier['frequency']; label: string }[];
+  showErrors?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -125,10 +187,58 @@ const emit = defineEmits<{
   (e: 'validation-changed', errors: TierFieldErrors[]): void;
 }>();
 
+type TierTouchedState = {
+  title: boolean;
+  price: boolean;
+  frequency: boolean;
+  description: boolean;
+  media: boolean[];
+};
+
+type TierPreset = {
+  label: string;
+  title: string;
+  price: string;
+  frequency: Tier['frequency'];
+};
+
 const entries = ref<TierDraft[]>([]);
 const validations = ref<TierFieldErrors[]>([]);
+const touched = reactive<Record<string, TierTouchedState>>({});
+const optionalOpen = reactive<Record<string, boolean>>({});
 let syncingFromProps = false;
 let skipNextPropSync = false;
+
+const tierPresets: TierPreset[] = [
+  { label: 'Supporter • 1k sats / monthly', title: 'Supporter', price: '1000', frequency: 'monthly' },
+  { label: 'Backer • 5k sats / monthly', title: 'Backer', price: '5000', frequency: 'monthly' },
+  { label: 'Believer • 10k sats / yearly', title: 'Believer', price: '10000', frequency: 'yearly' },
+  { label: 'Tip jar • 500 sats one-time', title: 'Tip jar', price: '500', frequency: 'one_time' },
+];
+
+const frequencyLabelMap = computed(() => {
+  const map: Partial<Record<Tier['frequency'], string>> = {};
+  for (const option of props.frequencyOptions) {
+    map[option.value] = option.label;
+  }
+  return map;
+});
+
+const tierSummaries = computed(() =>
+  entries.value.map((entry, index) => {
+    const priceNumber = Number(entry.price);
+    const priceValid = Number.isFinite(priceNumber) && priceNumber > 0;
+    const priceLabel = priceValid ? `${new Intl.NumberFormat().format(priceNumber)} sats` : 'Set a price';
+    const frequencyLabel = frequencyLabelMap.value[entry.frequency] ?? entry.frequency;
+    const title = entry.title.trim() || `Untitled tier #${index + 1}`;
+    return {
+      id: entry.id,
+      title,
+      caption: `${priceLabel} • ${frequencyLabel}`,
+      priceLabel,
+    };
+  })
+);
 
 function cloneErrors(results: TierFieldErrors[]): TierFieldErrors[] {
   return results.map(result => ({
@@ -145,6 +255,35 @@ function emitValidation(notifyParent = true) {
   }
 }
 
+function syncAncillaryState(drafts: TierDraft[]) {
+  const ids = drafts.map(draft => draft.id);
+  for (const existingId of Object.keys(touched)) {
+    if (!ids.includes(existingId)) {
+      delete touched[existingId];
+      delete optionalOpen[existingId];
+    }
+  }
+
+  for (const draft of drafts) {
+    const existing = touched[draft.id];
+    const normalizedMedia = draft.media.map((url, mediaIndex) => {
+      const fromExisting = existing?.media?.[mediaIndex];
+      return fromExisting ?? !!url.trim();
+    });
+    touched[draft.id] = {
+      title: existing?.title ?? !!draft.title.trim(),
+      price: existing?.price ?? false,
+      frequency: existing?.frequency ?? false,
+      description: existing?.description ?? !!draft.description.trim(),
+      media: normalizedMedia,
+    };
+
+    if (!(draft.id in optionalOpen)) {
+      optionalOpen[draft.id] = !!draft.description.trim() || draft.media.length > 0;
+    }
+  }
+}
+
 watch(
   () => props.tiers,
   tiers => {
@@ -155,6 +294,7 @@ watch(
     }
     syncingFromProps = true;
     entries.value = tiers.map(tier => tierToDraft(tier));
+    syncAncillaryState(entries.value);
     // ensure empty composer still allows adding media rows later
     if (!entries.value.length) {
       validations.value = [];
@@ -175,6 +315,7 @@ watch(
     if (syncingFromProps) {
       return;
     }
+    syncAncillaryState(entries.value);
     const sanitized = entries.value.map(entry => draftToTier(entry));
     skipNextPropSync = true;
     emit('update:tiers', sanitized);
@@ -183,8 +324,16 @@ watch(
   { deep: true }
 );
 
-function cardHasErrors(index: number) {
-  return hasTierErrors(validationAt(index));
+function ensureTouchedEntry(id: string) {
+  if (!(id in touched)) {
+    touched[id] = {
+      title: false,
+      price: false,
+      frequency: false,
+      description: false,
+      media: [],
+    };
+  }
 }
 
 function validationAt(index: number): TierFieldErrors {
@@ -194,6 +343,88 @@ function validationAt(index: number): TierFieldErrors {
 function mediaError(index: number, mediaIndex: number): string | null {
   const validation = validationAt(index);
   return validation.media?.[mediaIndex] ?? null;
+}
+
+function markTouched(id: string, field: keyof TierTouchedState, mediaIndex?: number) {
+  ensureTouchedEntry(id);
+  const state = touched[id];
+  if (field === 'media') {
+    const index = typeof mediaIndex === 'number' ? mediaIndex : 0;
+    state.media[index] = true;
+  } else {
+    state[field] = true;
+  }
+}
+
+function isFieldTouched(id: string, field: keyof TierTouchedState, mediaIndex?: number) {
+  const state = touched[id];
+  if (!state) {
+    return false;
+  }
+  if (props.showErrors) {
+    return true;
+  }
+  if (field === 'media') {
+    const index = typeof mediaIndex === 'number' ? mediaIndex : 0;
+    return state.media[index] ?? false;
+  }
+  return state[field];
+}
+
+function shouldShowFieldError(index: number, field: Exclude<keyof TierFieldErrors, 'media'>) {
+  const errors = validationAt(index);
+  const tier = entries.value[index];
+  if (!tier) {
+    return false;
+  }
+  const hasError = Boolean(errors[field]);
+  if (!hasError) {
+    return false;
+  }
+  return isFieldTouched(tier.id, field as keyof TierTouchedState);
+}
+
+function shouldShowMediaError(index: number, mediaIndex: number) {
+  const tier = entries.value[index];
+  if (!tier) {
+    return false;
+  }
+  const hasError = Boolean(mediaError(index, mediaIndex));
+  if (!hasError) {
+    return false;
+  }
+  return isFieldTouched(tier.id, 'media', mediaIndex);
+}
+
+function cardHasVisibleErrors(index: number) {
+  const errors = validationAt(index);
+  if (!hasTierErrors(errors)) {
+    return false;
+  }
+  const tier = entries.value[index];
+  if (!tier) {
+    return false;
+  }
+  if (props.showErrors) {
+    return true;
+  }
+  const state = touched[tier.id];
+  if (!state) {
+    return false;
+  }
+  if (errors.title && state.title) {
+    return true;
+  }
+  if (errors.price && state.price) {
+    return true;
+  }
+  if (errors.frequency && state.frequency) {
+    return true;
+  }
+  if (Array.isArray(errors.media)) {
+    return errors.media.some((entry, mediaIndex) => entry && state.media[mediaIndex]);
+  }
+  return false;
 }
 
 function addTier() {
@@ -212,6 +443,8 @@ function addMedia(index: number) {
   const draft = { ...next[index], media: [...next[index].media, ''] };
   next.splice(index, 1, draft);
   entries.value = next;
+  ensureTouchedEntry(draft.id);
+  touched[draft.id].media[draft.media.length - 1] = false;
 }
 
 function removeMedia(index: number, mediaIndex: number) {
@@ -221,11 +454,59 @@ function removeMedia(index: number, mediaIndex: number) {
   const draft = { ...next[index], media };
   next.splice(index, 1, draft);
   entries.value = next;
+  ensureTouchedEntry(draft.id);
+  touched[draft.id].media.splice(mediaIndex, 1);
+}
+
+function toggleOptional(id: string) {
+  optionalOpen[id] = !optionalOpen[id];
+}
+
+function isOptionalOpen(id: string) {
+  return optionalOpen[id] ?? false;
+}
+
+function applyPreset(index: number, preset: TierPreset) {
+  const next = [...entries.value];
+  const draft = {
+    ...next[index],
+    title: preset.title,
+    price: preset.price,
+    frequency: preset.frequency,
+  };
+  next.splice(index, 1, draft);
+  entries.value = next;
+  markTouched(draft.id, 'title');
+  markTouched(draft.id, 'price');
+  markTouched(draft.id, 'frequency');
 }
 </script>
 
 <style scoped>
 .tier-composer__card {
   border: 1px solid var(--surface-contrast-border, rgba(255, 255, 255, 0.08));
+}
+
+.tier-composer__summary {
+  border: 1px solid var(--surface-contrast-border, rgba(255, 255, 255, 0.08));
+  border-radius: 12px;
+}
+
+.tier-composer__summary-row {
+  border-radius: 8px;
+  padding: 8px 12px;
+  background-color: rgba(255, 255, 255, 0.02);
+}
+
+.tier-composer__summary-row.has-error {
+  border: 1px solid var(--q-negative, #f44336);
+}
+
+.tier-composer__summary-price {
+  white-space: nowrap;
+}
+
+.tier-optional__toggle {
+  align-self: flex-start;
 }
 </style>

--- a/src/pages/nutzap-profile/tierComposerUtils.ts
+++ b/src/pages/nutzap-profile/tierComposerUtils.ts
@@ -22,7 +22,7 @@ export function createEmptyDraft(overrides: Partial<TierDraft> = {}): TierDraft 
   return {
     id: overrides.id ?? '',
     title: overrides.title ?? '',
-    price: overrides.price ?? '',
+    price: overrides.price ?? '1000',
     frequency: overrides.frequency ?? 'monthly',
     description: overrides.description ?? '',
     media: overrides.media ? [...overrides.media] : [],
@@ -80,7 +80,7 @@ export function validateTierDraft(draft: TierDraft): TierFieldErrors {
     const mediaErrors = draft.media.map(url => {
       const trimmed = url.trim();
       if (!trimmed) {
-        return 'Enter a URL or remove the empty media row.';
+        return null;
       }
       if (!/^https?:\/\//i.test(trimmed)) {
         return 'Media URLs must start with http:// or https://';


### PR DESCRIPTION
## Summary
- redesign the Nutzap tier composer with a quick preview, optional detail drawer, and preset chips for common pricing setups
- delay inline validation until fields are touched or a publish attempt is made and surface publish attempts via the parent page
- relax tier validation defaults to allow optional media/description, seed new tiers with a default price, and keep JSON previews in sync

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d90e59a44c83308c4fe2005073b744