### PR TITLE
Refresh creator hub publish bar styling

### DIFF
--- a/src/components/PublishBar.vue
+++ b/src/components/PublishBar.vue
@@ -1,48 +1,56 @@
 <template>
-  <q-footer class="w-full bg-grey-3 dark:bg-grey-9 text-dark dark:text-white">
-    <q-toolbar class="justify-center column items-center">
-      <q-btn
-        color="primary"
-        outline
-        :loading="loading"
-        :disable="publishing"
-        @click="emit('publish')"
-      >
-        {{ $t("creatorHub.publish") }}
-      </q-btn>
+  <q-footer class="publish-bar q-px-md q-py-sm bg-surface-2 text-1">
+    <div class="publish-bar__content">
+      <div class="publish-bar__cta">
+        <span class="publish-bar__label text-2">
+          {{ $t("creatorHub.publishBar.unsavedChanges") }}
+        </span>
+        <q-btn
+          color="primary"
+          unelevated
+          class="publish-bar__button"
+          :loading="loading"
+          :disable="publishing"
+          @click="emit('publish')"
+        >
+          {{ $t("creatorHub.publish") }}
+        </q-btn>
+      </div>
       <q-banner
         v-if="fallbackUsed.length"
         dense
-        class="bg-warning text-black q-mt-sm"
+        class="publish-bar__fallback"
       >
         Your relays were unhealthy; also used fallback: {{ fallbackUsed.join(', ') }}
       </q-banner>
-      <div v-if="table.length" class="q-mt-sm">
-        <table class="text-caption">
-          <thead>
-            <tr>
-              <th class="q-pr-sm">Relay</th>
-              <th class="q-pr-sm">Status</th>
-              <th class="q-pr-sm">Latency</th>
-              <th>Source</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="r in table" :key="r.relay">
-              <td class="q-pr-sm" style="word-break: break-all">{{ r.relay }}</td>
-              <td class="q-pr-sm">
-                <span v-if="r.status === 'ok'">✅ ok</span>
-                <span v-else-if="r.status === 'timeout'">⏳ timeout</span>
-                <span v-else-if="r.status === 'notConnected'">⚠ notConnected</span>
-                <span v-else>❌ {{ r.status }}</span>
-              </td>
-              <td class="q-pr-sm">{{ r.latencyMs ? r.latencyMs + 'ms' : '' }}</td>
-              <td>{{ r.fromFallback ? 'fallback' : 'user' }}</td>
-            </tr>
-          </tbody>
-        </table>
+      <div v-if="table.length" class="publish-bar__report">
+        <div class="publish-report-card">
+          <table class="publish-report-card__table text-caption">
+            <thead>
+              <tr>
+                <th class="q-pr-sm">Relay</th>
+                <th class="q-pr-sm">Status</th>
+                <th class="q-pr-sm">Latency</th>
+                <th>Source</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="r in table" :key="r.relay">
+                <td class="q-pr-sm" style="word-break: break-all">{{ r.relay }}</td>
+                <td class="q-pr-sm">
+                  <span v-if="r.status === 'ok'">✅ ok</span>
+                  <span v-else-if="r.status === 'timeout'">⏳ timeout</span>
+                  <span v-else-if="r.status === 'notConnected'">⚠ notConnected</span>
+                  <span v-else>❌ {{ r.status }}</span>
+                </td>
+                <td class="q-pr-sm">{{ r.latencyMs ? r.latencyMs + 'ms' : '' }}</td>
+                <td>{{ r.fromFallback ? 'fallback' : 'user' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
-    </q-toolbar>
+    </div>
   </q-footer>
 </template>
 

--- a/src/css/creator-hub.scss
+++ b/src/css/creator-hub.scss
@@ -6,6 +6,105 @@
   border-radius: 8px;
 }
 
+.publish-bar {
+  display: flex;
+  justify-content: center;
+  border-top: 1px solid var(--surface-contrast-border);
+  box-shadow: 0 -4px 12px rgba(15, 23, 42, 0.08);
+
+  &__content {
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: stretch;
+  }
+
+  &__cta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    text-align: center;
+  }
+
+  &__label {
+    font-weight: 600;
+  }
+
+  &__button {
+    min-width: 180px;
+  }
+
+  &__fallback {
+    background-color: rgba(251, 191, 36, 0.15);
+    color: var(--text-1);
+    border-radius: 8px;
+    border: 1px solid rgba(217, 119, 6, 0.35);
+    margin: 0;
+    padding: 8px 12px;
+  }
+
+  &__report {
+    width: 100%;
+  }
+}
+
+.publish-report-card {
+  background-color: var(--surface-1);
+  border: 1px solid var(--surface-contrast-border);
+  border-radius: 12px;
+  padding: 12px 16px;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+  overflow-x: auto;
+
+  &__table {
+    width: 100%;
+    border-collapse: collapse;
+
+    th,
+    td {
+      padding-top: 6px;
+      padding-bottom: 6px;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    thead th {
+      font-weight: 600;
+      text-transform: uppercase;
+      font-size: 0.65rem;
+      letter-spacing: 0.04em;
+      color: var(--text-2);
+    }
+
+    tbody tr:last-child th,
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+  }
+}
+
+@media (min-width: 768px) {
+  .publish-bar {
+    &__content {
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    &__cta {
+      justify-content: space-between;
+      text-align: left;
+    }
+
+    &__label {
+      font-size: 0.95rem;
+    }
+  }
+}
+
 /* Dark slate gradient backgrounds */
 .gradient-dark-slate {
   background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1870,6 +1870,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1878,6 +1878,9 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
+    publishBar: {
+      unsavedChanges: "Unsaved changes",
+    },
     profileHeader: "Profile details",
     displayName: "Display Name",
     profilePictureUrl: "Profile Picture URL",


### PR DESCRIPTION
## Summary
- restyle the publish bar with surface accents, clear CTA, and contextual label
- wrap publish diagnostics in a dedicated card and add shared styling tokens
- add a translation key for the unsaved changes label across locales

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db9da14b488330b34b16039f6c36b2