### PR TITLE
Refine find creators layout

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -15,14 +15,20 @@
         color: #2d3748; /* Tailwind gray-800 */
       }
       .container {
-        max-width: 900px;
-        margin: 0 auto;
-        padding: 1rem;
+        width: 100%;
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: clamp(2rem, 4vw, 3rem);
+        padding: clamp(1.5rem, 4vw, 3rem) clamp(1rem, 4vw, 2.5rem);
+        box-sizing: border-box;
       }
       .search-container,
       .featured-creators-container {
-        margin: 2rem auto;
-        padding: 2rem;
+        width: min(100%, clamp(320px, 85vw, 1100px));
+        margin: 0 auto;
+        padding: clamp(1.5rem, 4vw, 2.5rem);
         background-color: white;
         border-radius: 0.75rem; /* Tailwind rounded-xl */
         box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),


### PR DESCRIPTION
## Summary
- update the standalone find-creators page shell to use a full-width, viewport-height layout
- clamp the search and featured sections with responsive padding so they adapt without a fixed wrapper

## Testing
- pnpm dev -- --host 0.0.0.0 --port 5173 (manually opened /find-creators.html and /find-creators)


------
https://chatgpt.com/codex/tasks/task_e_68da1f9d1fd48330a5351e527a521020