### PR TITLE
Refactor Nutzap profile helper imports

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -568,8 +568,8 @@ import {
 } from './nutzap-profile/nostrHelpers';
 import {
   normalizeAuthor,
-  pickLatestParamReplaceable,
   pickLatestReplaceable,
+  pickLatestParamReplaceable,
   parseTiersContent,
 } from 'src/nutzap/profileEvents';
 import { hasTierErrors, tierFrequencies, type TierFieldErrors } from './nutzap-profile/tierComposerUtils';

--- a/src/pages/nutzap-profile/nostrHelpers.ts
+++ b/src/pages/nutzap-profile/nostrHelpers.ts
@@ -13,12 +13,6 @@ import {
   HTTP_FALLBACK_TIMEOUT_MS,
 } from 'src/nutzap/relayEndpoints';
 import { getNutzapNdk } from 'src/nutzap/ndkInstance';
-export {
-  normalizeAuthor,
-  pickLatestParamReplaceable,
-  pickLatestReplaceable,
-  parseTiersContent,
-} from 'src/nutzap/profileEvents';
 
 export {
   FUNDSTR_WS_URL,


### PR DESCRIPTION
## Summary
- import Nutzap profile helper utilities directly from `src/nutzap/profileEvents`
- stop re-exporting the helper utilities from the Nutzap profile relay helper module

## Testing
- pnpm quasar build -m spa
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dc35859d0883308ce5480d1291e157