### PR TITLE
fix: import useQuasar in creator studio

### DIFF
--- a/src/pages/CreatorStudioPage.vue
+++ b/src/pages/CreatorStudioPage.vue
@@ -438,6 +438,7 @@ import { storeToRefs } from 'pinia';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 import { getPublicKey as getSecpPublicKey, utils as secpUtils } from '@noble/secp256k1';
 import { useRouter } from 'vue-router';
+import { useQuasar } from 'quasar';
 import TierComposer from './nutzap-profile/TierComposer.vue';
 import NutzapExplorerPanel from 'src/nutzap/onepage/NutzapExplorerPanel.vue';
 import { notifyError, notifySuccess, notifyWarning } from 'src/js/notify';


### PR DESCRIPTION
## Summary
- import `useQuasar` in Creator Studio so the Quasar instance is available

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68dcf0edb1748330895f8dc53017b9ca