### PR TITLE
Refactor Nutzap profile workspace into modular panels

### DIFF
--- a/src/nutzap/useNutzapRelayTelemetry.ts
+++ b/src/nutzap/useNutzapRelayTelemetry.ts
@@ -1,0 +1,165 @@
+import { computed, ref, watch, type Ref } from 'vue';
+import { FUNDSTR_WS_URL } from './relayEndpoints';
+import {
+  useRelayConnection,
+  type RelayActivityEntry,
+  type RelayActivityLevel,
+  type RelayConnectionStatus,
+} from './onepage/useRelayConnection';
+
+type RelayAlertHandler = (entry: RelayActivityEntry) => void;
+
+type UseNutzapRelayTelemetryOptions = {
+  onRelayAlert?: RelayAlertHandler;
+};
+
+export function useNutzapRelayTelemetry(options: UseNutzapRelayTelemetryOptions = {}) {
+  const {
+    relayUrl: relayConnectionUrl,
+    status: relayConnectionStatus,
+    autoReconnect: relayAutoReconnect,
+    activityLog: relayActivity,
+    connect: connectRelay,
+    disconnect: disconnectRelay,
+    publishEvent: publishEventToRelay,
+    clearActivity: clearRelayActivity,
+    isSupported: relaySupported,
+    isConnected: relayIsConnected,
+  } = useRelayConnection();
+
+  const relayUrlInput = ref(relayConnectionUrl.value);
+  const relayUrlInputValid = computed(() => relayUrlInput.value.trim().length > 0);
+
+  watch(relayConnectionUrl, value => {
+    relayUrlInput.value = value;
+  });
+
+  const relayStatusLabel = computed(() => describeStatus(relayConnectionStatus));
+  const relayStatusColor = computed(() => statusColor(relayConnectionStatus));
+  const relayStatusDotClass = computed(() => statusDotClass(relayConnectionStatus));
+
+  const latestRelayActivity = computed(() => {
+    const entries = relayActivity.value;
+    return entries.length ? entries[entries.length - 1] : null;
+  });
+
+  const relayActivityTimeline = computed(() => relayActivity.value.slice().reverse());
+
+  const activityTimeFormatter =
+    typeof Intl !== 'undefined'
+      ? new Intl.DateTimeFormat(undefined, {
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        })
+      : null;
+
+  const lastAlertId = ref<number | null>(null);
+
+  watch(
+    relayActivity,
+    entries => {
+      if (!options.onRelayAlert) {
+        return;
+      }
+      const latestError = [...entries].reverse().find(entry => entry.level === 'error');
+      if (latestError && latestError.id !== lastAlertId.value) {
+        lastAlertId.value = latestError.id;
+        options.onRelayAlert(latestError);
+      }
+    },
+    { deep: true }
+  );
+
+  function formatActivityTime(timestamp: number) {
+    if (!activityTimeFormatter) {
+      return new Date(timestamp).toISOString();
+    }
+    return activityTimeFormatter.format(new Date(timestamp));
+  }
+
+  function activityLevelColor(level: RelayActivityLevel) {
+    switch (level) {
+      case 'success':
+        return 'positive';
+      case 'warning':
+        return 'warning';
+      case 'error':
+        return 'negative';
+      default:
+        return 'primary';
+    }
+  }
+
+  function applyRelayUrlInput() {
+    const trimmed = relayUrlInput.value.trim();
+    relayConnectionUrl.value = trimmed || FUNDSTR_WS_URL;
+    relayUrlInput.value = relayConnectionUrl.value;
+  }
+
+  return {
+    relayConnectionUrl,
+    relayConnectionStatus,
+    relayAutoReconnect,
+    relayActivity,
+    connectRelay,
+    disconnectRelay,
+    publishEventToRelay,
+    clearRelayActivity,
+    relaySupported,
+    relayIsConnected,
+    relayUrlInput,
+    relayUrlInputValid,
+    relayStatusLabel,
+    relayStatusColor,
+    relayStatusDotClass,
+    latestRelayActivity,
+    relayActivityTimeline,
+    formatActivityTime,
+    activityLevelColor,
+    applyRelayUrlInput,
+  };
+}
+
+function describeStatus(status: Ref<RelayConnectionStatus>) {
+  switch (status.value) {
+    case 'connected':
+      return 'Connected';
+    case 'connecting':
+      return 'Connecting';
+    case 'reconnecting':
+      return 'Reconnecting';
+    case 'disconnected':
+      return 'Disconnected';
+    default:
+      return 'Idle';
+  }
+}
+
+function statusColor(status: Ref<RelayConnectionStatus>) {
+  switch (status.value) {
+    case 'connected':
+      return 'positive';
+    case 'connecting':
+    case 'reconnecting':
+      return 'warning';
+    case 'disconnected':
+      return 'negative';
+    default:
+      return 'grey-6';
+  }
+}
+
+function statusDotClass(status: Ref<RelayConnectionStatus>) {
+  switch (status.value) {
+    case 'connected':
+      return 'status-dot--positive';
+    case 'connecting':
+    case 'reconnecting':
+      return 'status-dot--warning';
+    case 'disconnected':
+      return 'status-dot--negative';
+    default:
+      return 'status-dot--idle';
+  }
+}

--- a/src/nutzap/useNutzapSignerWorkspace.ts
+++ b/src/nutzap/useNutzapSignerWorkspace.ts
@@ -1,0 +1,135 @@
+import { computed, ref, watch, type Ref } from 'vue';
+import { nip19 } from 'nostr-tools';
+import { useActiveNutzapSigner } from './signer';
+import { getNutzapNdk } from './ndkInstance';
+import { useNostrStore } from 'src/stores/nostr';
+
+type UseNutzapSignerWorkspaceOptions = {
+  onSignerActivated?: () => void;
+};
+
+export function useNutzapSignerWorkspace(
+  authorInput: Ref<string>,
+  options: UseNutzapSignerWorkspaceOptions = {}
+) {
+  const { pubkey, signer } = useActiveNutzapSigner();
+  const nostrStore = useNostrStore();
+
+  const keySecretHex = ref('');
+  const keyNsec = ref('');
+  const keyPublicHex = ref('');
+  const keyNpub = ref('');
+  const keyImportValue = ref('');
+  const advancedKeyManagementOpen = ref(false);
+
+  const storeNpub = computed(() => nostrStore.npub || '');
+  const usingStoreIdentity = computed(() => !!pubkey.value);
+
+  const connectedIdentitySummary = computed(() => {
+    if (!usingStoreIdentity.value) {
+      return '';
+    }
+    if (storeNpub.value) {
+      return shortenKey(storeNpub.value);
+    }
+    const activePub = typeof pubkey.value === 'string' ? pubkey.value.trim() : '';
+    if (!activePub) {
+      return '';
+    }
+    return shortenKey(activePub);
+  });
+
+  const lastSyncedPubkey = ref('');
+  let ensureSharedSignerPromise: Promise<void> | null = null;
+
+  async function ensureSharedSignerInitialized() {
+    if (ensureSharedSignerPromise) {
+      return ensureSharedSignerPromise;
+    }
+
+    ensureSharedSignerPromise = (async () => {
+      try {
+        await nostrStore.initSignerIfNotSet();
+      } catch (err) {
+        console.error('[nutzap] failed to initialize shared signer', err);
+      } finally {
+        const ndk = getNutzapNdk();
+        ndk.signer = (nostrStore.signer as any) ?? undefined;
+        ensureSharedSignerPromise = null;
+      }
+    })();
+
+    return ensureSharedSignerPromise;
+  }
+
+  watch(
+    usingStoreIdentity,
+    value => {
+      if (value) {
+        advancedKeyManagementOpen.value = false;
+        void ensureSharedSignerInitialized();
+      } else {
+        advancedKeyManagementOpen.value = true;
+      }
+    },
+    { immediate: true }
+  );
+
+  watch(
+    [pubkey, storeNpub],
+    ([newPubkey, storeNpubValue]) => {
+      const normalizedPubkey = typeof newPubkey === 'string' ? newPubkey.trim().toLowerCase() : '';
+      const encodedNpub = normalizedPubkey ? storeNpubValue || safeEncodeNpub(normalizedPubkey) : '';
+
+      if (normalizedPubkey) {
+        keyPublicHex.value = normalizedPubkey;
+        keyNpub.value = encodedNpub;
+        if (!authorInput.value || authorInput.value === lastSyncedPubkey.value) {
+          authorInput.value = normalizedPubkey;
+        }
+        lastSyncedPubkey.value = normalizedPubkey;
+        options.onSignerActivated?.();
+      } else {
+        if (keyPublicHex.value === lastSyncedPubkey.value) {
+          keyPublicHex.value = '';
+          keyNpub.value = '';
+        }
+        if (authorInput.value === lastSyncedPubkey.value) {
+          authorInput.value = '';
+        }
+        lastSyncedPubkey.value = '';
+      }
+    },
+    { immediate: true }
+  );
+
+  return {
+    pubkey,
+    signer,
+    keySecretHex,
+    keyNsec,
+    keyPublicHex,
+    keyNpub,
+    keyImportValue,
+    advancedKeyManagementOpen,
+    usingStoreIdentity,
+    connectedIdentitySummary,
+    ensureSharedSignerInitialized,
+  };
+}
+
+function shortenKey(value: string) {
+  const trimmed = value.trim();
+  if (trimmed.length <= 16) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, 8)}…${trimmed.slice(-4)}`;
+}
+
+function safeEncodeNpub(pubHex: string) {
+  try {
+    return nip19.npubEncode(pubHex);
+  } catch {
+    return '';
+  }
+}

--- a/src/pages/nutzap-profile/AuthorMetadataPanel.vue
+++ b/src/pages/nutzap-profile/AuthorMetadataPanel.vue
@@ -1,0 +1,393 @@
+<template>
+  <section class="section-card author-profile-card">
+    <div class="section-header">
+      <div class="section-title text-subtitle1 text-weight-medium text-1">Author metadata</div>
+      <div class="section-subtitle text-body2 text-2">
+        Compose profile details that will be published alongside your tiers.
+      </div>
+    </div>
+    <div class="section-body">
+      <div class="nested-sections">
+        <q-expansion-item
+          v-model="identityOpen"
+          switch-toggle-side
+          dense
+          expand-separator
+          class="nested-section"
+        >
+          <template #header>
+            <div class="nested-header">
+              <div class="nested-header__titles">
+                <div class="nested-title text-body1 text-weight-medium text-1">Identity basics</div>
+                <div class="nested-subtitle text-caption">
+                  Provide a display name and avatar for your payment profile (kind 10019).
+                  These are optional but help supporters recognize you.
+                </div>
+              </div>
+              <q-chip
+                dense
+                size="sm"
+                :color="identityBasicsComplete ? 'positive' : 'grey-6'"
+                :text-color="identityBasicsComplete ? 'white' : 'black'"
+                class="status-chip"
+              >
+                {{ identityBasicsComplete ? 'Added' : 'Optional' }}
+              </q-chip>
+            </div>
+          </template>
+          <div class="nested-section-body column q-gutter-md">
+            <q-input
+              :model-value="displayName"
+              label="Display Name"
+              dense
+              filled
+              @update:model-value="value => emit('update:displayName', value)"
+            />
+            <q-input
+              :model-value="pictureUrl"
+              label="Picture URL"
+              dense
+              filled
+              @update:model-value="value => emit('update:pictureUrl', value)"
+            />
+            <div class="text-caption text-2">
+              Display name and picture are nice-to-have details, but leaving them blank won’t block publishing.
+            </div>
+          </div>
+        </q-expansion-item>
+
+        <q-expansion-item
+          v-model="metadataOpen"
+          switch-toggle-side
+          dense
+          expand-separator
+          class="nested-section"
+        >
+          <template #header>
+            <div class="nested-header">
+              <div class="nested-header__titles">
+                <div class="nested-title text-body1 text-weight-medium text-1">Optional relay &amp; mint metadata</div>
+                <div class="nested-subtitle text-caption">
+                  List trusted mints (required for publishing) and add optional relay hints.
+                </div>
+              </div>
+              <q-chip
+                dense
+                size="sm"
+                :color="optionalMetadataComplete ? 'positive' : 'warning'"
+                :text-color="optionalMetadataComplete ? 'white' : 'black'"
+                class="status-chip"
+              >
+                {{ optionalMetadataComplete ? 'Ready' : 'Required' }}
+              </q-chip>
+            </div>
+          </template>
+          <div class="nested-section-body column q-gutter-md">
+            <q-input
+              :model-value="mintsText"
+              type="textarea"
+              label="Trusted Mints (one per line)"
+              dense
+              filled
+              autogrow
+              @update:model-value="value => emit('update:mintsText', value)"
+            />
+            <q-input
+              :model-value="relaysText"
+              type="textarea"
+              label="Relay Hints (optional, one per line)"
+              dense
+              filled
+              autogrow
+              @update:model-value="value => emit('update:relaysText', value)"
+            />
+          </div>
+        </q-expansion-item>
+
+        <q-expansion-item
+          v-model="encryptionOpen"
+          switch-toggle-side
+          dense
+          expand-separator
+          class="nested-section"
+        >
+          <template #header>
+            <div class="nested-header">
+              <div class="nested-header__titles">
+                <div class="nested-title text-body1 text-weight-medium text-1">Advanced encryption</div>
+                <div class="nested-subtitle text-caption">
+                  Generate or derive the P2PK pointer required for Nutzap payments.
+                </div>
+              </div>
+              <q-chip
+                dense
+                size="sm"
+                :color="advancedEncryptionComplete ? 'positive' : 'warning'"
+                :text-color="advancedEncryptionComplete ? 'white' : 'black'"
+                class="status-chip"
+              >
+                {{ advancedEncryptionComplete ? 'Ready' : 'Required' }}
+              </q-chip>
+            </div>
+          </template>
+          <div class="nested-section-body column q-gutter-md">
+            <q-input
+              :model-value="p2pkPriv"
+              label="P2PK Private Key (hex)"
+              dense
+              filled
+              autocomplete="off"
+              @update:model-value="value => emit('update:p2pkPriv', value)"
+            />
+            <div class="row q-gutter-sm">
+              <q-btn color="primary" label="Derive Public Key" @click="emit('request-derive-p2pk')" />
+              <q-btn color="primary" outline label="Generate Keypair" @click="emit('request-generate-p2pk')" />
+            </div>
+            <q-input
+              :model-value="p2pkPub"
+              label="P2PK Public Key"
+              dense
+              filled
+              @update:model-value="value => emit('update:p2pkPub', value)"
+            />
+            <q-input
+              :model-value="p2pkDerivedPub"
+              label="Derived P2PK Public Key"
+              type="textarea"
+              dense
+              filled
+              readonly
+              autogrow
+            />
+          </div>
+        </q-expansion-item>
+      </div>
+    </div>
+
+    <div class="section-footer q-mt-lg">
+      <div class="column q-gutter-sm">
+        <div class="text-body1 text-1">
+          <template v-if="usingStoreIdentity">
+            Connected as
+            <span class="text-weight-medium">{{ connectedIdentitySummary || 'Fundstr identity' }}</span>
+          </template>
+          <template v-else>Using a dedicated Nutzap key</template>
+        </div>
+        <div v-if="usingStoreIdentity" class="text-body2 text-2">
+          Your Fundstr signer is ready to publish Nutzap events. Stick with this shared identity unless you need a
+          separate persona or want to keep a secret key off the global store.
+        </div>
+        <div v-if="usingStoreIdentity" class="text-body2 text-2">
+          Choose a dedicated key when delegating publishing, testing against staging relays, or isolating collectibles
+          under a different author.
+        </div>
+        <div v-else class="text-body2 text-2">
+          This workspace is scoped to a standalone key, so Nutzap activity stays independent from your Fundstr profile.
+        </div>
+      </div>
+      <div v-if="!usingStoreIdentity" class="row items-center q-gutter-sm q-mt-sm">
+        <q-btn
+          color="primary"
+          outline
+          label="Manage dedicated key"
+          @click="emit('update:advancedKeyManagementOpen', true)"
+        />
+      </div>
+      <div v-else class="text-caption text-2 q-mt-sm">
+        Dedicated key tools become available when no Fundstr signer is connected.
+      </div>
+    </div>
+
+    <q-dialog v-if="!usingStoreIdentity" v-model="advancedDialogOpen" position="right">
+      <q-card class="advanced-key-drawer bg-surface-1">
+        <q-card-section class="row items-center justify-between q-gutter-sm">
+          <div class="text-subtitle1 text-weight-medium text-1">Dedicated key tools</div>
+          <q-btn icon="close" flat round dense v-close-popup aria-label="Close key tools" />
+        </q-card-section>
+        <q-separator />
+        <q-card-section class="advanced-key-drawer__body column q-gutter-lg">
+          <div class="column q-gutter-sm">
+            <div class="text-body2 text-2">
+              Generate a fresh key for Nutzap-only publishing or paste an existing secret to reuse another signer.
+            </div>
+          </div>
+          <div class="column q-gutter-sm">
+            <q-input
+              :model-value="keyImportValue"
+              label="Secret key (nsec or 64-char hex)"
+              dense
+              filled
+              autocomplete="off"
+              @update:model-value="value => emit('update:keyImportValue', value)"
+            />
+            <div class="row q-gutter-sm">
+              <q-btn color="primary" label="Generate" @click="emit('request-generate-secret')" />
+              <q-btn color="primary" outline label="Import" @click="emit('request-import-secret')" />
+            </div>
+          </div>
+          <div class="column q-gutter-sm">
+            <q-input
+              :model-value="keySecretHex"
+              label="Secret key (hex)"
+              type="textarea"
+              dense
+              filled
+              readonly
+              autogrow
+            />
+            <q-input
+              :model-value="keyNsec"
+              label="Secret key (nsec)"
+              type="textarea"
+              dense
+              filled
+              readonly
+              autogrow
+            />
+            <q-input
+              :model-value="keyPublicHex"
+              label="Public key (hex)"
+              type="textarea"
+              dense
+              filled
+              readonly
+              autogrow
+            />
+            <q-input
+              :model-value="keyNpub"
+              label="Public key (npub)"
+              type="textarea"
+              dense
+              filled
+              readonly
+              autogrow
+            />
+          </div>
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+
+const props = defineProps({
+  displayName: { type: String, required: true },
+  pictureUrl: { type: String, required: true },
+  mintsText: { type: String, required: true },
+  relaysText: { type: String, required: true },
+  p2pkPriv: { type: String, required: true },
+  p2pkPub: { type: String, required: true },
+  p2pkDerivedPub: { type: String, required: true },
+  keySecretHex: { type: String, required: true },
+  keyNsec: { type: String, required: true },
+  keyPublicHex: { type: String, required: true },
+  keyNpub: { type: String, required: true },
+  keyImportValue: { type: String, required: true },
+  usingStoreIdentity: { type: Boolean, required: true },
+  connectedIdentitySummary: { type: String, required: true },
+  identityBasicsComplete: { type: Boolean, required: true },
+  optionalMetadataComplete: { type: Boolean, required: true },
+  advancedEncryptionComplete: { type: Boolean, required: true },
+  advancedKeyManagementOpen: { type: Boolean, required: true },
+});
+
+const emit = defineEmits<{
+  (e: 'update:displayName', value: string): void;
+  (e: 'update:pictureUrl', value: string): void;
+  (e: 'update:mintsText', value: string): void;
+  (e: 'update:relaysText', value: string): void;
+  (e: 'update:p2pkPriv', value: string): void;
+  (e: 'update:p2pkPub', value: string): void;
+  (e: 'update:keyImportValue', value: string): void;
+  (e: 'update:advancedKeyManagementOpen', value: boolean): void;
+  (e: 'request-derive-p2pk'): void;
+  (e: 'request-generate-p2pk'): void;
+  (e: 'request-generate-secret'): void;
+  (e: 'request-import-secret'): void;
+}>();
+
+const identityOpen = ref(true);
+const metadataOpen = ref(true);
+const encryptionOpen = ref(false);
+
+watch(
+  () => props.identityBasicsComplete,
+  value => {
+    if (value) {
+      identityOpen.value = true;
+    }
+  },
+  { immediate: true }
+);
+
+watch(
+  () => props.optionalMetadataComplete,
+  value => {
+    if (value) {
+      metadataOpen.value = true;
+    }
+    if (value && !props.advancedEncryptionComplete) {
+      encryptionOpen.value = true;
+    }
+  },
+  { immediate: true }
+);
+
+watch(
+  () => props.advancedEncryptionComplete,
+  value => {
+    if (value) {
+      encryptionOpen.value = true;
+    }
+  },
+  { immediate: true }
+);
+
+const advancedDialogOpen = computed({
+  get: () => props.advancedKeyManagementOpen,
+  set: value => emit('update:advancedKeyManagementOpen', value),
+});
+
+const displayName = computed(() => props.displayName);
+const pictureUrl = computed(() => props.pictureUrl);
+const mintsText = computed(() => props.mintsText);
+const relaysText = computed(() => props.relaysText);
+const p2pkPriv = computed(() => props.p2pkPriv);
+const p2pkPub = computed(() => props.p2pkPub);
+const p2pkDerivedPub = computed(() => props.p2pkDerivedPub);
+const keyImportValue = computed(() => props.keyImportValue);
+const keySecretHex = computed(() => props.keySecretHex);
+const keyNsec = computed(() => props.keyNsec);
+const keyPublicHex = computed(() => props.keyPublicHex);
+const keyNpub = computed(() => props.keyNpub);
+const usingStoreIdentity = computed(() => props.usingStoreIdentity);
+const connectedIdentitySummary = computed(() => props.connectedIdentitySummary);
+const identityBasicsComplete = computed(() => props.identityBasicsComplete);
+const optionalMetadataComplete = computed(() => props.optionalMetadataComplete);
+const advancedEncryptionComplete = computed(() => props.advancedEncryptionComplete);
+</script>
+
+<style scoped>
+.author-profile-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-footer {
+  border-top: 1px solid var(--surface-contrast-border);
+  padding-top: 16px;
+}
+
+.advanced-key-drawer {
+  width: min(400px, 100vw);
+  max-width: 100vw;
+}
+
+.advanced-key-drawer__body {
+  max-height: 80vh;
+  overflow-y: auto;
+}
+</style>

--- a/src/pages/nutzap-profile/ConnectionPanel.vue
+++ b/src/pages/nutzap-profile/ConnectionPanel.vue
@@ -1,0 +1,244 @@
+<template>
+  <section class="section-card connection-module">
+    <div class="section-header">
+      <div class="section-title text-subtitle1 text-weight-medium text-1">Connection</div>
+      <div class="section-subtitle text-body2 text-2">
+        Control the live WebSocket session used for publishing events and monitor relay activity.
+      </div>
+    </div>
+    <div class="section-body column q-gutter-lg">
+      <div class="connection-status column q-gutter-xs">
+        <div class="status-indicators row items-center wrap q-gutter-sm">
+          <RelayStatusIndicator class="connection-status-indicator" />
+          <span class="status-dot" :class="statusDotClass" aria-hidden="true"></span>
+          <q-chip dense :color="statusColor" text-color="white" class="status-chip">
+            {{ statusLabel }}
+          </q-chip>
+        </div>
+        <div v-if="latestActivity" class="latest-activity text-caption">
+          <span class="text-2">Latest update:</span>
+          <span class="text-weight-medium text-1">{{ latestActivity.message }}</span>
+          <span class="text-2">({{ formatActivityTime(latestActivity.timestamp) }})</span>
+        </div>
+        <div v-else class="latest-activity text-caption text-2">No relay activity yet.</div>
+      </div>
+
+      <div class="connection-controls column q-gutter-sm">
+        <q-input
+          :model-value="relayUrl"
+          label="Relay URL"
+          dense
+          filled
+          :disable="!relaySupported"
+          autocomplete="off"
+          @update:model-value="value => emit('update:relayUrl', value)"
+        />
+        <div class="row items-center wrap q-gutter-sm">
+          <q-btn
+            color="primary"
+            label="Connect"
+            :disable="!relaySupported || !relayUrlValid"
+            @click="emit('connect')"
+          />
+          <q-btn
+            color="primary"
+            outline
+            label="Disconnect"
+            :disable="!relaySupported || !relayIsConnected"
+            @click="emit('disconnect')"
+          />
+          <q-toggle
+            :model-value="relayAutoReconnect"
+            label="Auto reconnect"
+            dense
+            :disable="!relaySupported"
+            @update:model-value="value => emit('update:autoReconnect', value)"
+          />
+        </div>
+      </div>
+
+      <div class="connection-activity column q-gutter-xs">
+        <q-expansion-item
+          dense
+          expand-separator
+          icon="history"
+          label="Activity timeline"
+          header-class="activity-expansion-header"
+          :disable="!activityTimeline.length"
+        >
+          <template #header>
+            <div class="timeline-header row items-center justify-between full-width">
+              <div class="row items-center q-gutter-sm">
+                <q-icon name="history" size="sm" />
+                <div class="text-body2 text-weight-medium text-1">Activity timeline</div>
+              </div>
+              <q-chip dense :color="statusColor" text-color="white" class="status-chip">
+                {{ statusLabel }}
+              </q-chip>
+            </div>
+          </template>
+          <div v-if="activityTimeline.length" class="activity-timeline column q-gutter-md q-mt-sm">
+            <div
+              v-for="entry in activityTimeline"
+              :key="entry.id"
+              class="timeline-entry row no-wrap"
+            >
+              <div class="timeline-marker" :class="`timeline-marker--${entry.level}`"></div>
+              <div class="timeline-content column q-gutter-xs">
+                <div class="timeline-header row items-center q-gutter-sm">
+                  <span class="text-caption text-2">{{ formatActivityTime(entry.timestamp) }}</span>
+                  <q-badge :color="activityLevelColor(entry.level)" outline size="sm">
+                    {{ entry.level }}
+                  </q-badge>
+                </div>
+                <div class="timeline-message text-body2 text-1">{{ entry.message }}</div>
+                <div v-if="entry.context" class="timeline-context text-caption text-2">{{ entry.context }}</div>
+              </div>
+            </div>
+            <div class="timeline-actions row justify-end">
+              <q-btn flat label="Clear log" size="sm" :disable="!activityTimeline.length" @click="emit('clear-activity')" />
+            </div>
+          </div>
+          <div v-else class="section-empty text-caption text-2">No relay activity yet.</div>
+        </q-expansion-item>
+        <div v-if="!activityTimeline.length" class="text-caption text-2">
+          Activity will appear once the relay connection initializes.
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { toRefs, type PropType } from 'vue';
+import RelayStatusIndicator from 'src/nutzap/RelayStatusIndicator.vue';
+import { type RelayActivityEntry, type RelayActivityLevel } from 'src/nutzap/onepage/useRelayConnection';
+
+type Props = {
+  statusLabel: string;
+  statusColor: string;
+  statusDotClass: string;
+  latestActivity: RelayActivityEntry | null;
+  activityTimeline: RelayActivityEntry[];
+  relayUrl: string;
+  relayUrlValid: boolean;
+  relaySupported: boolean;
+  relayIsConnected: boolean;
+  relayAutoReconnect: boolean;
+  formatActivityTime: (timestamp: number) => string;
+  activityLevelColor: (level: RelayActivityLevel) => string;
+};
+
+const props = defineProps({
+  statusLabel: { type: String, required: true },
+  statusColor: { type: String, required: true },
+  statusDotClass: { type: String, required: true },
+  latestActivity: { type: Object as PropType<RelayActivityEntry | null>, default: null },
+  activityTimeline: { type: Array as PropType<RelayActivityEntry[]>, default: () => [] },
+  relayUrl: { type: String, required: true },
+  relayUrlValid: { type: Boolean, required: true },
+  relaySupported: { type: Boolean, required: true },
+  relayIsConnected: { type: Boolean, required: true },
+  relayAutoReconnect: { type: Boolean, required: true },
+  formatActivityTime: { type: Function as PropType<(timestamp: number) => string>, required: true },
+  activityLevelColor: {
+    type: Function as PropType<(level: RelayActivityLevel) => string>,
+    required: true,
+  },
+});
+
+const emit = defineEmits<{
+  (e: 'update:relayUrl', value: string): void;
+  (e: 'update:autoReconnect', value: boolean): void;
+  (e: 'connect'): void;
+  (e: 'disconnect'): void;
+  (e: 'clear-activity'): void;
+}>();
+
+const {
+  statusLabel,
+  statusColor,
+  statusDotClass,
+  latestActivity,
+  activityTimeline,
+  relayUrl,
+  relayUrlValid,
+  relaySupported,
+  relayIsConnected,
+  relayAutoReconnect,
+  formatActivityTime,
+  activityLevelColor,
+} = toRefs(props as Props);
+</script>
+
+<style scoped>
+.connection-module {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.connection-status-indicator {
+  width: 28px;
+  height: 28px;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 9999px;
+  background: var(--surface-contrast-border);
+  transition: background-color 150ms ease;
+}
+
+.status-dot--positive {
+  background: #21ba45;
+}
+
+.status-dot--warning {
+  background: #f2c037;
+}
+
+.status-dot--negative {
+  background: #c10015;
+}
+
+.status-dot--idle {
+  background: var(--surface-contrast-border);
+}
+
+.status-chip {
+  text-transform: capitalize;
+  font-weight: 600;
+}
+
+.timeline-entry {
+  gap: 12px;
+}
+
+.timeline-marker {
+  width: 6px;
+  border-radius: 999px;
+  background: var(--surface-contrast-border);
+}
+
+.timeline-marker--success {
+  background: #21ba45;
+}
+
+.timeline-marker--warning {
+  background: #f2c037;
+}
+
+.timeline-marker--error {
+  background: #c10015;
+}
+
+.timeline-marker--info {
+  background: var(--accent-500);
+}
+
+.timeline-actions {
+  margin-top: 4px;
+}
+</style>

--- a/src/pages/nutzap-profile/ReviewPublishCard.vue
+++ b/src/pages/nutzap-profile/ReviewPublishCard.vue
@@ -1,0 +1,142 @@
+<template>
+  <section class="section-card">
+    <q-expansion-item
+      v-model="internalOpen"
+      switch-toggle-side
+      dense
+      expand-separator
+      :disable="!tiersReady"
+      :class="['nested-section', 'review-expansion', { 'is-disabled': !tiersReady }]"
+    >
+      <template #header>
+        <div class="nested-header">
+          <div class="nested-header__titles">
+            <div class="nested-title text-body1 text-weight-medium text-1">Review &amp; Publish</div>
+            <div class="nested-subtitle text-caption">
+              Inspect the JSON payload before pushing updates to the relay.
+            </div>
+          </div>
+        </div>
+        <q-chip
+          dense
+          size="sm"
+          :color="tiersReady ? 'positive' : 'grey-6'"
+          :text-color="tiersReady ? 'white' : 'black'"
+          class="status-chip"
+        >
+          {{ tiersReady ? 'Ready' : 'Locked' }}
+        </q-chip>
+      </template>
+      <div class="nested-section-body column q-gutter-md">
+        <q-input
+          :model-value="tiersJsonPreview"
+          type="textarea"
+          label="Tiers JSON preview"
+          dense
+          filled
+          autogrow
+          readonly
+          spellcheck="false"
+        />
+        <div class="row justify-end q-gutter-sm">
+          <q-btn
+            color="primary"
+            label="Publish profile &amp; tiers"
+            :disable="publishDisabled"
+            :loading="publishing"
+            @click="emit('publish')"
+          />
+        </div>
+        <div v-if="publicProfileUrl" class="share-inline row items-center q-gutter-sm" data-testid="publish-summary-share">
+          <q-input
+            :model-value="publicProfileUrl"
+            dense
+            filled
+            readonly
+            class="col"
+            data-testid="publish-public-profile-url"
+          >
+            <template #append>
+              <q-btn
+                flat
+                color="primary"
+                label="Copy link"
+                data-testid="publish-copy-public-profile-url"
+                @click="emit('copy-link')"
+              />
+            </template>
+          </q-input>
+        </div>
+        <div class="text-body2 text-2" v-if="lastPublishInfo">
+          {{ lastPublishInfo }}
+        </div>
+      </div>
+    </q-expansion-item>
+    <div v-if="!tiersReady" class="review-lock-message text-caption text-2">
+      Add at least one valid tier to unlock review and publishing.
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+
+const props = defineProps({
+  open: { type: Boolean, required: true },
+  tiersReady: { type: Boolean, required: true },
+  tiersJsonPreview: { type: String, required: true },
+  publishDisabled: { type: Boolean, required: true },
+  publishing: { type: Boolean, required: true },
+  publicProfileUrl: { type: String, required: true },
+  lastPublishInfo: { type: String, required: true },
+});
+
+const emit = defineEmits<{
+  (e: 'update:open', value: boolean): void;
+  (e: 'publish'): void;
+  (e: 'copy-link'): void;
+}>();
+
+const internalOpen = ref(props.open);
+
+watch(
+  () => props.open,
+  value => {
+    internalOpen.value = value;
+  }
+);
+
+watch(internalOpen, value => {
+  emit('update:open', value);
+});
+
+watch(
+  () => props.tiersReady,
+  ready => {
+    if (!ready && internalOpen.value) {
+      internalOpen.value = false;
+    } else if (ready && !internalOpen.value) {
+      internalOpen.value = true;
+    }
+  },
+  { immediate: true }
+);
+
+const tiersJsonPreview = computed(() => props.tiersJsonPreview);
+const publishDisabled = computed(() => props.publishDisabled);
+const publishing = computed(() => props.publishing);
+const publicProfileUrl = computed(() => props.publicProfileUrl);
+const lastPublishInfo = computed(() => props.lastPublishInfo);
+const tiersReady = computed(() => props.tiersReady);
+</script>
+
+<style scoped>
+.review-expansion.is-disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.review-lock-message {
+  margin-top: 8px;
+}
+</style>

--- a/src/pages/nutzap-profile/TierComposerCard.vue
+++ b/src/pages/nutzap-profile/TierComposerCard.vue
@@ -1,0 +1,56 @@
+<template>
+  <section class="section-card">
+    <div class="section-header section-header--with-status">
+      <div class="section-header-primary">
+        <div class="section-title text-subtitle1 text-weight-medium text-1">Compose tiers</div>
+        <div class="section-subtitle text-body2 text-2">
+          Draft pricing, benefits, and cadence before publishing downstream.
+        </div>
+      </div>
+      <q-chip
+        dense
+        size="sm"
+        :color="tiersReady ? 'positive' : 'warning'"
+        :text-color="tiersReady ? 'white' : 'black'"
+        class="status-chip"
+      >
+        {{ tiersReady ? 'Valid' : 'Needs review' }}
+      </q-chip>
+    </div>
+    <div class="section-body column q-gutter-md">
+      <TierComposer
+        :tiers="tiers"
+        :frequency-options="frequencyOptions"
+        :show-errors="showErrors"
+        @update:tiers="value => emit('update:tiers', value)"
+        @validation-changed="value => emit('validation-changed', value)"
+      />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { toRefs, type PropType } from 'vue';
+import TierComposer from './TierComposer.vue';
+import type { Tier } from 'src/nutzap/types';
+import type { TierFieldErrors } from './tierComposerUtils';
+
+type FrequencyOption = {
+  value: Tier['frequency'];
+  label: string;
+};
+
+const props = defineProps({
+  tiers: { type: Array as PropType<Tier[]>, required: true },
+  frequencyOptions: { type: Array as PropType<FrequencyOption[]>, required: true },
+  showErrors: { type: Boolean, required: true },
+  tiersReady: { type: Boolean, required: true },
+});
+
+const emit = defineEmits<{
+  (e: 'update:tiers', value: Tier[]): void;
+  (e: 'validation-changed', value: TierFieldErrors[]): void;
+}>();
+
+const { tiers, frequencyOptions, showErrors, tiersReady } = toRefs(props);
+</script>


### PR DESCRIPTION
## Summary
- extract Nutzap connection, metadata, composer, and publish sections into dedicated components under `src/pages/nutzap-profile`
- add shared Nutzap composables for relay telemetry and signer sync consumed by the new components
- simplify `NutzapProfilePage.vue` to orchestrate the workspace via the new components and composables

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dbbd731c6c83309dfc13ee4b0f3427