### PR TITLE
Fix creator studio routing and nav access

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -90,6 +90,15 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
+      <q-item v-if="!isGuest" clickable @click="gotoCreatorStudio">
+        <q-item-section avatar>
+          <q-icon name="dashboard_customize" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>Creator Studio</q-item-label>
+          <q-item-label caption>Manage Nutzap profile &amp; tiers</q-item-label>
+        </q-item-section>
+      </q-item>
       <q-item v-if="!isGuest" clickable @click="gotoMyProfile">
         <q-item-section avatar>
           <q-icon name="person" />
@@ -226,6 +235,7 @@ const gotoWallet = () => goto("/wallet");
 const gotoSettings = () => goto("/settings");
 const gotoFindCreators = () => goto("/find-creators");
 const gotoCreatorHub = () => goto("/creator-hub");
+const gotoCreatorStudio = () => goto("/creator-studio");
 const gotoMyProfile = () => goto("/my-profile");
 const gotoBuckets = () => goto("/buckets");
 const gotoSubscriptions = () => goto("/subscriptions");

--- a/src/pages/CreatorStudioPage.vue
+++ b/src/pages/CreatorStudioPage.vue
@@ -437,6 +437,7 @@ import { useEventBus, useLocalStorage } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { getPublicKey as getSecpPublicKey, utils as secpUtils } from '@noble/secp256k1';
+import { useRouter } from 'vue-router';
 import TierComposer from './nutzap-profile/TierComposer.vue';
 import NutzapExplorerPanel from 'src/nutzap/onepage/NutzapExplorerPanel.vue';
 import { notifyError, notifySuccess, notifyWarning } from 'src/js/notify';


### PR DESCRIPTION
## Summary
- import Vue Router inside Creator Studio to restore router-dependent computed state
- surface the Creator Studio entry in the main navigation drawer for authenticated users

## Testing
- pnpm test *(fails: Vitest CLI does not support the --runInBand option)*

------
https://chatgpt.com/codex/tasks/task_e_68dcedeb57a8833092cbb8578f6b1e10