### PR TITLE
Improve HTTP fallback diagnostics

### DIFF
--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -563,6 +563,22 @@ function flagDiagnosticsAttention(
   };
 }
 
+function maybeFlagHttpFallbackTimeout(error: unknown) {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+  if (!message) {
+    return;
+  }
+  if (message.toLowerCase().includes('http fallback timed out')) {
+    const detail = `${message}. Confirm ${FUNDSTR_REQ_URL} is reachable or adjust VITE_NUTZAP_PRIMARY_RELAY_HTTP.`;
+    flagDiagnosticsAttention('relay', detail, 'warning');
+  }
+}
+
 watch(diagnosticsAttention, value => {
   if (value) {
     helpBannerDismissed.value = false;
@@ -1253,6 +1269,7 @@ async function loadTiers(authorHex: string) {
     applyTiersEvent(latest);
   } catch (err) {
     console.error('[nutzap] failed to load tiers', err);
+    maybeFlagHttpFallbackTimeout(err);
     const message = err instanceof Error ? err.message : String(err);
     notifyError(message);
     throw err instanceof Error ? err : new Error(message);
@@ -1278,6 +1295,7 @@ async function loadProfile(authorHex: string) {
     applyProfileEvent(latest);
   } catch (err) {
     console.error('[nutzap] failed to load profile', err);
+    maybeFlagHttpFallbackTimeout(err);
     const message = err instanceof Error ? err.message : String(err);
     notifyError(message);
     throw err instanceof Error ? err : new Error(message);

--- a/test/vitest/__tests__/NutzapProfilePage.spec.ts
+++ b/test/vitest/__tests__/NutzapProfilePage.spec.ts
@@ -198,7 +198,7 @@ vi.mock("../../../src/pages/nutzap-profile/nostrHelpers", () => ({
   FUNDSTR_WS_URL: "wss://relay.fundstr.me",
   FUNDSTR_REQ_URL: "https://relay.fundstr.me/req",
   WS_FIRST_TIMEOUT_MS: 5000,
-  HTTP_FALLBACK_TIMEOUT_MS: 5000,
+  HTTP_FALLBACK_TIMEOUT_MS: 8000,
   publishTiers: (...args: any[]) => ensureShared().publishTiersToRelayMock(...args),
   publishNostrEvent: (...args: any[]) => ensureShared().publishNostrEventMock(...args),
 }));


### PR DESCRIPTION
## Summary
- log the computed HTTP fallback URL and include it in thrown errors so operators can spot duplicate /req suffixes
- normalize NUTZAP_RELAY_HTTP so /req and /event aren’t appended twice and lengthen the fallback timeout
- surface relay diagnostics when the HTTP fallback times out in Creator Studio and Nutzap Profile

## Testing
- pnpm vitest run test/vitest/__tests__/NutzapProfilePage.spec.ts *(fails: upstream vue-i18n mock is incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_68de202898888330ad48b6aa5b88a9b3