### PR TITLE
Improve Nutzap relay attention handling

### DIFF
--- a/docs/relay-access.md
+++ b/docs/relay-access.md
@@ -77,3 +77,15 @@ self-declared relays are queried before falling back to the public pool.
 `NetworkOnly` strategy. Together with the explicit `no-store` fetch options this
 guarantees that relay responses are never cached inside the service worker,
 which is required to always observe the most recent replaceable events.
+
+## QA checklist
+
+- Establish a successful websocket session and confirm the connection chip in
+  the Nutzap profile screen flips to **Connected** while a success entry lands in
+  the activity log.
+- Trigger repeated connection failures (e.g. point the workspace to an
+  unreachable relay) and confirm the inline warning beside the Connect button
+  summarizes the latest error and escalates to a “needs attention” state with
+  guidance to verify the workspace key or fall back to HTTP.
+- While “needs attention” is active, ensure publish controls are disabled and
+  the diagnostics banner nudges the operator to resolve the relay transport.

--- a/src/nutzap/onepage/useRelayConnection.ts
+++ b/src/nutzap/onepage/useRelayConnection.ts
@@ -483,6 +483,7 @@ const handleOpen = () => {
     status: readonly(status) as Readonly<Ref<RelayConnectionStatus>>,
     autoReconnect,
     activityLog: readonly(activityLog) as Readonly<Ref<RelayActivityEntry[]>>,
+    reconnectAttempts: readonly(reconnectAttempts) as Readonly<Ref<number>>,
     connect,
     disconnect,
     publishEvent,

--- a/src/pages/nutzap-profile/ConnectionPanel.vue
+++ b/src/pages/nutzap-profile/ConnectionPanel.vue
@@ -54,6 +54,25 @@
             :disable="!relaySupported"
             @update:model-value="value => emit('update:autoReconnect', value)"
           />
+          <div
+            v-if="latestAlertLabel"
+            class="connection-inline-hint row items-center"
+            :class="relayNeedsAttention ? 'connection-inline-hint--attention' : 'connection-inline-hint--warning'"
+          >
+            <q-icon
+              name="warning_amber"
+              size="16px"
+              :color="relayNeedsAttention ? 'negative' : 'warning'"
+              class="q-mr-xs"
+            />
+            <span class="connection-inline-hint__message">
+              {{
+                relayNeedsAttention
+                  ? `${latestAlertLabel} — verify your workspace key or try HTTP fallback.`
+                  : latestAlertLabel
+              }}
+            </span>
+          </div>
         </div>
       </div>
 
@@ -119,6 +138,8 @@ type Props = {
   statusColor: string;
   statusDotClass: string;
   latestActivity: RelayActivityEntry | null;
+  latestAlertLabel: string;
+  relayNeedsAttention: boolean;
   activityTimeline: RelayActivityEntry[];
   relayUrl: string;
   relayUrlValid: boolean;
@@ -134,6 +155,8 @@ const props = defineProps({
   statusColor: { type: String, required: true },
   statusDotClass: { type: String, required: true },
   latestActivity: { type: Object as PropType<RelayActivityEntry | null>, default: null },
+  latestAlertLabel: { type: String, default: '' },
+  relayNeedsAttention: { type: Boolean, default: false },
   activityTimeline: { type: Array as PropType<RelayActivityEntry[]>, default: () => [] },
   relayUrl: { type: String, required: true },
   relayUrlValid: { type: Boolean, required: true },
@@ -160,6 +183,8 @@ const {
   statusColor,
   statusDotClass,
   latestActivity,
+  latestAlertLabel,
+  relayNeedsAttention,
   activityTimeline,
   relayUrl,
   relayUrlValid,
@@ -197,6 +222,28 @@ const {
   border-radius: 9999px;
   background: var(--surface-contrast-border);
   transition: background-color 150ms ease;
+}
+
+.connection-inline-hint {
+  font-size: 12px;
+  line-height: 1.4;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--accent-200) 40%, transparent);
+}
+
+.connection-inline-hint--warning {
+  color: var(--text-2);
+}
+
+.connection-inline-hint--attention {
+  color: var(--q-negative);
+  background: color-mix(in srgb, var(--q-negative) 18%, transparent);
+}
+
+.connection-inline-hint__message {
+  white-space: normal;
 }
 
 .status-dot--positive {


### PR DESCRIPTION
## Summary
- add telemetry helpers for the latest relay alert and repeated reconnect attempts
- surface inline needs-attention guidance in the Nutzap connection panel and gate publish actions
- document the QA flow covering connection recovery and attention states

## Testing
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_e_68dcb8f94fec833086bed7c6567e88d7