### PR TITLE
Fix Nutzap composer relay client initialization

### DIFF
--- a/src/pages/nutzap-profile/nostrHelpers.ts
+++ b/src/pages/nutzap-profile/nostrHelpers.ts
@@ -41,7 +41,7 @@ export type PublishNostrEventOptions = {
 
 let fundstrRelayClientPromise: Promise<FundstrRelayClient> | null = null;
 
-async function ensureFundstrRelayClient(): Promise<FundstrRelayClient> {
+export async function ensureFundstrRelayClient(): Promise<FundstrRelayClient> {
   if (!fundstrRelayClientPromise) {
     fundstrRelayClientPromise = import('src/nutzap/relayClient').then(
       module => module.fundstrRelayClient


### PR DESCRIPTION
## Summary
- export an `ensureFundstrRelayClient` helper so the relay client is loaded on demand
- lazily resolve the relay client before loading tiers/profile data or wiring subscriptions on the Nutzap profile page
- reuse the resolved client for publishing/subscription flows to avoid TDZ errors when the composer mounts

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dca69b312883308dfdeb8f37d268a0