### PR TITLE
Refactor Nutzap profile workflow layout

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -3,45 +3,108 @@
     <div class="nutzap-profile-container">
       <q-card class="profile-card bg-surface-2 shadow-4 full-width">
         <div class="profile-card-header">
-          <div class="status-banner text-1">
-            <div class="status-summary">
-              <span class="status-dot" :class="relayStatusDotClass" aria-hidden="true"></span>
-              <span class="status-label text-caption text-weight-medium">{{ relayStatusLabel }}</span>
+          <div class="profile-hero">
+            <div class="profile-hero__intro">
+              <div class="profile-hero__eyebrow text-caption text-2">Creator Nutzap workspace</div>
+              <h1 class="profile-hero__title text-h5 text-weight-bold text-1">Connect → configure → publish</h1>
+              <p class="profile-hero__description text-body1 text-2">
+                Move through the checklist to link your signer, configure payout details, and publish tiers without guesswork.
+              </p>
+              <div class="profile-hero__status text-caption">
+                <span class="status-dot" :class="relayStatusDotClass" aria-hidden="true"></span>
+                <span class="text-weight-medium text-1">{{ relayStatusLabel }}</span>
+                <span class="text-2">· Isolated relay: relay.fundstr.me (WS → HTTP fallback)</span>
+              </div>
             </div>
-            <div class="status-meta text-body2 text-2">
-              Isolated relay: relay.fundstr.me (WS → HTTP fallback)
+            <div class="profile-hero__actions">
+              <q-btn
+                class="profile-primary-cta"
+                color="primary"
+                unelevated
+                :loading="primaryCtaLoading"
+                :disable="primaryCtaDisabled"
+                :label="primaryCtaLabel"
+                @click="handlePrimaryCta"
+              />
+              <div class="profile-hero__next-step text-caption">
+                <template v-if="nextBlockingTask">
+                  <span class="text-2">Next step:</span>
+                  <span class="text-weight-medium text-1">{{ nextBlockingTask.label }}</span>
+                </template>
+                <template v-else>
+                  <span class="text-positive text-weight-medium">All systems ready — publish when you're set.</span>
+                </template>
+              </div>
+              <q-btn
+                outline
+                dense
+                icon="travel_explore"
+                class="profile-hero__explorer"
+                label="Open data explorer"
+                @click="requestExplorerOpen('toolbar')"
+              />
             </div>
           </div>
-          <div class="profile-readiness" role="status" aria-live="polite">
-            <div class="profile-readiness-title text-caption text-2">Workspace readiness</div>
-            <div class="profile-readiness-chips">
-              <q-chip
-                v-for="chip in readinessChips"
-                :key="chip.key"
-                dense
-                size="sm"
-                :icon="chip.icon"
-                :class="['profile-readiness-chip', `is-${chip.state}`]"
-              >
-                {{ chip.label }}
-              </q-chip>
+          <div class="readiness-checklist" role="status" aria-live="polite">
+            <div class="readiness-header">
+              <div class="readiness-title text-subtitle2 text-weight-medium text-1">Workspace readiness</div>
+              <div class="readiness-subtitle text-body2 text-2">Track blockers across connect, configure, and publish.</div>
+            </div>
+            <div class="readiness-body column q-gutter-lg">
+              <div v-for="(section, index) in readinessSections" :key="section.key" class="readiness-section">
+                <div class="readiness-section__header">
+                  <div class="readiness-section__index text-caption text-weight-medium">{{ index + 1 }}</div>
+                  <div>
+                    <div class="readiness-section__title text-body1 text-weight-medium text-1">{{ section.title }}</div>
+                    <div class="readiness-section__summary text-caption text-2">{{ section.summary }}</div>
+                  </div>
+                </div>
+                <q-list padding class="readiness-section__list">
+                  <q-item
+                    v-for="task in section.tasks"
+                    :key="task.key"
+                    dense
+                    class="readiness-task"
+                    :class="`is-${task.state}`"
+                  >
+                    <q-item-section avatar>
+                      <q-icon
+                        :name="task.icon"
+                        :color="task.state === 'ready' ? 'positive' : task.state === 'blocked' ? 'warning' : 'grey-6'"
+                      />
+                    </q-item-section>
+                    <q-item-section>
+                      <q-item-label class="text-body2 text-1">{{ task.label }}</q-item-label>
+                      <q-item-label v-if="task.detail" class="text-caption text-2">{{ task.detail }}</q-item-label>
+                    </q-item-section>
+                    <q-item-section v-if="task.state === 'blocked'" side>
+                      <q-btn
+                        flat
+                        size="sm"
+                        color="primary"
+                        :label="task.actionLabel"
+                        @click="handleReadinessTaskClick(section.key, task.key)"
+                      />
+                    </q-item-section>
+                  </q-item>
+                </q-list>
+              </div>
             </div>
           </div>
         </div>
         <div class="profile-card-body">
-          <div class="profile-content-toolbar">
-            <q-btn
-              outline
-              dense
-              icon="travel_explore"
-              class="data-explorer-trigger"
-              label="Open data explorer"
-              @click="requestExplorerOpen('toolbar')"
-            />
-          </div>
           <div class="profile-main-grid">
-            <ConnectionPanel
-              class="profile-grid-item profile-grid-item--connection"
+            <section ref="connectStageRef" class="profile-stage">
+              <header class="profile-stage__header">
+                <div class="profile-stage__eyebrow text-caption text-2">Step 1</div>
+                <div class="profile-stage__title text-subtitle1 text-weight-medium text-1">Connect</div>
+                <div class="profile-stage__summary text-body2 text-2">
+                  Link your signer and stabilize the Fundstr relay before configuring payouts.
+                </div>
+              </header>
+              <div class="profile-stage__content column q-gutter-lg">
+                <ConnectionPanel
+                  class="profile-grid-item profile-grid-item--connection"
               :status-label="relayStatusLabel"
               :status-color="relayStatusColor"
               :status-dot-class="relayStatusDotClass"
@@ -63,12 +126,76 @@
               @clear-activity="clearRelayActivity"
             />
 
-            <section class="section-card share-summary-card profile-grid-item profile-grid-item--share">
-              <div class="section-header">
-                <div class="section-title text-subtitle1 text-weight-medium text-1">Share &amp; snapshot</div>
-                <div class="section-subtitle text-body2 text-2">
-                  Copy your supporter-facing link and confirm key profile details.
+            <section ref="configureStageRef" class="profile-stage">
+              <header class="profile-stage__header">
+                <div class="profile-stage__eyebrow text-caption text-2">Step 2</div>
+                <div class="profile-stage__title text-subtitle1 text-weight-medium text-1">Configure</div>
+                <div class="profile-stage__summary text-body2 text-2">
+                  Capture trusted payout details and craft the supporter experience before publishing.
                 </div>
+              </header>
+              <div class="profile-stage__content column q-gutter-lg">
+                <AuthorMetadataPanel
+                  class="profile-grid-item profile-grid-item--author"
+                  :display-name="displayName"
+                  :picture-url="pictureUrl"
+                  :mints-text="mintsText"
+                  :relays-text="relaysText"
+                  :p2pk-priv="p2pkPriv"
+                  :p2pk-pub="p2pkPub"
+                  :p2pk-derived-pub="p2pkDerivedPub"
+                  :key-secret-hex="keySecretHex"
+                  :key-nsec="keyNsec"
+                  :key-public-hex="keyPublicHex"
+                  :key-npub="keyNpub"
+                  :key-import-value="keyImportValue"
+                  :using-store-identity="usingStoreIdentity"
+                  :connected-identity-summary="connectedIdentitySummary"
+                  :identity-basics-complete="identityBasicsComplete"
+                  :optional-metadata-complete="optionalMetadataComplete"
+                  :advanced-encryption-complete="advancedEncryptionComplete"
+                  :advanced-key-management-open="advancedKeyManagementOpen"
+                  @update:display-name="value => (displayName.value = value)"
+                  @update:picture-url="value => (pictureUrl.value = value)"
+                  @update:mints-text="value => (mintsText.value = value)"
+                  @update:relays-text="value => (relaysText.value = value)"
+                  @update:p2pk-priv="value => (p2pkPriv.value = value)"
+                  @update:p2pk-pub="value => (p2pkPub.value = value)"
+                  @update:key-import-value="value => (keyImportValue.value = value)"
+                  @update:advanced-key-management-open="value => (advancedKeyManagementOpen.value = value)"
+                  @request-derive-p2pk="deriveP2pkPublicKey"
+                  @request-generate-p2pk="generateP2pkKeypair"
+                  @request-generate-secret="generateNewSecret"
+                  @request-import-secret="importSecretKey"
+                />
+
+                <TierComposerCard
+                  class="profile-grid-item profile-grid-item--tiers"
+                  :tiers="tiers"
+                  :frequency-options="tierFrequencyOptions"
+                  :show-errors="showTierValidation"
+                  :tiers-ready="tiersReady"
+                  @update:tiers="value => (tiers.value = value)"
+                  @validation-changed="handleTierValidation"
+                />
+              </div>
+            </section>
+
+            <section ref="publishStageRef" class="profile-stage">
+              <header class="profile-stage__header">
+                <div class="profile-stage__eyebrow text-caption text-2">Step 3</div>
+                <div class="profile-stage__title text-subtitle1 text-weight-medium text-1">Publish</div>
+                <div class="profile-stage__summary text-body2 text-2">
+                  Review the public snapshot and push your tiers live when everything looks right.
+                </div>
+              </header>
+              <div class="profile-stage__content column q-gutter-lg">
+                <section class="section-card share-summary-card profile-grid-item profile-grid-item--share">
+                  <div class="section-header">
+                    <div class="section-title text-subtitle1 text-weight-medium text-1">Share &amp; snapshot</div>
+                    <div class="section-subtitle text-body2 text-2">
+                      Copy your supporter-facing link and confirm key profile details.
+                    </div>
               </div>
               <div class="section-body column q-gutter-lg">
                 <div class="share-link-block" data-testid="profile-share-block">
@@ -205,83 +332,41 @@
               </div>
             </section>
 
-            <AuthorMetadataPanel
-              class="profile-grid-item profile-grid-item--author"
-              :display-name="displayName"
-              :picture-url="pictureUrl"
-              :mints-text="mintsText"
-              :relays-text="relaysText"
-              :p2pk-priv="p2pkPriv"
-              :p2pk-pub="p2pkPub"
-              :p2pk-derived-pub="p2pkDerivedPub"
-              :key-secret-hex="keySecretHex"
-              :key-nsec="keyNsec"
-              :key-public-hex="keyPublicHex"
-              :key-npub="keyNpub"
-              :key-import-value="keyImportValue"
-              :using-store-identity="usingStoreIdentity"
-              :connected-identity-summary="connectedIdentitySummary"
-              :identity-basics-complete="identityBasicsComplete"
-              :optional-metadata-complete="optionalMetadataComplete"
-              :advanced-encryption-complete="advancedEncryptionComplete"
-              :advanced-key-management-open="advancedKeyManagementOpen"
-              @update:display-name="value => (displayName.value = value)"
-              @update:picture-url="value => (pictureUrl.value = value)"
-              @update:mints-text="value => (mintsText.value = value)"
-              @update:relays-text="value => (relaysText.value = value)"
-              @update:p2pk-priv="value => (p2pkPriv.value = value)"
-              @update:p2pk-pub="value => (p2pkPub.value = value)"
-              @update:key-import-value="value => (keyImportValue.value = value)"
-              @update:advanced-key-management-open="value => (advancedKeyManagementOpen.value = value)"
-              @request-derive-p2pk="deriveP2pkPublicKey"
-              @request-generate-p2pk="generateP2pkKeypair"
-              @request-generate-secret="generateNewSecret"
-              @request-import-secret="importSecretKey"
-            />
+                <section class="section-card tier-kind-card profile-grid-item profile-grid-item--tier-kind">
+                  <div class="section-header">
+                    <div class="section-title text-subtitle1 text-weight-medium text-1">Tier strategy</div>
+                    <div class="section-subtitle text-body2 text-2">
+                      Publishing as {{ tierKindLabel }} — parameterized replaceable ["d", "tiers"].
+                    </div>
+                  </div>
+                  <div class="section-body column q-gutter-md">
+                    <div class="row items-center justify-between wrap q-gutter-sm">
+                      <div class="text-subtitle2 text-1">Tier kind</div>
+                      <q-btn-toggle
+                        v-model="tierKind"
+                        :options="tierKindOptions"
+                        dense
+                        toggle-color="primary"
+                        unelevated
+                      />
+                    </div>
+                  </div>
+                </section>
 
-            <section class="section-card tier-kind-card profile-grid-item profile-grid-item--tier-kind">
-              <div class="section-header">
-                <div class="section-title text-subtitle1 text-weight-medium text-1">Tier strategy</div>
-                <div class="section-subtitle text-body2 text-2">
-                  Publishing as {{ tierKindLabel }} — parameterized replaceable ["d", "tiers"].
-                </div>
-              </div>
-              <div class="section-body column q-gutter-md">
-                <div class="row items-center justify-between wrap q-gutter-sm">
-                  <div class="text-subtitle2 text-1">Tier kind</div>
-                  <q-btn-toggle
-                    v-model="tierKind"
-                    :options="tierKindOptions"
-                    dense
-                    toggle-color="primary"
-                    unelevated
-                  />
-                </div>
+                <ReviewPublishCard
+                  class="profile-grid-item profile-grid-item--publish"
+                  v-model:open="reviewPublishSectionOpen"
+                  :tiers-ready="tiersReady"
+                  :tiers-json-preview="tiersJsonPreview"
+                  :publish-disabled="publishDisabled"
+                  :publishing="publishingAll"
+                  :public-profile-url="publicProfileUrl"
+                  :last-publish-info="lastPublishInfo"
+                  @publish="publishAll"
+                  @copy-link="copy(publicProfileUrl)"
+                />
               </div>
             </section>
-
-            <TierComposerCard
-              class="profile-grid-item profile-grid-item--tiers"
-              :tiers="tiers"
-              :frequency-options="tierFrequencyOptions"
-              :show-errors="showTierValidation"
-              :tiers-ready="tiersReady"
-              @update:tiers="value => (tiers.value = value)"
-              @validation-changed="handleTierValidation"
-            />
-
-            <ReviewPublishCard
-              class="profile-grid-item profile-grid-item--publish"
-              v-model:open="reviewPublishSectionOpen"
-              :tiers-ready="tiersReady"
-              :tiers-json-preview="tiersJsonPreview"
-              :publish-disabled="publishDisabled"
-              :publishing="publishingAll"
-              :public-profile-url="publicProfileUrl"
-              :last-publish-info="lastPublishInfo"
-              @publish="publishAll"
-              @copy-link="copy(publicProfileUrl)"
-            />
           </div>
         </div>
       </q-card>
@@ -314,7 +399,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, shallowRef, watch, type Ref } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch, type Ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { useQuasar } from 'quasar';
 import { useEventBus, useLocalStorage } from '@vueuse/core';
@@ -483,16 +568,28 @@ const publicProfileUrl = computed(() => {
 });
 
 const reviewPublishSectionOpen = ref(false);
+const connectStageRef = ref<HTMLElement | null>(null);
+const configureStageRef = ref<HTMLElement | null>(null);
+const publishStageRef = ref<HTMLElement | null>(null);
 
-type ReadinessChipState = 'ready' | 'todo' | 'optional';
-type ReadinessChipKey = 'authorKey' | 'identity' | 'mint' | 'p2pk' | 'tiers';
+type ReadinessTaskState = 'ready' | 'blocked' | 'info';
+type ReadinessSectionKey = 'connect' | 'configure' | 'publish';
 
-type ReadinessChip = {
-  key: ReadinessChipKey;
+type ReadinessTask = {
+  key: string;
   label: string;
-  state: ReadinessChipState;
+  detail?: string;
+  state: ReadinessTaskState;
   icon: string;
-  required: boolean;
+  actionLabel: string;
+  blocker: boolean;
+};
+
+type ReadinessSection = {
+  key: ReadinessSectionKey;
+  title: string;
+  summary: string;
+  tasks: ReadinessTask[];
 };
 
 type DiagnosticsAttention = {
@@ -878,6 +975,10 @@ const optionalMetadataComplete = computed(() => mintList.value.length > 0);
 
 const advancedEncryptionComplete = computed(() => p2pkPub.value.trim().length > 0);
 
+const signerReady = computed(() => Boolean(signer.value));
+
+const relayHealthy = computed(() => relayIsConnected.value && !relayNeedsAttention.value);
+
 const relayList = computed(() => {
   const entries = relaysText.value
     .split('\n')
@@ -1006,75 +1107,211 @@ const tierFrequencyOptions = computed(() =>
   }))
 );
 
-const authorKeyReady = computed(() => authorInput.value.trim().length > 0);
+const readinessSections = computed<ReadinessSection[]>(() => {
+  const connectTasks: ReadinessTask[] = [
+    {
+      key: 'signer',
+      label: signerReady.value ? 'Signer linked' : 'Link your signer',
+      detail: signerReady.value
+        ? connectedIdentitySummary.value || 'Fundstr signer connected.'
+        : 'Connect a signer to fetch profile data and publish updates.',
+      state: signerReady.value ? 'ready' : 'blocked',
+      icon: signerReady.value ? 'task_alt' : 'vpn_key_off',
+      actionLabel: signerReady.value ? 'Review signer' : 'Link signer',
+      blocker: true,
+    },
+    {
+      key: 'relay',
+      label: relayHealthy.value ? 'Relay responding' : relayStatusLabel.value,
+      detail: relayHealthy.value
+        ? latestRelayActivity.value?.message
+          ? `Latest: ${latestRelayActivity.value.message}`
+          : 'Fundstr relay is ready.'
+        : relayNeedsAttention.value
+          ? 'Verify the workspace key or try the HTTP fallback.'
+          : 'Initialize the workspace relay before publishing.',
+      state: relayHealthy.value ? 'ready' : 'blocked',
+      icon: relayHealthy.value ? 'wifi' : 'wifi_off',
+      actionLabel: relayHealthy.value ? 'Review relay' : 'Reconnect',
+      blocker: true,
+    },
+  ];
 
-const readinessChips = computed<ReadinessChip[]>(() => {
-  const entries = [
-    {
-      key: 'authorKey',
-      ready: authorKeyReady.value,
-      required: true,
-      readyLabel: 'Signer ready',
-      actionLabel: 'Link signer',
-      readyIcon: 'task_alt',
-      actionIcon: 'vpn_key_off',
-    },
-    {
-      key: 'identity',
-      ready: identityBasicsComplete.value,
-      required: false,
-      readyLabel: 'Identity noted',
-      actionLabel: 'Identity optional',
-      readyIcon: 'badge',
-      actionIcon: 'tips_and_updates',
-    },
+  const configureTasks: ReadinessTask[] = [
     {
       key: 'mint',
-      ready: optionalMetadataComplete.value,
-      required: true,
-      readyLabel: 'Mint configured',
-      actionLabel: 'Add mint',
-      readyIcon: 'payments',
-      actionIcon: 'add_card',
+      label: optionalMetadataComplete.value ? 'Trusted mints added' : 'Add at least one trusted mint',
+      detail: optionalMetadataComplete.value
+        ? `${mintList.value.length} trusted mint${mintList.value.length === 1 ? '' : 's'} configured.`
+        : 'Trusted mints are required so supporters know where to zap.',
+      state: optionalMetadataComplete.value ? 'ready' : 'blocked',
+      icon: optionalMetadataComplete.value ? 'payments' : 'add_card',
+      actionLabel: optionalMetadataComplete.value ? 'Review mints' : 'Add mint',
+      blocker: true,
     },
     {
       key: 'p2pk',
-      ready: advancedEncryptionComplete.value,
-      required: true,
-      readyLabel: 'P2PK ready',
-      actionLabel: 'Add P2PK pointer',
-      readyIcon: 'key',
-      actionIcon: 'key_off',
+      label: advancedEncryptionComplete.value ? 'P2PK pointer ready' : 'Add a P2PK pointer',
+      detail: advancedEncryptionComplete.value
+        ? 'Encrypted payouts can be decrypted by your signer.'
+        : 'A P2PK pointer is required so supporters can deliver Nutzaps.',
+      state: advancedEncryptionComplete.value ? 'ready' : 'blocked',
+      icon: advancedEncryptionComplete.value ? 'key' : 'key_off',
+      actionLabel: advancedEncryptionComplete.value ? 'Review pointer' : 'Add pointer',
+      blocker: true,
     },
     {
       key: 'tiers',
-      ready: tiersReady.value,
-      required: true,
-      readyLabel: 'Tiers validated',
-      actionLabel: 'Review tiers',
-      readyIcon: 'task_alt',
-      actionIcon: 'playlist_add',
+      label: tiersReady.value ? 'Tiers validated' : 'Draft at least one tier',
+      detail: tiersReady.value
+        ? `${tiers.value.length} tier${tiers.value.length === 1 ? '' : 's'} ready to publish.`
+        : 'Each published profile needs at least one valid tier.',
+      state: tiersReady.value ? 'ready' : 'blocked',
+      icon: tiersReady.value ? 'playlist_add_check' : 'playlist_add',
+      actionLabel: tiersReady.value ? 'Review tiers' : 'Add tier',
+      blocker: true,
     },
-  ] as const;
+    {
+      key: 'identity',
+      label: identityBasicsComplete.value
+        ? 'Identity details added'
+        : 'Optional: personalize with a display name or avatar',
+      detail: identityBasicsComplete.value
+        ? 'Supporters will see your display name and picture.'
+        : 'Skip for now or personalize your profile later.',
+      state: identityBasicsComplete.value ? 'ready' : 'info',
+      icon: identityBasicsComplete.value ? 'badge' : 'tips_and_updates',
+      actionLabel: identityBasicsComplete.value ? 'Edit identity' : 'Add identity',
+      blocker: false,
+    },
+  ];
 
-  return entries.map(entry =>
-    entry.ready
-      ? {
-          key: entry.key,
-          label: entry.readyLabel,
-          state: 'ready' as ReadinessChipState,
-          icon: entry.readyIcon,
-          required: entry.required,
-        }
-      : {
-          key: entry.key,
-          label: entry.actionLabel,
-          state: entry.required ? ('todo' as ReadinessChipState) : ('optional' as ReadinessChipState),
-          icon: entry.actionIcon,
-          required: entry.required,
-        }
-  );
+  const publishReady = !publishDisabled.value;
+  const publishTasks: ReadinessTask[] = [
+    {
+      key: 'review',
+      label: publishReady ? 'Ready to publish' : 'Complete checklist before publishing',
+      detail: publishReady
+        ? lastPublishInfo.value || 'Review JSON preview before sending to the relay.'
+        : 'Resolve outstanding blockers to enable publishing.',
+      state: publishReady ? 'ready' : 'blocked',
+      icon: publishReady ? 'rocket_launch' : 'hourglass_bottom',
+      actionLabel: publishReady ? 'Open review' : 'See blockers',
+      blocker: !publishReady,
+    },
+    {
+      key: 'share',
+      label: publicProfileUrl.value ? 'Shareable link available' : 'Link appears after first publish',
+      detail: publicProfileUrl.value
+        ? publicProfileUrl.value
+        : 'Publish once to generate your public link.',
+      state: publicProfileUrl.value ? 'info' : 'info',
+      icon: publicProfileUrl.value ? 'link' : 'visibility_off',
+      actionLabel: publicProfileUrl.value ? 'Copy link' : 'Learn more',
+      blocker: false,
+    },
+  ];
+
+  return [
+    {
+      key: 'connect',
+      title: 'Connect',
+      summary: 'Link your signer and confirm the relay is responding.',
+      tasks: connectTasks,
+    },
+    {
+      key: 'configure',
+      title: 'Configure',
+      summary: 'Set up trusted payout details and supporter tiers.',
+      tasks: configureTasks,
+    },
+    {
+      key: 'publish',
+      title: 'Publish',
+      summary: 'Review the output and share your profile with supporters.',
+      tasks: publishTasks,
+    },
+  ];
 });
+
+type BlockingTask = {
+  sectionKey: ReadinessSectionKey;
+  key: string;
+  label: string;
+  actionLabel: string;
+};
+
+const nextBlockingTask = computed<BlockingTask | null>(() => {
+  for (const section of readinessSections.value) {
+    for (const task of section.tasks) {
+      if (task.blocker && task.state !== 'ready') {
+        return {
+          sectionKey: section.key,
+          key: task.key,
+          label: task.label,
+          actionLabel: task.actionLabel,
+        };
+      }
+    }
+  }
+  return null;
+});
+
+const primaryCtaLabel = computed(() => {
+  if (!publishDisabled.value) {
+    return 'Publish to Fundstr relay';
+  }
+  return nextBlockingTask.value?.actionLabel || 'Review checklist';
+});
+
+const primaryCtaLoading = computed(() => publishingAll.value);
+
+const primaryCtaDisabled = computed(() => publishingAll.value);
+
+function scrollToStage(section: ReadinessSectionKey) {
+  const target =
+    section === 'connect'
+      ? connectStageRef.value
+      : section === 'configure'
+        ? configureStageRef.value
+        : publishStageRef.value;
+  if (target) {
+    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+}
+
+function handleReadinessTaskClick(sectionKey: ReadinessSectionKey, taskKey: string) {
+  scrollToStage(sectionKey);
+
+  if (sectionKey === 'connect') {
+    if (taskKey === 'signer') {
+      ensureSharedSignerInitialized();
+    } else if (taskKey === 'relay') {
+      handleRelayConnect();
+    }
+  } else if (sectionKey === 'configure') {
+    if (taskKey === 'tiers') {
+      showTierValidation.value = true;
+    }
+  } else if (sectionKey === 'publish') {
+    reviewPublishSectionOpen.value = true;
+  }
+}
+
+function handlePrimaryCta() {
+  if (!publishDisabled.value) {
+    reviewPublishSectionOpen.value = true;
+    void nextTick(() => scrollToStage('publish'));
+    return;
+  }
+
+  if (nextBlockingTask.value) {
+    handleReadinessTaskClick(nextBlockingTask.value.sectionKey, nextBlockingTask.value.key);
+    return;
+  }
+
+  scrollToStage('publish');
+}
 
 const tiersJsonPreview = computed(() => JSON.stringify(buildTiersJsonPayload(tiers.value), null, 2));
 
@@ -1709,23 +1946,38 @@ onBeforeUnmount(() => {
 .profile-card-header {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 24px;
 }
 
-.status-banner {
+.profile-hero {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 16px 18px;
+  gap: 16px;
+  padding: 20px 24px;
   border: 1px solid var(--surface-contrast-border);
   border-radius: 16px;
   background: color-mix(in srgb, var(--surface-2) 94%, transparent);
 }
 
-.status-summary {
+.profile-hero__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 620px;
+}
+
+.profile-hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-2);
+}
+
+.profile-hero__status {
   display: flex;
   align-items: center;
   gap: 8px;
+  font-size: 0.85rem;
+  color: var(--text-2);
 }
 
 .status-dot {
@@ -1752,89 +2004,141 @@ onBeforeUnmount(() => {
   background: var(--surface-contrast-border);
 }
 
-.status-label {
-  text-transform: capitalize;
-}
-
-.status-meta {
-  font-size: 13px;
-  line-height: 1.4;
-  color: var(--text-2);
-}
-
-.profile-readiness {
+.profile-hero__actions {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 16px 18px;
-  border: 1px solid var(--surface-contrast-border);
-  border-radius: 16px;
-  background: color-mix(in srgb, var(--surface-2) 96%, transparent);
+  align-items: flex-start;
+  gap: 12px;
 }
 
-.profile-readiness-title {
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  letter-spacing: 0.04em;
+.profile-primary-cta {
+  min-width: 220px;
+}
+
+.profile-hero__next-step {
   color: var(--text-2);
 }
 
-.profile-readiness-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+.profile-hero__explorer {
+  align-self: flex-start;
 }
 
-.profile-readiness-chip {
-  --q-chip-padding: 2px 10px;
-  font-size: 0.75rem;
-  border-radius: 999px;
-  background-color: var(--chip-bg);
-  color: var(--chip-text);
+.readiness-checklist {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px 24px;
   border: 1px solid var(--surface-contrast-border);
-  font-weight: 600;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--surface-2) 94%, transparent);
+}
+
+.readiness-header {
+  display: flex;
+  flex-direction: column;
   gap: 4px;
 }
 
-.profile-readiness-chip :deep(.q-chip__icon) {
-  font-size: 16px;
+.readiness-title {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
-.profile-readiness-chip.is-ready {
-  background-color: var(--accent-500);
-  color: var(--text-inverse);
-  border-color: var(--accent-500);
+.readiness-body {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
-.profile-readiness-chip.is-todo {
-  background-color: color-mix(in srgb, var(--accent-200) 35%, transparent);
-  color: var(--accent-600);
-  border-color: color-mix(in srgb, var(--accent-200) 55%, transparent);
+.readiness-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.profile-readiness-chip.is-optional {
-  background-color: color-mix(in srgb, var(--surface-2) 85%, transparent);
+.readiness-section__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.readiness-section__index {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--surface-2) 82%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--text-2);
-  border-color: var(--surface-contrast-border);
+}
+
+.readiness-section__list {
+  border: 1px solid var(--surface-contrast-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface-1) 98%, transparent);
+}
+
+.readiness-task {
+  border-bottom: 1px solid color-mix(in srgb, var(--surface-contrast-border) 55%, transparent);
+}
+
+.readiness-task:last-child {
+  border-bottom: none;
+}
+
+.readiness-task.is-ready {
+  background: color-mix(in srgb, var(--surface-2) 90%, transparent);
+}
+
+.readiness-task.is-blocked {
+  background: color-mix(in srgb, var(--accent-200) 20%, transparent);
+}
+
+.readiness-task.is-info {
+  background: transparent;
 }
 
 .profile-card-body {
   display: flex;
   flex-direction: column;
-  gap: 24px;
-}
-
-.profile-content-toolbar {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.data-explorer-trigger {
-  align-self: flex-end;
+  gap: 32px;
 }
 
 .profile-main-grid {
-  display: grid;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.profile-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile-stage__header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--surface-contrast-border);
+}
+
+.profile-stage__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-2);
+}
+
+.profile-stage__summary {
+  color: var(--text-2);
+  line-height: 1.5;
+}
+
+.profile-stage__content {
+  display: flex;
+  flex-direction: column;
   gap: 24px;
 }
 
@@ -2040,90 +2344,58 @@ onBeforeUnmount(() => {
   padding: 0 20px 20px;
 }
 
-@media (min-width: 600px) {
-  .profile-readiness {
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-}
-
 @media (min-width: 768px) {
   .profile-card-header {
     flex-direction: row;
     align-items: stretch;
+    gap: 24px;
   }
 
-  .status-banner,
-  .profile-readiness {
+  .profile-hero {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
     flex: 1 1 0%;
   }
 
-  .profile-main-grid {
-    grid-template-columns: repeat(6, minmax(0, 1fr));
+  .profile-hero__actions {
+    align-items: flex-end;
+    text-align: right;
   }
 
-  .profile-grid-item--connection {
-    grid-column: span 6;
+  .profile-hero__explorer {
+    align-self: flex-end;
   }
 
-  .profile-grid-item--share {
-    grid-column: span 6;
+  .readiness-checklist {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 24px;
+    flex: 1 1 0%;
   }
 
-  .profile-grid-item--author {
-    grid-column: span 6;
+  .readiness-body {
+    flex: 1 1 0%;
   }
 
-  .profile-grid-item--tier-kind {
-    grid-column: span 6;
-  }
-
-  .profile-grid-item--tiers {
-    grid-column: span 6;
-  }
-
-  .profile-grid-item--publish {
-    grid-column: span 6;
+  .readiness-section__list {
+    background: color-mix(in srgb, var(--surface-1) 96%, transparent);
   }
 
   .share-summary-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
   }
 }
 
 @media (min-width: 1200px) {
   .profile-main-grid {
-    grid-template-columns: repeat(12, minmax(0, 1fr));
+    gap: 40px;
   }
 
-  .profile-grid-item--connection {
-    grid-column: span 5;
-  }
-
-  .profile-grid-item--share {
-    grid-column: span 7;
-  }
-
-  .profile-grid-item--author {
-    grid-column: span 6;
-  }
-
-  .profile-grid-item--tier-kind {
-    grid-column: span 6;
-  }
-
-  .profile-grid-item--tiers {
-    grid-column: span 7;
-  }
-
-  .profile-grid-item--publish {
-    grid-column: span 5;
-  }
-
-  .profile-readiness {
-    align-items: flex-start;
+  .profile-stage__content {
+    gap: 32px;
   }
 }
 </style>

--- a/src/pages/nutzap-profile/AuthorMetadataPanel.vue
+++ b/src/pages/nutzap-profile/AuthorMetadataPanel.vue
@@ -1,159 +1,75 @@
 <template>
   <section class="section-card author-profile-card">
     <div class="section-header">
-      <div class="section-title text-subtitle1 text-weight-medium text-1">Author metadata</div>
+      <div class="section-title text-subtitle1 text-weight-medium text-1">Payout &amp; identity</div>
       <div class="section-subtitle text-body2 text-2">
-        Compose profile details that will be published alongside your tiers.
+        Capture the payout details supporters rely on before publishing.
       </div>
     </div>
-    <div class="section-body">
-      <div class="nested-sections">
-        <q-expansion-item
-          v-model="identityOpen"
-          switch-toggle-side
-          dense
-          expand-separator
-          class="nested-section"
-        >
-          <template #header>
-            <div class="nested-header">
-              <div class="nested-header__titles">
-                <div class="nested-title text-body1 text-weight-medium text-1">Identity basics</div>
-                <div class="nested-subtitle text-caption">
-                  Provide a display name and avatar for your payment profile (kind 10019).
-                  These are optional but help supporters recognize you.
-                </div>
-              </div>
-              <q-chip
-                dense
-                size="sm"
-                :color="identityBasicsComplete ? 'positive' : 'grey-6'"
-                :text-color="identityBasicsComplete ? 'white' : 'black'"
-                class="status-chip"
-              >
-                {{ identityBasicsComplete ? 'Added' : 'Optional' }}
-              </q-chip>
-            </div>
-          </template>
-          <div class="nested-section-body column q-gutter-md">
-            <q-input
-              :model-value="displayName"
-              label="Display Name"
-              dense
-              filled
-              @update:model-value="value => emit('update:displayName', value)"
-            />
-            <q-input
-              :model-value="pictureUrl"
-              label="Picture URL"
-              dense
-              filled
-              @update:model-value="value => emit('update:pictureUrl', value)"
-            />
-            <div class="text-caption text-2">
-              Display name and picture are nice-to-have details, but leaving them blank won’t block publishing.
-            </div>
-          </div>
-        </q-expansion-item>
+    <div class="section-body column q-gutter-lg">
+      <div class="author-guide" :class="`author-guide--${guideState}`">
+        <q-icon :name="guideIcon" size="24px" />
+        <div class="author-guide__copy">
+          <div class="author-guide__label text-caption text-2">{{ guideLabel }}</div>
+          <div class="author-guide__message text-body2 text-1">{{ guideMessage }}</div>
+        </div>
+      </div>
 
-        <q-expansion-item
-          v-model="metadataOpen"
-          switch-toggle-side
+      <div class="author-required column q-gutter-sm">
+        <div class="author-required__heading text-body1 text-weight-medium text-1">Trusted mints</div>
+        <q-input
+          :model-value="mintsText"
+          type="textarea"
+          label="Trusted mints (one per line)"
           dense
-          expand-separator
-          class="nested-section"
-        >
-          <template #header>
-            <div class="nested-header">
-              <div class="nested-header__titles">
-                <div class="nested-title text-body1 text-weight-medium text-1">Optional relay &amp; mint metadata</div>
-                <div class="nested-subtitle text-caption">
-                  List trusted mints (required for publishing) and add optional relay hints.
-                </div>
-              </div>
-              <q-chip
-                dense
-                size="sm"
-                :color="optionalMetadataComplete ? 'positive' : 'warning'"
-                :text-color="optionalMetadataComplete ? 'white' : 'black'"
-                class="status-chip"
-              >
-                {{ optionalMetadataComplete ? 'Ready' : 'Required' }}
-              </q-chip>
-            </div>
-          </template>
-          <div class="nested-section-body column q-gutter-md">
-            <q-input
-              :model-value="mintsText"
-              type="textarea"
-              label="Trusted Mints (one per line)"
-              dense
-              filled
-              autogrow
-              @update:model-value="value => emit('update:mintsText', value)"
-            />
-            <q-input
-              :model-value="relaysText"
-              type="textarea"
-              label="Relay Hints (optional, one per line)"
-              dense
-              filled
-              autogrow
-              @update:model-value="value => emit('update:relaysText', value)"
-            />
-          </div>
-        </q-expansion-item>
+          filled
+          autogrow
+          @update:model-value="value => emit('update:mintsText', value)"
+        />
+        <div class="text-caption text-2">Add at least one mint so backers know where to deliver Nutzaps.</div>
+      </div>
 
-        <q-expansion-item
-          v-model="encryptionOpen"
-          switch-toggle-side
+      <div class="author-required column q-gutter-sm">
+        <div class="author-required__heading text-body1 text-weight-medium text-1">P2PK pointer</div>
+        <q-input
+          :model-value="p2pkPub"
+          label="P2PK public key (hex)"
           dense
-          expand-separator
-          class="nested-section"
-        >
+          filled
+          @update:model-value="value => emit('update:p2pkPub', value)"
+        />
+        <div class="text-caption text-2">
+          This pointer is published with your tiers so supporters can send encrypted payouts.
+        </div>
+        <q-expansion-item v-model="pointerToolsOpen" dense switch-toggle-side class="nested-section nested-section--inline">
           <template #header>
             <div class="nested-header">
-              <div class="nested-header__titles">
-                <div class="nested-title text-body1 text-weight-medium text-1">Advanced encryption</div>
-                <div class="nested-subtitle text-caption">
-                  Generate or derive the P2PK pointer required for Nutzap payments.
-                </div>
-              </div>
-              <q-chip
-                dense
-                size="sm"
-                :color="advancedEncryptionComplete ? 'positive' : 'warning'"
-                :text-color="advancedEncryptionComplete ? 'white' : 'black'"
-                class="status-chip"
-              >
-                {{ advancedEncryptionComplete ? 'Ready' : 'Required' }}
-              </q-chip>
+              <div class="nested-title text-body2 text-weight-medium text-1">Need to derive or generate a pointer?</div>
             </div>
           </template>
-          <div class="nested-section-body column q-gutter-md">
+          <div class="nested-section-body column q-gutter-sm">
             <q-input
               :model-value="p2pkPriv"
-              label="P2PK Private Key (hex)"
+              label="P2PK private key (hex)"
               dense
               filled
               autocomplete="off"
               @update:model-value="value => emit('update:p2pkPriv', value)"
             />
-            <div class="row q-gutter-sm">
-              <q-btn color="primary" label="Derive Public Key" @click="emit('request-derive-p2pk')" />
-              <q-btn color="primary" outline label="Generate Keypair" @click="emit('request-generate-p2pk')" />
+            <div class="row q-gutter-sm wrap">
+              <q-btn color="primary" label="Derive public key" @click="emit('request-derive-p2pk')" />
+              <q-btn color="primary" outline label="Generate keypair" @click="emit('request-generate-p2pk')" />
+              <q-btn
+                v-if="!usingStoreIdentity"
+                color="primary"
+                outline
+                label="Manage dedicated key"
+                @click="emit('update:advancedKeyManagementOpen', true)"
+              />
             </div>
             <q-input
-              :model-value="p2pkPub"
-              label="P2PK Public Key"
-              dense
-              filled
-              @update:model-value="value => emit('update:p2pkPub', value)"
-            />
-            <q-input
               :model-value="p2pkDerivedPub"
-              label="Derived P2PK Public Key"
-              type="textarea"
+              label="Derived P2PK public key"
               dense
               filled
               readonly
@@ -162,39 +78,72 @@
           </div>
         </q-expansion-item>
       </div>
+
+      <q-expansion-item v-model="identityOpen" dense switch-toggle-side class="nested-section">
+        <template #header>
+          <div class="nested-header">
+            <div class="nested-title text-body2 text-weight-medium text-1">Profile identity (optional)</div>
+            <div class="nested-subtitle text-caption text-2">
+              Add a display name or avatar so supporters recognize you.
+            </div>
+          </div>
+        </template>
+        <div class="nested-section-body column q-gutter-md">
+          <q-input
+            :model-value="displayName"
+            label="Display name"
+            dense
+            filled
+            @update:model-value="value => emit('update:displayName', value)"
+          />
+          <q-input
+            :model-value="pictureUrl"
+            label="Picture URL"
+            dense
+            filled
+            @update:model-value="value => emit('update:pictureUrl', value)"
+          />
+        </div>
+      </q-expansion-item>
+
+      <q-expansion-item v-model="relayHintsOpen" dense switch-toggle-side class="nested-section">
+        <template #header>
+          <div class="nested-header">
+            <div class="nested-title text-body2 text-weight-medium text-1">Relay hints (optional)</div>
+            <div class="nested-subtitle text-caption text-2">
+              Suggest additional relays your supporters can query.
+            </div>
+          </div>
+        </template>
+        <div class="nested-section-body column q-gutter-md">
+          <q-input
+            :model-value="relaysText"
+            type="textarea"
+            label="Relay hints (one per line)"
+            dense
+            filled
+            autogrow
+            @update:model-value="value => emit('update:relaysText', value)"
+          />
+        </div>
+      </q-expansion-item>
     </div>
 
     <div class="section-footer q-mt-lg">
-      <div class="column q-gutter-sm">
+      <div class="column q-gutter-xs">
         <div class="text-body1 text-1">
           <template v-if="usingStoreIdentity">
-            Connected as
-            <span class="text-weight-medium">{{ connectedIdentitySummary || 'Fundstr identity' }}</span>
+            Connected as <span class="text-weight-medium">{{ connectedIdentitySummary || 'Fundstr identity' }}</span>
           </template>
           <template v-else>Using a dedicated Nutzap key</template>
         </div>
         <div v-if="usingStoreIdentity" class="text-body2 text-2">
-          Your Fundstr signer is ready to publish Nutzap events. Stick with this shared identity unless you need a
-          separate persona or want to keep a secret key off the global store.
-        </div>
-        <div v-if="usingStoreIdentity" class="text-body2 text-2">
-          Choose a dedicated key when delegating publishing, testing against staging relays, or isolating collectibles
-          under a different author.
+          Your Fundstr signer is ready to publish Nutzap events. Switch to a dedicated key when you need a separate
+          persona or want to keep secrets outside the global store.
         </div>
         <div v-else class="text-body2 text-2">
-          This workspace is scoped to a standalone key, so Nutzap activity stays independent from your Fundstr profile.
+          This workspace is scoped to a standalone key, keeping Nutzap activity independent from your Fundstr profile.
         </div>
-      </div>
-      <div v-if="!usingStoreIdentity" class="row items-center q-gutter-sm q-mt-sm">
-        <q-btn
-          color="primary"
-          outline
-          label="Manage dedicated key"
-          @click="emit('update:advancedKeyManagementOpen', true)"
-        />
-      </div>
-      <div v-else class="text-caption text-2 q-mt-sm">
-        Dedicated key tools become available when no Fundstr signer is connected.
       </div>
     </div>
 
@@ -308,9 +257,9 @@ const emit = defineEmits<{
   (e: 'request-import-secret'): void;
 }>();
 
-const identityOpen = ref(true);
-const metadataOpen = ref(true);
-const encryptionOpen = ref(false);
+const identityOpen = ref(false);
+const pointerToolsOpen = ref(false);
+const relayHintsOpen = ref(false);
 
 watch(
   () => props.identityBasicsComplete,
@@ -323,13 +272,10 @@ watch(
 );
 
 watch(
-  () => props.optionalMetadataComplete,
+  () => props.relaysText,
   value => {
-    if (value) {
-      metadataOpen.value = true;
-    }
-    if (value && !props.advancedEncryptionComplete) {
-      encryptionOpen.value = true;
+    if (value.trim().length > 0) {
+      relayHintsOpen.value = true;
     }
   },
   { immediate: true }
@@ -338,9 +284,7 @@ watch(
 watch(
   () => props.advancedEncryptionComplete,
   value => {
-    if (value) {
-      encryptionOpen.value = true;
-    }
+    pointerToolsOpen.value = !value;
   },
   { immediate: true }
 );
@@ -364,9 +308,38 @@ const keyPublicHex = computed(() => props.keyPublicHex);
 const keyNpub = computed(() => props.keyNpub);
 const usingStoreIdentity = computed(() => props.usingStoreIdentity);
 const connectedIdentitySummary = computed(() => props.connectedIdentitySummary);
-const identityBasicsComplete = computed(() => props.identityBasicsComplete);
-const optionalMetadataComplete = computed(() => props.optionalMetadataComplete);
-const advancedEncryptionComplete = computed(() => props.advancedEncryptionComplete);
+
+const guide = computed(() => {
+  if (!props.optionalMetadataComplete) {
+    return {
+      state: 'warning',
+      icon: 'add_card',
+      label: 'Next required step',
+      message: 'Add at least one trusted mint to publish your tiers.',
+    } as const;
+  }
+
+  if (!props.advancedEncryptionComplete) {
+    return {
+      state: 'warning',
+      icon: 'key',
+      label: 'Next required step',
+      message: 'Generate or paste a P2PK pointer so Nutzaps route to you.',
+    } as const;
+  }
+
+  return {
+    state: 'ready',
+    icon: 'task_alt',
+    label: 'Metadata ready',
+    message: 'All required payout details are in place.',
+  } as const;
+});
+
+const guideState = computed(() => guide.value.state);
+const guideIcon = computed(() => guide.value.icon);
+const guideLabel = computed(() => guide.value.label);
+const guideMessage = computed(() => guide.value.message);
 </script>
 
 <style scoped>
@@ -375,6 +348,58 @@ const advancedEncryptionComplete = computed(() => props.advancedEncryptionComple
   flex-direction: column;
   gap: 16px;
   height: 100%;
+}
+
+.author-guide {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--surface-contrast-border);
+}
+
+.author-guide--warning {
+  background: color-mix(in srgb, var(--accent-200) 20%, transparent);
+}
+
+.author-guide--ready {
+  background: color-mix(in srgb, var(--surface-2) 92%, transparent);
+}
+
+.author-guide__label {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.author-required {
+  border: 1px solid var(--surface-contrast-border);
+  border-radius: 12px;
+  padding: 16px;
+  background: color-mix(in srgb, var(--surface-2) 96%, transparent);
+}
+
+.author-required__heading {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.nested-section {
+  border: 1px solid var(--surface-contrast-border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.nested-section--inline {
+  margin-top: 8px;
+}
+
+.nested-section :deep(.q-expansion-item__container) {
+  background: transparent;
+}
+
+.nested-section :deep(.q-expansion-item__content) {
+  padding: 0 16px 16px;
 }
 
 .section-footer {

--- a/src/pages/nutzap-profile/ConnectionPanel.vue
+++ b/src/pages/nutzap-profile/ConnectionPanel.vue
@@ -1,9 +1,9 @@
 <template>
   <section class="section-card connection-module">
     <div class="section-header">
-      <div class="section-title text-subtitle1 text-weight-medium text-1">Connection</div>
+      <div class="section-title text-subtitle1 text-weight-medium text-1">Relay connection</div>
       <div class="section-subtitle text-body2 text-2">
-        Control the live WebSocket session used for publishing events and monitor relay activity.
+        Verify the Fundstr relay before configuring payouts. We'll surface alerts if anything needs attention.
       </div>
     </div>
     <div class="section-body column q-gutter-lg">

--- a/src/pages/nutzap-profile/ReviewPublishCard.vue
+++ b/src/pages/nutzap-profile/ReviewPublishCard.vue
@@ -38,9 +38,14 @@
           readonly
           spellcheck="false"
         />
+        <div v-if="tiersReady" class="review-ready-hint text-body2 text-2">
+          Final check: confirm the payload below, then publish to the Fundstr relay.
+        </div>
         <div class="row justify-end q-gutter-sm">
           <q-btn
             color="primary"
+            unelevated
+            class="primary-publish-btn"
             label="Publish profile &amp; tiers"
             :disable="publishDisabled"
             :loading="publishing"
@@ -156,6 +161,17 @@ const tiersReady = computed(() => props.tiersReady);
 
 .share-inline {
   width: 100%;
+}
+
+.primary-publish-btn {
+  min-width: 220px;
+}
+
+.review-ready-hint {
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--surface-contrast-border);
+  background: color-mix(in srgb, var(--surface-2) 94%, transparent);
 }
 
 .review-expansion.is-disabled {

--- a/src/pages/nutzap-profile/TierComposerCard.vue
+++ b/src/pages/nutzap-profile/TierComposerCard.vue
@@ -2,9 +2,9 @@
   <section class="section-card tier-composer-card">
     <div class="section-header section-header--with-status">
       <div class="section-header-primary">
-        <div class="section-title text-subtitle1 text-weight-medium text-1">Compose tiers</div>
+        <div class="section-title text-subtitle1 text-weight-medium text-1">Tiers &amp; benefits</div>
         <div class="section-subtitle text-body2 text-2">
-          Draft pricing, benefits, and cadence before publishing downstream.
+          Outline pricing, cadence, and supporter perks. We'll flag anything that still needs attention.
         </div>
       </div>
       <q-chip
@@ -14,10 +14,13 @@
         :text-color="tiersReady ? 'white' : 'black'"
         class="status-chip"
       >
-        {{ tiersReady ? 'Valid' : 'Needs review' }}
+        {{ tiersReady ? 'Validated' : 'Incomplete' }}
       </q-chip>
     </div>
     <div class="section-body column q-gutter-md">
+      <div v-if="!tiersReady" class="tier-composer-hint text-caption text-2">
+        Add at least one tier with a title, price, and frequency to unlock publishing.
+      </div>
       <TierComposer
         :tiers="tiers"
         :frequency-options="frequencyOptions"
@@ -67,5 +70,11 @@ const { tiers, frequencyOptions, showErrors, tiersReady } = toRefs(props);
   flex: 1;
   display: flex;
   flex-direction: column;
+}
+
+.tier-composer-hint {
+  padding: 12px 16px;
+  border: 1px dashed var(--surface-contrast-border);
+  border-radius: 12px;
 }
 </style>


### PR DESCRIPTION
## Summary
- restructure the Nutzap profile workspace with a hero banner, readiness checklist, and step-based layout
- streamline author metadata inputs with inline required fields, guided messaging, and optional expansions
- refresh tier composition and publish review cards so the next action and primary CTA are easier to spot

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dcd4cff8ec8330a325cda543a2551e