### PR TITLE
refactor: redesign nutzap profile workspace layout

### DIFF
--- a/src/pages/nutzap-profile/AuthorMetadataPanel.vue
+++ b/src/pages/nutzap-profile/AuthorMetadataPanel.vue
@@ -374,6 +374,7 @@ const advancedEncryptionComplete = computed(() => props.advancedEncryptionComple
   display: flex;
   flex-direction: column;
   gap: 16px;
+  height: 100%;
 }
 
 .section-footer {

--- a/src/pages/nutzap-profile/ConnectionPanel.vue
+++ b/src/pages/nutzap-profile/ConnectionPanel.vue
@@ -176,6 +176,14 @@ const {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  height: 100%;
+}
+
+.connection-module .section-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 .connection-status-indicator {
@@ -210,6 +218,13 @@ const {
 .status-chip {
   text-transform: capitalize;
   font-weight: 600;
+}
+
+.connection-activity {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .timeline-entry {

--- a/src/pages/nutzap-profile/ReviewPublishCard.vue
+++ b/src/pages/nutzap-profile/ReviewPublishCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="section-card">
+  <section class="section-card review-card">
     <q-expansion-item
       v-model="internalOpen"
       switch-toggle-side
@@ -131,6 +131,33 @@ const tiersReady = computed(() => props.tiersReady);
 </script>
 
 <style scoped>
+.review-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+}
+
+.review-card :deep(.q-expansion-item__container) {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.review-card :deep(.q-expansion-item__content) {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.review-card .nested-section-body {
+  flex: 1;
+}
+
+.share-inline {
+  width: 100%;
+}
+
 .review-expansion.is-disabled {
   opacity: 0.6;
   pointer-events: none;

--- a/src/pages/nutzap-profile/TierComposerCard.vue
+++ b/src/pages/nutzap-profile/TierComposerCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="section-card">
+  <section class="section-card tier-composer-card">
     <div class="section-header section-header--with-status">
       <div class="section-header-primary">
         <div class="section-title text-subtitle1 text-weight-medium text-1">Compose tiers</div>
@@ -54,3 +54,18 @@ const emit = defineEmits<{
 
 const { tiers, frequencyOptions, showErrors, tiersReady } = toRefs(props);
 </script>
+
+<style scoped>
+.tier-composer-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+}
+
+.tier-composer-card .section-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+</style>


### PR DESCRIPTION
## Summary
- redesign the Nutzap profile workspace to show connection, author metadata, tiers, and publish controls together with inline readiness chips and share snapshot
- surface share link, mint/relay summaries, and diagnostics banner alongside the composer while reusing readiness validation for publish enablement
- update child panels to flex within the responsive grid so connection, metadata, tiers, and review cards align with the new layout

## Testing
- pnpm dev
- pnpm run build:pwa

------
https://chatgpt.com/codex/tasks/task_e_68dcb0aa2cac8330b7180d5e34ed244f