### PR TITLE
Refactor Nutzap profile helpers to new read-only module

### DIFF
--- a/src/nutzap/profileEvents.ts
+++ b/src/nutzap/profileEvents.ts
@@ -1,0 +1,161 @@
+import { nip19 } from 'nostr-tools';
+import type { Tier } from './types';
+
+const HEX_64_REGEX = /^[0-9a-f]{64}$/i;
+
+type RawTier = {
+  id?: string;
+  title?: string;
+  price?: number | string;
+  price_sats?: number | string;
+  frequency?: Tier['frequency'];
+  description?: string;
+  media?: Array<string | { type?: string; url?: string }>;
+};
+
+type ReplaceableLike = {
+  kind?: number;
+  pubkey?: string;
+  created_at?: number;
+  tags?: any[];
+};
+
+function selectLatestByKey<T extends ReplaceableLike>(
+  events: readonly T[],
+  keyFn: (event: T) => string,
+): T | null {
+  const map = new Map<string, T>();
+
+  for (const event of events) {
+    if (!event || typeof event !== 'object') continue;
+    const { kind, pubkey } = event as ReplaceableLike;
+    if (typeof kind !== 'number' || typeof pubkey !== 'string') continue;
+    const key = keyFn(event);
+    if (!key) continue;
+    const current = map.get(key);
+    if (!current || ((event as any).created_at ?? 0) > ((current as any).created_at ?? 0)) {
+      map.set(key, event);
+    }
+  }
+
+  const latest = Array.from(map.values()).sort(
+    (a, b) => ((b as any).created_at ?? 0) - ((a as any).created_at ?? 0),
+  );
+  return latest[0] ?? null;
+}
+
+export function normalizeAuthor(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new Error('Author is required.');
+  }
+
+  if (HEX_64_REGEX.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+
+  if (trimmed.toLowerCase().startsWith('npub')) {
+    try {
+      const decoded = nip19.decode(trimmed);
+      if (decoded.type !== 'npub') {
+        throw new Error('Only npub identifiers are supported.');
+      }
+      const data = decoded.data;
+      let hex: string;
+      if (typeof data === 'string') {
+        hex = data;
+      } else if (data instanceof Uint8Array) {
+        hex = Array.from(data)
+          .map(b => b.toString(16).padStart(2, '0'))
+          .join('');
+      } else {
+        throw new Error('Invalid npub payload.');
+      }
+      if (!HEX_64_REGEX.test(hex)) {
+        throw new Error('Invalid npub payload.');
+      }
+      return hex.toLowerCase();
+    } catch (err) {
+      throw new Error(err instanceof Error ? err.message : 'Invalid npub');
+    }
+  }
+
+  throw new Error('Author must be a 64-character hex pubkey or npub.');
+}
+
+export function pickLatestReplaceable<T extends ReplaceableLike>(events: readonly T[]): T | null {
+  return selectLatestByKey(events, event => {
+    const kind = (event as any).kind;
+    const pubkey = String((event as any).pubkey ?? '').toLowerCase();
+    return typeof kind === 'number' && pubkey ? `${kind}:${pubkey}` : '';
+  });
+}
+
+export function pickLatestParamReplaceable<T extends ReplaceableLike>(events: readonly T[]): T | null {
+  return selectLatestByKey(events, event => {
+    const kind = (event as any).kind;
+    const pubkey = String((event as any).pubkey ?? '').toLowerCase();
+    const tags = Array.isArray((event as any).tags) ? (event as any).tags : [];
+    const dTag = tags.find(tag => Array.isArray(tag) && tag[0] === 'd');
+    const dValue = typeof dTag?.[1] === 'string' ? dTag[1] : '';
+    return typeof kind === 'number' && pubkey ? `${kind}:${pubkey}:${dValue}` : '';
+  });
+}
+
+function normalizeRawTier(raw: RawTier): Tier | null {
+  if (!raw) return null;
+  const id = typeof raw.id === 'string' && raw.id ? raw.id : '';
+  const title = typeof raw.title === 'string' ? raw.title : '';
+  const priceSource = raw.price ?? raw.price_sats ?? 0;
+  const price = Number(priceSource);
+  const frequency: Tier['frequency'] = ['one_time', 'monthly', 'yearly'].includes(
+    raw.frequency as Tier['frequency'],
+  )
+    ? (raw.frequency as Tier['frequency'])
+    : 'monthly';
+  const description = typeof raw.description === 'string' && raw.description ? raw.description : undefined;
+  let media: Tier['media'];
+  if (Array.isArray(raw.media)) {
+    const normalized = raw.media
+      .map(entry => {
+        if (!entry) return null;
+        if (typeof entry === 'string') {
+          return { type: 'link', url: entry };
+        }
+        const url = typeof entry.url === 'string' ? entry.url : '';
+        if (!url) return null;
+        const type = typeof entry.type === 'string' ? entry.type : 'link';
+        return { type, url };
+      })
+      .filter((item): item is { type: string; url: string } => !!item && !!item.url);
+    media = normalized.length ? normalized : undefined;
+  }
+
+  const globalCrypto = (globalThis as any)?.crypto;
+  return {
+    id: id || globalCrypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`,
+    title,
+    price: Number.isFinite(price) ? price : 0,
+    frequency,
+    description,
+    media,
+  };
+}
+
+export function parseTiersContent(content: string | undefined): Tier[] {
+  if (!content) return [];
+  try {
+    const parsed = JSON.parse(content) as { tiers?: RawTier[] } | RawTier[];
+    const rawTiers = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray(parsed?.tiers)
+        ? parsed.tiers
+        : [];
+    return rawTiers
+      .map(normalizeRawTier)
+      .filter((tier): tier is Tier => !!tier && !!tier.title);
+  } catch (err) {
+    console.warn('[nutzap] failed to parse tiers content', err);
+    return [];
+  }
+}

--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -563,13 +563,15 @@ import {
   FUNDSTR_REQ_URL,
   WS_FIRST_TIMEOUT_MS,
   HTTP_FALLBACK_TIMEOUT_MS,
+  publishTiers as publishTiersToRelay,
+  publishNostrEvent,
+} from './nutzap-profile/nostrHelpers';
+import {
   normalizeAuthor,
   pickLatestParamReplaceable,
   pickLatestReplaceable,
-  publishTiers as publishTiersToRelay,
-  publishNostrEvent,
   parseTiersContent,
-} from './nutzap-profile/nostrHelpers';
+} from 'src/nutzap/profileEvents';
 import { hasTierErrors, tierFrequencies, type TierFieldErrors } from './nutzap-profile/tierComposerUtils';
 import { fundstrRelayClient, RelayPublishError } from 'src/nutzap/relayClient';
 import { sanitizeRelayUrls } from 'src/utils/relay';

--- a/src/pages/nutzap-profile/__tests__/nostrHelpers.spec.ts
+++ b/src/pages/nutzap-profile/__tests__/nostrHelpers.spec.ts
@@ -359,14 +359,16 @@ describe('fundstrRelayClient', () => {
   });
 });
 import {
-  normalizeAuthor,
   isNostrEvent,
-  pickLatestReplaceable,
-  pickLatestParamReplaceable,
   FUNDSTR_REQ_URL,
   WS_FIRST_TIMEOUT_MS,
   HTTP_FALLBACK_TIMEOUT_MS,
 } from '../nostrHelpers';
+import {
+  normalizeAuthor,
+  pickLatestReplaceable,
+  pickLatestParamReplaceable,
+} from 'src/nutzap/profileEvents';
 
 describe('normalizeAuthor', () => {
   const hexKey = '5015f8a13449bcc6e21b54de0dc6be037ce8e90c96582343c5c8f668c67515e8';

--- a/src/pages/nutzap-profile/nostrHelpers.ts
+++ b/src/pages/nutzap-profile/nostrHelpers.ts
@@ -1,5 +1,4 @@
 import { NDKEvent } from '@nostr-dev-kit/ndk';
-import { nip19 } from 'nostr-tools';
 import type {
   FundstrRelayClient,
   FundstrRelayPublishAck,
@@ -14,6 +13,12 @@ import {
   HTTP_FALLBACK_TIMEOUT_MS,
 } from 'src/nutzap/relayEndpoints';
 import { getNutzapNdk } from 'src/nutzap/ndkInstance';
+export {
+  normalizeAuthor,
+  pickLatestParamReplaceable,
+  pickLatestReplaceable,
+  parseTiersContent,
+} from 'src/nutzap/profileEvents';
 
 export {
   FUNDSTR_WS_URL,
@@ -25,16 +30,6 @@ export {
 
 const HEX_64_REGEX = /^[0-9a-f]{64}$/i;
 const HEX_128_REGEX = /^[0-9a-f]{128}$/i;
-
-type RawTier = {
-  id?: string;
-  title?: string;
-  price?: number | string;
-  price_sats?: number | string;
-  frequency?: Tier['frequency'];
-  description?: string;
-  media?: Array<string | { type?: string; url?: string }>;
-};
 
 export type NostrEvent = {
   id: string;
@@ -69,45 +64,6 @@ export type NostrFilter = {
   limit?: number;
 };
 
-export function normalizeAuthor(input: string): string {
-  const trimmed = input.trim();
-  if (!trimmed) {
-    throw new Error('Author is required.');
-  }
-
-  if (HEX_64_REGEX.test(trimmed)) {
-    return trimmed.toLowerCase();
-  }
-
-  if (trimmed.toLowerCase().startsWith('npub')) {
-    try {
-      const decoded = nip19.decode(trimmed);
-      if (decoded.type !== 'npub') {
-        throw new Error('Only npub identifiers are supported.');
-      }
-      const data = decoded.data;
-      let hex: string;
-      if (typeof data === 'string') {
-        hex = data;
-      } else if (data instanceof Uint8Array) {
-        hex = Array.from(data)
-          .map(b => b.toString(16).padStart(2, '0'))
-          .join('');
-      } else {
-        throw new Error('Invalid npub payload.');
-      }
-      if (!HEX_64_REGEX.test(hex)) {
-        throw new Error('Invalid npub payload.');
-      }
-      return hex.toLowerCase();
-    } catch (err) {
-      throw new Error(err instanceof Error ? err.message : 'Invalid npub');
-    }
-  }
-
-  throw new Error('Author must be a 64-character hex pubkey or npub.');
-}
-
 export function isNostrEvent(e: any): e is NostrEvent {
   if (!e || typeof e !== 'object') return false;
   const { id, pubkey, created_at, kind, tags, content, sig } = e as Partial<NostrEvent>;
@@ -119,46 +75,6 @@ export function isNostrEvent(e: any): e is NostrEvent {
   if (typeof content !== 'string') return false;
   if (!HEX_128_REGEX.test(sig ?? '')) return false;
   return true;
-}
-
-function selectLatestByKey(events: any[], keyFn: (event: any) => string): any | null {
-  const map = new Map<string, any>();
-  for (const event of events ?? []) {
-    if (!event || typeof event !== 'object') continue;
-    const kind = (event as any).kind;
-    const pubkey = (event as any).pubkey;
-    if (typeof kind !== 'number' || typeof pubkey !== 'string') continue;
-    const key = keyFn(event);
-    if (!key) continue;
-    const current = map.get(key);
-    if (!current || ((event as any).created_at ?? 0) > ((current as any).created_at ?? 0)) {
-      map.set(key, event);
-    }
-  }
-
-  const latest = Array.from(map.values()).sort(
-    (a, b) => ((b as any).created_at ?? 0) - ((a as any).created_at ?? 0)
-  );
-  return latest[0] ?? null;
-}
-
-export function pickLatestReplaceable(events: any[]): any {
-  return selectLatestByKey(events, event => {
-    const kind = (event as any).kind;
-    const pubkey = String((event as any).pubkey ?? '').toLowerCase();
-    return typeof kind === 'number' && pubkey ? `${kind}:${pubkey}` : '';
-  });
-}
-
-export function pickLatestParamReplaceable(events: any[]): any {
-  return selectLatestByKey(events, event => {
-    const kind = (event as any).kind;
-    const pubkey = String((event as any).pubkey ?? '').toLowerCase();
-    const tags = Array.isArray((event as any).tags) ? (event as any).tags : [];
-    const dTag = tags.find(tag => Array.isArray(tag) && tag[0] === 'd');
-    const dValue = typeof dTag?.[1] === 'string' ? dTag[1] : '';
-    return typeof kind === 'number' && pubkey ? `${kind}:${pubkey}:${dValue}` : '';
-  });
 }
 
 function serializeMinimal(tiers: Tier[]) {
@@ -181,46 +97,6 @@ function serializeMinimal(tiers: Tier[]) {
       ...(media && media.length ? { media } : {}),
     };
   });
-}
-
-function normalizeRawTier(raw: RawTier): Tier | null {
-  if (!raw) return null;
-  const id = typeof raw.id === 'string' && raw.id ? raw.id : '';
-  const title = typeof raw.title === 'string' ? raw.title : '';
-  const priceSource = raw.price ?? raw.price_sats ?? 0;
-  const price = Number(priceSource);
-  const frequency: Tier['frequency'] = ['one_time', 'monthly', 'yearly'].includes(
-    raw.frequency as Tier['frequency']
-  )
-    ? (raw.frequency as Tier['frequency'])
-    : 'monthly';
-  const description = typeof raw.description === 'string' && raw.description ? raw.description : undefined;
-  let media: Tier['media'];
-  if (Array.isArray(raw.media)) {
-    const normalized = raw.media
-      .map(entry => {
-        if (!entry) return null;
-        if (typeof entry === 'string') {
-          return { type: 'link', url: entry };
-        }
-        const url = typeof entry.url === 'string' ? entry.url : '';
-        if (!url) return null;
-        const type = typeof entry.type === 'string' ? entry.type : 'link';
-        return { type, url };
-      })
-      .filter((item): item is { type: string; url: string } => !!item && !!item.url);
-    media = normalized.length ? normalized : undefined;
-  }
-
-  const globalCrypto = (globalThis as any)?.crypto;
-  return {
-    id: id || globalCrypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`,
-    title,
-    price: Number.isFinite(price) ? price : 0,
-    frequency,
-    description,
-    media,
-  };
 }
 
 async function signPublishTemplate(template: {
@@ -281,22 +157,4 @@ export async function publishTiers(
   ];
   const content = JSON.stringify({ v: 1, tiers: serializeMinimal(tiers) });
   return publishNostrEvent({ kind, tags, content }, options);
-}
-
-export function parseTiersContent(content: string | undefined): Tier[] {
-  if (!content) return [];
-  try {
-    const parsed = JSON.parse(content) as { tiers?: RawTier[] } | RawTier[];
-    const rawTiers = Array.isArray(parsed)
-      ? parsed
-      : Array.isArray(parsed?.tiers)
-        ? parsed.tiers
-        : [];
-    return rawTiers
-      .map(normalizeRawTier)
-      .filter((tier): tier is Tier => !!tier && !!tier.title);
-  } catch (err) {
-    console.warn('[nutzap] failed to parse tiers content', err);
-    return [];
-  }
 }

--- a/test/vitest/__tests__/NutzapProfilePage.spec.ts
+++ b/test/vitest/__tests__/NutzapProfilePage.spec.ts
@@ -199,6 +199,11 @@ vi.mock("../../../src/pages/nutzap-profile/nostrHelpers", () => ({
   FUNDSTR_REQ_URL: "https://relay.fundstr.me/req",
   WS_FIRST_TIMEOUT_MS: 5000,
   HTTP_FALLBACK_TIMEOUT_MS: 5000,
+  publishTiers: (...args: any[]) => ensureShared().publishTiersToRelayMock(...args),
+  publishNostrEvent: (...args: any[]) => ensureShared().publishNostrEventMock(...args),
+}));
+
+vi.mock("src/nutzap/profileEvents", () => ({
   normalizeAuthor: (input: string) => {
     const trimmed = input.trim();
     if (!trimmed) {
@@ -211,8 +216,6 @@ vi.mock("../../../src/pages/nutzap-profile/nostrHelpers", () => ({
   },
   pickLatestReplaceable: (...args: any[]) => pickLatestReplaceableMock(...args),
   pickLatestParamReplaceable: (...args: any[]) => pickLatestParamReplaceableMock(...args),
-  publishTiers: (...args: any[]) => ensureShared().publishTiersToRelayMock(...args),
-  publishNostrEvent: (...args: any[]) => ensureShared().publishNostrEventMock(...args),
   parseTiersContent: (json?: string | null) => {
     if (!json) {
       return [];


### PR DESCRIPTION
## Summary
- extract shared read-only Nutzap helper functions into `src/nutzap/profileEvents.ts`
- update Nutzap profile page and tests to import those helpers from the new module
- leave publishing helpers in `nostrHelpers` and re-export the read-only utilities for compatibility

## Testing
- pnpm test
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dc30dc52608330b3f92b1c3ca2bfd4