### PR TITLE
Fix Nutzap relay client initialization TDZ

### DIFF
--- a/test/relayClient.ensure.spec.ts
+++ b/test/relayClient.ensure.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { ensureFundstrRelayClient } from 'src/pages/nutzap-profile/nostrHelpers';
+import { fundstrRelayClient } from 'src/nutzap/relayClient';
+
+describe('ensureFundstrRelayClient', () => {
+  it('returns the shared FundstrRelayClient instance', async () => {
+    const client = await ensureFundstrRelayClient();
+    const second = await ensureFundstrRelayClient();
+    expect(client).toBe(fundstrRelayClient);
+    expect(second).toBe(fundstrRelayClient);
+  });
+});


### PR DESCRIPTION
## Summary
- store the shared relay client in a shallowRef so early loadAll calls no longer hit a TDZ
- keep the ensureRelayClient helper interface intact while updating NutzapProfilePage to use the ref-backed getter
- add a regression test to ensure the dynamic import still returns the singleton FundstrRelayClient instance

## Testing
- pnpm exec vitest run test/relayClient.ensure.spec.ts


------
https://chatgpt.com/codex/tasks/task_e_68dcb644f6d0833092a9495001f199c0