### PR TITLE
Normalize Nutzap relay URL handling

### DIFF
--- a/src/pages/CreatorStudioPage.vue
+++ b/src/pages/CreatorStudioPage.vue
@@ -45,8 +45,14 @@
               label="Relay URL (WS)"
               dense
               filled
-              :error="!relayUrlInputValid.value"
-              error-message="Enter a valid wss:// relay"
+              :hint="relayUrlInputState.value === 'warning' ? relayUrlInputMessage.value : ''"
+              :hide-hint="relayUrlInputState.value !== 'warning'"
+              :error="relayUrlInputState.value === 'error' || !relayUrlInputValid.value"
+              :error-message="
+                relayUrlInputState.value === 'error'
+                  ? relayUrlInputMessage.value
+                  : 'Enter a valid wss:// relay'
+              "
             />
             <div class="row items-center justify-between wrap q-gutter-sm">
               <q-toggle v-model="relayAutoReconnect.value" label="Auto reconnect" />
@@ -731,6 +737,8 @@ const {
   relayIsConnected,
   relayUrlInput,
   relayUrlInputValid,
+  relayUrlInputState,
+  relayUrlInputMessage,
   relayStatusLabel,
   relayStatusColor,
   relayStatusDotClass,

--- a/test/vitest/__tests__/CreatorStudioPage.publish.spec.ts
+++ b/test/vitest/__tests__/CreatorStudioPage.publish.spec.ts
@@ -44,6 +44,8 @@ type SharedMocks = {
   relayNeedsAttention: ReturnType<typeof ref<boolean>>;
   relayUrlInput: ReturnType<typeof ref<string>>;
   relayUrlInputValid: ReturnType<typeof ref<boolean>>;
+  relayUrlInputState: ReturnType<typeof ref<'warning' | 'error' | null>>;
+  relayUrlInputMessage: ReturnType<typeof ref<string>>;
   relayStatusLabel: ReturnType<typeof ref<string>>;
   relayStatusColor: ReturnType<typeof ref<string>>;
   relayStatusDotClass: ReturnType<typeof ref<string>>;
@@ -95,6 +97,8 @@ function ensureShared(): SharedMocks {
       relayNeedsAttention,
       relayUrlInput: ref('wss://relay.fundstr.me'),
       relayUrlInputValid: ref(true),
+      relayUrlInputState: ref(null),
+      relayUrlInputMessage: ref(''),
       relayStatusLabel: ref('Connected'),
       relayStatusColor: ref('positive'),
       relayStatusDotClass: ref('status-dot--positive'),
@@ -179,6 +183,8 @@ vi.mock('src/nutzap/useNutzapRelayTelemetry', () => ({
       relayIsConnected: state.relayIsConnected,
       relayUrlInput: state.relayUrlInput,
       relayUrlInputValid: state.relayUrlInputValid,
+      relayUrlInputState: state.relayUrlInputState,
+      relayUrlInputMessage: state.relayUrlInputMessage,
       relayStatusLabel: state.relayStatusLabel,
       relayStatusColor: state.relayStatusColor,
       relayStatusDotClass: state.relayStatusDotClass,

--- a/test/vitest/__tests__/useNutzapRelayTelemetry.spec.ts
+++ b/test/vitest/__tests__/useNutzapRelayTelemetry.spec.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, nextTick, ref } from 'vue';
+
+import { useNutzapRelayTelemetry } from '../../../src/nutzap/useNutzapRelayTelemetry';
+import { FUNDSTR_WS_URL } from '../../../src/nutzap/relayEndpoints';
+
+let relayConnectionUrl = ref(FUNDSTR_WS_URL);
+let relayConnectionStatus = ref<'idle' | 'connected'>('idle');
+let relayAutoReconnect = ref(false);
+let relayActivity = ref([] as any[]);
+let relayReconnectAttempts = ref(0);
+let relayIsConnected = ref(false);
+let connectRelayMock = vi.fn();
+let disconnectRelayMock = vi.fn();
+let publishEventMock = vi.fn();
+let clearActivityMock = vi.fn();
+let logActivityMock = vi.fn();
+
+vi.mock('../../../src/nutzap/onepage/useRelayConnection', () => ({
+  useRelayConnection: () => ({
+    relayUrl: relayConnectionUrl,
+    status: relayConnectionStatus,
+    autoReconnect: relayAutoReconnect,
+    activityLog: relayActivity,
+    reconnectAttempts: relayReconnectAttempts,
+    connect: connectRelayMock,
+    disconnect: disconnectRelayMock,
+    publishEvent: publishEventMock,
+    clearActivity: clearActivityMock,
+    logActivity: logActivityMock,
+    isSupported: true,
+    isConnected: computed(() => relayIsConnected.value),
+  }),
+}));
+
+describe('useNutzapRelayTelemetry', () => {
+  beforeEach(() => {
+    relayConnectionUrl = ref(FUNDSTR_WS_URL);
+    relayConnectionStatus = ref('idle');
+    relayAutoReconnect = ref(false);
+    relayActivity = ref([]);
+    relayReconnectAttempts = ref(0);
+    relayIsConnected = ref(false);
+    connectRelayMock = vi.fn();
+    disconnectRelayMock = vi.fn();
+    publishEventMock = vi.fn();
+    clearActivityMock = vi.fn();
+    logActivityMock = vi.fn();
+  });
+
+  it('treats sanitized relay URLs as valid and surfaces normalization warnings', async () => {
+    const telemetry = useNutzapRelayTelemetry();
+
+    telemetry.relayUrlInput.value = 'http://relay.example.com/';
+
+    expect(telemetry.relayUrlInputValid.value).toBe(true);
+
+    telemetry.applyRelayUrlInput();
+    await nextTick();
+
+    expect(telemetry.relayConnectionUrl.value).toBe('wss://relay.example.com');
+    expect(telemetry.relayUrlInput.value).toBe('wss://relay.example.com');
+    expect(telemetry.relayUrlInputState.value).toBe('warning');
+    expect(telemetry.relayUrlInputMessage.value).toContain('wss://relay.example.com');
+  });
+
+  it('falls back to the default relay when input is blank', async () => {
+    const telemetry = useNutzapRelayTelemetry();
+
+    telemetry.relayUrlInput.value = '   ';
+
+    telemetry.applyRelayUrlInput();
+    await nextTick();
+
+    expect(telemetry.relayConnectionUrl.value).toBe(FUNDSTR_WS_URL);
+    expect(telemetry.relayUrlInput.value).toBe(FUNDSTR_WS_URL);
+    expect(telemetry.relayUrlInputState.value).toBe('warning');
+    expect(telemetry.relayUrlInputMessage.value).toContain(FUNDSTR_WS_URL);
+  });
+
+  it('flags invalid relay URLs and restores the default endpoint', async () => {
+    const telemetry = useNutzapRelayTelemetry();
+
+    telemetry.relayUrlInput.value = '//';
+
+    expect(telemetry.relayUrlInputValid.value).toBe(false);
+
+    telemetry.applyRelayUrlInput();
+    await nextTick();
+
+    expect(telemetry.relayConnectionUrl.value).toBe(FUNDSTR_WS_URL);
+    expect(telemetry.relayUrlInput.value).toBe(FUNDSTR_WS_URL);
+    expect(telemetry.relayUrlInputState.value).toBe('error');
+    expect(telemetry.relayUrlInputMessage.value).toContain(FUNDSTR_WS_URL);
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize Nutzap relay URL input and surface normalization/error feedback in the telemetry composable
- update the Creator Studio relay field to display enforced URLs and contextual messages
- add regression coverage for the telemetry URL normalization logic

## Testing
- pnpm vitest run test/vitest/__tests__/useNutzapRelayTelemetry.spec.ts test/vitest/__tests__/CreatorStudioPage.publish.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcfa80f7448330b76aee24360eca36