### PR TITLE
Publish canonical Nutzap tier definitions with legacy fallback

### DIFF
--- a/src/nostr/builders.ts
+++ b/src/nostr/builders.ts
@@ -23,6 +23,7 @@ export function buildKind10002RelayList(
 }
 
 import type { NutzapProfilePayload } from "./nutzapProfile";
+import type { NutzapWireTier } from "./tiers";
 
 export function buildKind10019NutzapProfile(
   pubkey: string,
@@ -48,4 +49,21 @@ export function buildKind30000Tiers(pubkey: string, tiers: any[], d = "tiers") {
     pubkey,
     created_at: Math.floor(Date.now() / 1000),
   };
+}
+
+export function buildKind30019Tiers(
+  pubkey: string,
+  tiers: NutzapWireTier[],
+  d = "tiers",
+) {
+  return {
+    kind: 30019,
+    content: JSON.stringify({ v: 1, tiers }),
+    tags: [
+      ["d", d],
+      ["t", "nutzap-tiers"],
+    ],
+    pubkey,
+    created_at: Math.floor(Date.now() / 1000),
+  } as const;
 }

--- a/src/nutzap/relayConfig.ts
+++ b/src/nutzap/relayConfig.ts
@@ -32,3 +32,5 @@ export const NUTZAP_PROFILE_KIND =
 
 export const NUTZAP_TIERS_KIND =
   Number(import.meta.env.VITE_NUTZAP_TIERS_KIND ?? 30019);
+
+export const LEGACY_NUTZAP_TIERS_KIND = 30000;


### PR DESCRIPTION
## Summary
- publish canonical kind 30019 Nutzap tier events alongside the existing legacy 30000 events
- normalize tier serialization/deserialization around the title/price wire shape and track the preferred tier kind in the creator hub store
- update the creator bundle workflow to advertise the correct tier address and reuse the new helpers

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68db7ff39ed883308f54815625c7706a