### PR TITLE
Add display name fallback for creator profile

### DIFF
--- a/src/stores/creatorProfile.ts
+++ b/src/stores/creatorProfile.ts
@@ -48,9 +48,11 @@ export const useCreatorProfileStore = defineStore("creatorProfile", {
     },
   },
   actions: {
-    setProfile(data: Partial<CreatorProfile>) {
+    setProfile(data: Partial<CreatorProfile> & { name?: string }) {
       if (data.display_name !== undefined)
         this.display_name = data.display_name;
+      else if (typeof data.name === "string")
+        this.display_name = data.name.trim();
       if (data.picture !== undefined) this.picture = data.picture;
       if (data.about !== undefined) this.about = data.about;
       if (data.pubkey !== undefined) this.pubkey = data.pubkey.trim();

--- a/test/vitest/__tests__/creatorProfileStore.spec.ts
+++ b/test/vitest/__tests__/creatorProfileStore.spec.ts
@@ -43,3 +43,12 @@ describe("CreatorProfileStore isDirty", () => {
     expect(store.isDirty).toBe(true);
   });
 });
+
+describe("CreatorProfileStore setProfile", () => {
+  it("falls back to name when display_name missing", () => {
+    const store = useCreatorProfileStore();
+    store.setProfile({ name: " Example " });
+
+    expect(store.display_name).toBe("Example");
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the creator profile store falls back to a trimmed name when no display name is provided
- cover the fallback behavior with a unit test

## Testing
- pnpm vitest run test/vitest/__tests__/creatorProfileStore.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68db92bae9cc83309b76775a25ef1bef