### PR TITLE
Ensure Fundstr relay is prioritized for find creators

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -307,8 +307,9 @@
 
     <script type="module" defer>
       import { filterHealthyRelays } from "./relayHealth.js";
+      const FUNDSTR_RELAY = "wss://relay.fundstr.me";
       const DEFAULT_RELAYS = [
-        "wss://relay.fundstr.me",
+        FUNDSTR_RELAY,
         "wss://relay.damus.io",
         "wss://relay.primal.net",
         "wss://relay.snort.social",
@@ -342,7 +343,11 @@
       async function refreshRelays() {
         try {
           const healthy = await filterHealthyRelays(DEFAULT_RELAYS);
-          RELAYS = healthy;
+          const prioritized = [
+            FUNDSTR_RELAY,
+            ...healthy.filter((relay) => relay !== FUNDSTR_RELAY),
+          ];
+          RELAYS = prioritized;
           relayFailureCount = 0;
           document.getElementById("relayList").textContent = RELAYS.join(", ");
           statusMessageElement.classList.add("hidden");

--- a/public/relayHealth.js
+++ b/public/relayHealth.js
@@ -1,4 +1,6 @@
+const FUNDSTR_RELAY = "wss://relay.fundstr.me";
 const FREE_RELAYS = [
+  FUNDSTR_RELAY,
   "wss://relay.damus.io",
   "wss://relay.primal.net",
   "wss://relayable.org",


### PR DESCRIPTION
## Summary
- keep the Fundstr relay constant alongside the default relay list
- always reinsert the Fundstr relay at the top of the refreshed relay list display
- include the Fundstr relay in the fallback relay list used by the health checker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da1dc2ecdc83308c2fb8402303db23