### PR TITLE
Normalize query handling in Nutzap explorer panel

### DIFF
--- a/src/nutzap/onepage/NutzapExplorerPanel.vue
+++ b/src/nutzap/onepage/NutzapExplorerPanel.vue
@@ -208,6 +208,7 @@ const authorModel = computed({
 });
 
 const query = ref('');
+const normalizedQuery = computed(() => (typeof query.value === 'string' ? query.value : ''));
 const mode = ref<'profiles' | 'notes' | 'address'>('profiles');
 const limit = ref<number>(20);
 const daysBack = ref<number>(7);
@@ -232,7 +233,10 @@ const HEX_64 = /^[0-9a-f]{64}$/i;
 
 const sanitizedRelayList = computed(() => sanitizeRelayUrls(relayInput.value.split(/[\s,]+/).filter(Boolean)));
 
-const canSearch = computed(() => Boolean(query.value.trim() || sanitizedRelayList.value.length));
+const canSearch = computed(() => {
+  const rawQuery = normalizedQuery.value;
+  return Boolean(rawQuery.trim() || sanitizedRelayList.value.length);
+});
 
 const currentModeLabel = computed(() => modeOptions.find(option => option.value === mode.value)?.label ?? 'Profiles');
 
@@ -324,7 +328,8 @@ async function buildFilters(): Promise<{
   pointerRelays: string[];
   forcedMode: typeof mode.value;
 }> {
-  const trimmed = query.value.trim();
+  const rawQuery = normalizedQuery.value;
+  const trimmed = rawQuery.trim();
   const since = daysBack.value > 0 ? Math.floor(Date.now() / 1000) - daysBack.value * 86400 : undefined;
   const limitValue = limit.value > 0 ? Math.min(Math.floor(limit.value), 500) : 50;
   const filters: NostrFilter[] = [];

--- a/test/vitest/__tests__/NutzapExplorerPanel.spec.ts
+++ b/test/vitest/__tests__/NutzapExplorerPanel.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import { nextTick } from "vue";
+import NutzapExplorerPanel from "../../../src/nutzap/onepage/NutzapExplorerPanel.vue";
+
+const mocks = vi.hoisted(() => ({
+  multiRelaySearchMock: vi.fn(async () => ({ events: [], timedOut: false, usedRelays: [] })),
+  mergeRelayHintsMock: vi.fn(() => []),
+}));
+
+vi.mock("../../../src/nutzap/onepage/multiRelaySearch", () => ({
+  multiRelaySearch: mocks.multiRelaySearchMock,
+  mergeRelayHints: mocks.mergeRelayHintsMock,
+}));
+
+const stubs = {
+  "q-input": { props: ["modelValue"], emits: ["update:modelValue"], template: "<input />" },
+  "q-btn": {
+    emits: ["click"],
+    template: "<button @click=\"$emit('click')\"><slot /></button>",
+  },
+  "q-btn-toggle": {
+    props: ["modelValue"],
+    emits: ["update:modelValue"],
+    template: "<div><slot /></div>",
+  },
+  "q-banner": { template: "<div><slot /></div>" },
+  "q-table": { template: "<div><slot /></div>" },
+  "q-inner-loading": { template: "<div><slot /></div>" },
+  "q-td": { template: "<td><slot /></td>" },
+  "q-drawer": {
+    props: ["modelValue"],
+    emits: ["update:modelValue"],
+    template: "<div><slot /></div>",
+  },
+  "q-toolbar": { template: "<div><slot /></div>" },
+  "q-toolbar-title": { template: "<div><slot /></div>" },
+  "q-separator": { template: "<hr />" },
+};
+
+describe("NutzapExplorerPanel", () => {
+  it("keeps search disabled and handles null queries", async () => {
+    mocks.multiRelaySearchMock.mockClear();
+    mocks.mergeRelayHintsMock.mockClear();
+
+    const wrapper = shallowMount(NutzapExplorerPanel, {
+      props: { modelValue: "", loadingAuthor: false, tierAddressPreview: "" },
+      global: { stubs },
+    });
+
+    const vm = wrapper.vm as unknown as {
+      relayInput: string;
+      query: string | null;
+      canSearch: boolean;
+      runSearch: () => Promise<void>;
+    };
+
+    vm.relayInput = "";
+    vm.query = null;
+    await nextTick();
+
+    expect(vm.canSearch).toBe(false);
+    await expect(vm.runSearch()).resolves.toBeUndefined();
+    expect(mocks.multiRelaySearchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize the Nutzap explorer query ref before trimming so null values no longer throw
- reuse the normalized query inside canSearch and buildFilters to keep downstream logic consistent
- add a regression test that covers a null query value during runSearch

## Testing
- pnpm exec vitest run test/vitest/__tests__/NutzapExplorerPanel.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68de3bd28a708330b5f983cff0225b64