### PR TITLE
Fix Creator Studio explorer dialog bindings

### DIFF
--- a/src/pages/CreatorStudioPage.vue
+++ b/src/pages/CreatorStudioPage.vue
@@ -413,11 +413,11 @@
     </div>
 
     <q-dialog
-      v-model="dataExplorerDialogOpen.value"
-      :position="explorerDialogPosition.value"
+      v-model="dataExplorerDialogOpen"
+      :position="explorerDialogPosition"
       :maximized="$q.screen.lt.md"
-      :transition-show="explorerDialogTransitions.value.show"
-      :transition-hide="explorerDialogTransitions.value.hide"
+      :transition-show="explorerDialogTransitions.show"
+      :transition-hide="explorerDialogTransitions.hide"
     >
       <q-card :class="['studio-explorer', $q.screen.lt.md ? 'is-mobile' : '']" class="bg-surface-2 text-1">
         <div class="studio-explorer__header">


### PR DESCRIPTION
## Summary
- fix the Creator Studio data explorer dialog bindings so transition config is always defined

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68dcf2e016bc83309f906773e248feb7