### PR TITLE
Enhance Nutzap profile event tags

### DIFF
--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -619,12 +619,16 @@ export function useCreatorHub() {
       kind10002.created_at = createdAt;
       const kind10019 = new NDKEvent(
         ndkConn,
-        buildKind10019NutzapProfile(nostr.pubkey, {
-          p2pk: payload.p2pkPub,
-          mints: payload.mints,
-          relays,
-          tierAddr: payload.tierAddr,
-        }),
+        buildKind10019NutzapProfile(
+          nostr.pubkey,
+          {
+            p2pk: payload.p2pkPub,
+            mints: payload.mints,
+            relays,
+            tierAddr: payload.tierAddr,
+          },
+          payload.profile,
+        ),
       );
       kind10019.created_at = createdAt;
 

--- a/src/nostr/builders.ts
+++ b/src/nostr/builders.ts
@@ -25,17 +25,51 @@ export function buildKind10002RelayList(
 import type { NutzapProfilePayload } from "./nutzapProfile";
 import type { NutzapWireTier } from "./tiers";
 
+type ProfileLike = {
+  name?: string;
+  display_name?: string;
+  picture?: string;
+} | undefined;
+
 export function buildKind10019NutzapProfile(
   pubkey: string,
   np: NutzapProfilePayload,
+  profile?: ProfileLike,
 ) {
+  const tags: string[][] = [
+    ["t", "nutzap-profile"],
+    ["client", "fundstr"],
+  ];
+
+  if (Array.isArray(np.mints)) {
+    for (const mint of np.mints) {
+      if (mint) tags.push(["mint", mint, "sat"]);
+    }
+  }
+
+  if (Array.isArray(np.relays)) {
+    for (const relay of np.relays) {
+      if (relay) tags.push(["relay", relay]);
+    }
+  }
+
+  if (np.p2pk) {
+    tags.push(["pubkey", np.p2pk]);
+  }
+
+  const displayName = profile?.display_name || profile?.name;
+  if (displayName) {
+    tags.push(["name", displayName]);
+  }
+
+  if (profile?.picture) {
+    tags.push(["picture", profile.picture]);
+  }
+
   return {
     kind: 10019,
     content: JSON.stringify({ v: 1, ...np }),
-    tags: [
-      ["t", "nutzap-profile"],
-      ["client", "fundstr"],
-    ],
+    tags,
     pubkey,
     created_at: Math.floor(Date.now() / 1000),
   } as const;


### PR DESCRIPTION
## Summary
- add mint, relay, pubkey, and optional name/picture tags to Nutzap profile events
- reuse the enhanced builder in publish flows to mirror Nutzap profile footprints
- extend the discovery profile unit test to validate mint and relay tagging

## Testing
- pnpm vitest run test/publishDiscoveryProfile.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68db850781c88330b53d53308f2d9e45