### PR TITLE
Improve creator studio author fallbacks

### DIFF
--- a/src/nutzap/useNutzapSignerWorkspace.ts
+++ b/src/nutzap/useNutzapSignerWorkspace.ts
@@ -77,8 +77,11 @@ export function useNutzapSignerWorkspace(
     [pubkey, storeNpub],
     ([newPubkey, storeNpubValue]) => {
       const normalizedPubkey = typeof newPubkey === 'string' ? newPubkey.trim().toLowerCase() : '';
-      const encodedNpub = normalizedPubkey ? storeNpubValue || safeEncodeNpub(normalizedPubkey) : '';
-      const displayValue = encodedNpub || normalizedPubkey;
+      const normalizedStoreNpub = typeof storeNpubValue === 'string' ? storeNpubValue.trim() : '';
+      const encodedNpub = normalizedPubkey
+        ? normalizedStoreNpub || safeEncodeNpub(normalizedPubkey)
+        : '';
+      const displayValue = normalizedPubkey ? encodedNpub || normalizedPubkey : normalizedStoreNpub;
 
       if (normalizedPubkey) {
         keyPublicHex.value = normalizedPubkey;
@@ -89,19 +92,35 @@ export function useNutzapSignerWorkspace(
         lastSyncedAuthorHex.value = normalizedPubkey;
         lastSyncedAuthorDisplay.value = displayValue;
         options.onSignerActivated?.();
-      } else {
+        return;
+      }
+
+      if (normalizedStoreNpub) {
+        if (!authorInput.value || authorInput.value === lastSyncedAuthorDisplay.value) {
+          authorInput.value = normalizedStoreNpub;
+        }
+        if (!keyNpub.value || keyNpub.value === lastSyncedAuthorDisplay.value) {
+          keyNpub.value = normalizedStoreNpub;
+        }
         if (keyPublicHex.value === lastSyncedAuthorHex.value) {
           keyPublicHex.value = '';
         }
-        if (keyNpub.value === lastSyncedAuthorDisplay.value) {
-          keyNpub.value = '';
-        }
-        if (authorInput.value === lastSyncedAuthorDisplay.value) {
-          authorInput.value = '';
-        }
         lastSyncedAuthorHex.value = '';
-        lastSyncedAuthorDisplay.value = '';
+        lastSyncedAuthorDisplay.value = normalizedStoreNpub;
+        return;
       }
+
+      if (keyPublicHex.value === lastSyncedAuthorHex.value) {
+        keyPublicHex.value = '';
+      }
+      if (keyNpub.value === lastSyncedAuthorDisplay.value) {
+        keyNpub.value = '';
+      }
+      if (authorInput.value === lastSyncedAuthorDisplay.value) {
+        authorInput.value = '';
+      }
+      lastSyncedAuthorHex.value = '';
+      lastSyncedAuthorDisplay.value = '';
     },
     { immediate: true }
   );


### PR DESCRIPTION
## Summary
- default the creator author field from the route npub, stored identity, or active signer before loading data
- update the signer workspace to keep author data when only the stored npub is available
- allow publishing when any identity source is present by relaxing the author blocker check

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dd167125288330bb6600a2dd78bc7a