### PR TITLE
Refine Creator Hub status header layout

### DIFF
--- a/src/css/creator-hub.scss
+++ b/src/css/creator-hub.scss
@@ -35,6 +35,132 @@
   border-radius: 20px;
 }
 
+/* Creator hub status header */
+.creator-status-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid var(--surface-contrast-border);
+  background-color: rgba(148, 163, 184, 0.08);
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+
+  &--neutral {
+    background-color: rgba(148, 163, 184, 0.08);
+    border-color: rgba(148, 163, 184, 0.24);
+  }
+
+  &--success {
+    background-color: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.35);
+  }
+
+  &--alert {
+    background-color: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.4);
+    box-shadow: 0 0 0 1px rgba(239, 68, 68, 0.15);
+  }
+
+  &__summary {
+    flex: 1 1 260px;
+    min-width: 0;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 4px;
+  }
+
+  &__subtitle {
+    margin-top: 4px;
+  }
+
+  &__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+  }
+
+  &__failure-list {
+    margin-top: 12px;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background-color: rgba(239, 68, 68, 0.08);
+    border: 1px solid rgba(239, 68, 68, 0.24);
+  }
+
+  &__failure-items {
+    margin: 0;
+    padding-left: 18px;
+    list-style: disc;
+
+    li {
+      margin-bottom: 4px;
+      word-break: break-all;
+      font-size: 0.75rem;
+      line-height: 1.3;
+    }
+
+    li:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__actions {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+  }
+}
+
+.status-chip {
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+
+  &--neutral {
+    background-color: rgba(148, 163, 184, 0.2);
+    border-color: rgba(148, 163, 184, 0.35);
+    color: var(--text-2);
+  }
+
+  &--positive {
+    background-color: rgba(34, 197, 94, 0.2);
+    border-color: rgba(34, 197, 94, 0.35);
+    color: #166534;
+  }
+
+  &--warning {
+    background-color: rgba(234, 179, 8, 0.24);
+    border-color: rgba(234, 179, 8, 0.45);
+    color: #92400e;
+  }
+
+  &--negative {
+    background-color: rgba(239, 68, 68, 0.24);
+    border-color: rgba(239, 68, 68, 0.45);
+    color: #991b1b;
+  }
+}
+
+@media (max-width: 599px) {
+  .creator-status-header {
+    &__actions {
+      width: 100%;
+      justify-content: flex-start;
+    }
+  }
+}
+
 /* Chip variants */
 .chip-outline {
   border: var(--surface-contrast-border);


### PR DESCRIPTION
## Summary
- replace the Creator Hub relay banners with a consolidated status header card that shows connection counts, Fundstr relay state, and failure details alongside quick actions
- add SCSS helpers for the new status header, compact chips, and responsive alignment so the layout remains usable on mobile

## Testing
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_e_68db98fb35508330866d46bcd8be53c9