### PR TITLE
feat: sync wallet with creator studio P2PK

### DIFF
--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -2,6 +2,7 @@ export const LOCAL_STORAGE_KEYS = {
   CASHU_P2PKKEYS: "cashu.P2PKKeys",
   CASHU_ACTIVEMINTURL: "cashu.activeMintUrl",
   CASHU_ACTIVEUNIT: "cashu.activeUnit",
+  CASHU_ACTIVE_P2PK: "cashu.activeP2pk",
   CASHU_BUCKETRULES: "cashu.bucketRules",
   CASHU_BUCKETS: "cashu.buckets",
   CASHU_DEXIE_MIGRATED: "cashu.dexie.migrated",


### PR DESCRIPTION
## Summary
- persist the active Cashu pointer in wallet state and clear dependent payment data when it changes
- ensure Creator Studio updates the wallet’s active P2PK when keys are selected or stored
- extend unit tests for wallet and Creator Studio to cover the new behaviour

## Testing
- pnpm vitest run test/wallet-store.spec.ts test/vitest/__tests__/CreatorStudioPage.publish.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd670fe55083309632896b5ce3d0b0