### PR TITLE
Lazy-load Nutzap relay client to prevent helper init errors

### DIFF
--- a/src/components/ChooseMint.vue
+++ b/src/components/ChooseMint.vue
@@ -97,7 +97,6 @@ import { mapActions, mapState, mapWritableState } from "pinia";
 import { useMintsStore } from "stores/mints";
 import { MintClass } from "stores/mints";
 import { i18n } from "../boot/i18n";
-import { title } from "process";
 
 export default defineComponent({
   name: "ChooseMint",


### PR DESCRIPTION
## Summary
- lazily resolve the Fundstr relay client inside Nutzap profile helpers so read utilities initialize without relay side effects
- remove an unused process.title import from ChooseMint that caused production builds to fail

## Testing
- pnpm quasar build -m spa
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc2da036ec8330b67f553bec157dd4