### PR TITLE
Normalize creator profile pubkey handling

### DIFF
--- a/src/utils/nostrKeys.ts
+++ b/src/utils/nostrKeys.ts
@@ -1,0 +1,30 @@
+import { nip19 } from "nostr-tools";
+import { toHex } from "src/nostr/relayClient";
+
+const NPUB_PREFIX = /^npub1/i;
+
+export type CreatorKeys = {
+  npub: string;
+  hex: string;
+};
+
+export function deriveCreatorKeys(raw: string | undefined | null): CreatorKeys {
+  const input = (raw ?? "").trim();
+  if (!input) {
+    throw new Error("Missing pubkey");
+  }
+
+  const hex = toHex(input);
+
+  let npub = input;
+  if (!NPUB_PREFIX.test(input)) {
+    try {
+      npub = nip19.npubEncode(hex);
+    } catch (err) {
+      // ignore encoding error and fall back to original input
+      npub = input;
+    }
+  }
+
+  return { npub, hex };
+}

--- a/test/nostrKeys.spec.ts
+++ b/test/nostrKeys.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { nip19 } from "nostr-tools";
+
+import { deriveCreatorKeys } from "src/utils/nostrKeys";
+
+describe("deriveCreatorKeys", () => {
+  it("returns canonical hex when given an npub", () => {
+    const hex = "f".repeat(64);
+    const npub = nip19.npubEncode(hex);
+
+    const result = deriveCreatorKeys(npub);
+
+    expect(result.hex).toBe(hex);
+    expect(result.npub).toBe(npub);
+  });
+
+  it("produces an npub when given a raw hex key", () => {
+    const hex = "a".repeat(64);
+
+    const result = deriveCreatorKeys(hex);
+
+    expect(result.hex).toBe(hex);
+    expect(result.npub).toBe(nip19.npubEncode(hex));
+  });
+
+  it("throws when given invalid input", () => {
+    expect(() => deriveCreatorKeys("not-a-key")).toThrowError();
+    expect(() => deriveCreatorKeys(undefined)).toThrowError();
+    expect(() => deriveCreatorKeys("")).toThrowError();
+  });
+});


### PR DESCRIPTION
## Summary
- derive canonical hex + shareable npub when loading the public creator profile route
- use the hex key for tier/profile store lookups and surface a friendly error when parsing fails
- add a reusable nostr key helper with vitest coverage and extend page tests for hex inputs

## Testing
- pnpm exec vitest run test/publicCreatorProfilePage.spec.ts test/nostrKeys.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68da6810d87c83308a5422b3dbcd92ee