### PR TITLE
Ensure Fundstr relay stays prioritized and warn when unreachable

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -172,6 +172,15 @@
         padding: 1.5rem;
         font-style: italic;
       }
+      .relay-warning {
+        margin-top: 1rem;
+        padding: 0.75rem 1rem;
+        background-color: #fef3c7;
+        border: 1px solid #f6ad55;
+        border-radius: 0.5rem;
+        color: #b7791f;
+        font-weight: 600;
+      }
       .retry-button {
         margin: 0 auto;
         margin-top: -1rem;
@@ -308,11 +317,12 @@
         <p id="featuredStatusMessage" class="status-message hidden"></p>
       </div>
 
+      <p id="relayWarning" class="relay-warning hidden"></p>
       <div class="relay-info">Connecting to: <span id="relayList"></span></div>
     </div>
 
     <script type="module" defer>
-      import { filterHealthyRelays } from "./relayHealth.js";
+      import { filterHealthyRelays, pingRelay } from "./relayHealth.js";
       const FUNDSTR_RELAY = "wss://relay.fundstr.me";
       const DEFAULT_RELAYS = [
         FUNDSTR_RELAY,
@@ -323,6 +333,7 @@
         "wss://relay.nostr.band",
       ];
       const statusMessageElement = document.getElementById("statusMessage");
+      const relayWarningElement = document.getElementById("relayWarning");
       const retryButtonElement = document.getElementById("retryButton");
       // --- Nostr Tools ---
       if (!window.NostrTools) {
@@ -349,6 +360,7 @@
       async function refreshRelays() {
         try {
           const healthy = await filterHealthyRelays(DEFAULT_RELAYS);
+          const fundstrReachable = await pingRelay(FUNDSTR_RELAY);
           const prioritized = [
             FUNDSTR_RELAY,
             ...healthy.filter((relay) => relay !== FUNDSTR_RELAY),
@@ -357,6 +369,14 @@
           relayFailureCount = 0;
           document.getElementById("relayList").textContent = RELAYS.join(", ");
           statusMessageElement.classList.add("hidden");
+          if (fundstrReachable) {
+            relayWarningElement.classList.add("hidden");
+            relayWarningElement.textContent = "";
+          } else {
+            relayWarningElement.textContent =
+              "Fundstr relay is temporarily unreachable. We'll keep retrying while temporarily using backups.";
+            relayWarningElement.classList.remove("hidden");
+          }
         } catch {
           relayFailureCount++;
           if (relayFailureCount >= 3) {
@@ -367,6 +387,8 @@
             statusMessageElement.textContent =
               "Network error: could not reach relays.";
             statusMessageElement.classList.remove("hidden");
+            relayWarningElement.classList.add("hidden");
+            relayWarningElement.textContent = "";
             clearInterval(relayInterval);
           }
         }

--- a/public/relayHealth.js
+++ b/public/relayHealth.js
@@ -1,10 +1,23 @@
 const FUNDSTR_RELAY = "wss://relay.fundstr.me";
-const FREE_RELAYS = [
-  FUNDSTR_RELAY,
+const BASE_FREE_RELAYS = [
   "wss://relay.damus.io",
   "wss://relay.primal.net",
   "wss://relayable.org",
 ];
+
+function ensureFundstr(relays) {
+  const seen = new Set();
+  const ordered = [];
+  for (const url of [FUNDSTR_RELAY, ...relays]) {
+    if (url && !seen.has(url)) {
+      ordered.push(url);
+      seen.add(url);
+    }
+  }
+  return ordered;
+}
+
+const FREE_RELAYS = ensureFundstr(BASE_FREE_RELAYS);
 
 // keep track of relays that have already produced a constructor error so we only
 // emit a single console message per relay. This keeps startup logs readable when
@@ -40,7 +53,8 @@ export async function pingRelay(url) {
   const now = Date.now();
   if (cached && now - cached.ts < CACHE_TTL_MS) return cached.ok;
 
-  const attemptOnce = () =>
+  const isFundstr = url === FUNDSTR_RELAY;
+  const attemptOnce = (timeoutMs) =>
     new Promise((resolve) => {
       let settled = false;
       let ws;
@@ -66,7 +80,7 @@ export async function pingRelay(url) {
           }
           resolve(false);
         }
-      }, 1000);
+      }, timeoutMs);
       ws.onopen = () => {
         if (!settled) {
           settled = true;
@@ -96,16 +110,18 @@ export async function pingRelay(url) {
       };
     });
 
-  const maxAttempts = 3;
-  let delay = 1000;
+  const maxAttempts = isFundstr ? 5 : 3;
+  let delay = isFundstr ? 1500 : 1000;
+  let timeoutMs = isFundstr ? 3000 : 1200;
   for (let i = 0; i < maxAttempts; i++) {
-    if (await attemptOnce()) {
+    if (await attemptOnce(timeoutMs)) {
       pingCache.set(url, { ts: now, ok: true });
       return true;
     }
     if (i < maxAttempts - 1) {
       await new Promise((r) => setTimeout(r, delay));
       delay = Math.min(delay * 2, 32000);
+      timeoutMs = Math.min(timeoutMs + (isFundstr ? 500 : 250), 5000);
     }
   }
 
@@ -134,16 +150,22 @@ export async function filterHealthyRelays(relays) {
     const batchHealthy = results.filter((u) => !!u);
     healthy.push(...batchHealthy);
   }
+  const healthyWithFundstr = ensureFundstr(healthy);
+
   if (healthy.length === 0) {
     if (!allFailedWarned) {
       console.warn("No reachable relays; falling back to FREE_RELAYS");
       allFailedWarned = true;
     }
-    filterCache.set(key, { ts: now, res: FREE_RELAYS });
-    return FREE_RELAYS;
+    const fallback = ensureFundstr(FREE_RELAYS);
+    filterCache.set(key, { ts: now, res: fallback });
+    return fallback;
   }
 
-  const res = healthy.length >= 2 ? healthy : FREE_RELAYS;
+  const res =
+    healthy.length >= 2 || healthy.includes(FUNDSTR_RELAY)
+      ? healthyWithFundstr
+      : ensureFundstr(FREE_RELAYS);
   filterCache.set(key, { ts: now, res });
   return res;
 }


### PR DESCRIPTION
## Summary
- ensure the relay health helper always includes the Fundstr relay in fallbacks and gives it extra retry tolerance
- keep the finder relay list anchored on Fundstr and surface a warning banner if it is unreachable
- add warning styles so users see when Fundstr is temporarily down

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68da25f758188330ac54890f53c293e0