### PR TITLE
Handle fallback relay pool unreachable state

### DIFF
--- a/src/nostr/freeRelayFallback.ts
+++ b/src/nostr/freeRelayFallback.ts
@@ -1,0 +1,133 @@
+import type NDK from "@nostr-dev-kit/ndk";
+
+type FreeRelayFallbackState = {
+  attemptedAt: number | null;
+  unreachable: boolean;
+  warned: boolean;
+};
+
+export type FreeRelayFallbackStatus = {
+  lastAttemptAt: number | null;
+  unreachable: boolean;
+};
+
+export type FreeRelayFallbackContext = "bootstrap" | "watchdog";
+
+const fallbackStates = new WeakMap<NDK, FreeRelayFallbackState>();
+
+let fallbackStatus: FreeRelayFallbackStatus = {
+  lastAttemptAt: null,
+  unreachable: false,
+};
+
+const fallbackStatusListeners = new Set<
+  (status: FreeRelayFallbackStatus) => void
+>();
+
+function getState(ndk: NDK): FreeRelayFallbackState {
+  let state = fallbackStates.get(ndk);
+  if (!state) {
+    state = { attemptedAt: null, unreachable: false, warned: false };
+    fallbackStates.set(ndk, state);
+  }
+  return state;
+}
+
+function emitStatus() {
+  const snapshot: FreeRelayFallbackStatus = { ...fallbackStatus };
+  for (const listener of fallbackStatusListeners) {
+    try {
+      listener(snapshot);
+    } catch {
+      /* noop */
+    }
+  }
+}
+
+function updateStatus(partial: Partial<FreeRelayFallbackStatus>) {
+  const next: FreeRelayFallbackStatus = {
+    ...fallbackStatus,
+    ...partial,
+  };
+  if (
+    next.lastAttemptAt === fallbackStatus.lastAttemptAt &&
+    next.unreachable === fallbackStatus.unreachable
+  ) {
+    return;
+  }
+  fallbackStatus = next;
+  emitStatus();
+}
+
+export function getFreeRelayFallbackStatus(): FreeRelayFallbackStatus {
+  return { ...fallbackStatus };
+}
+
+export function onFreeRelayFallbackStatusChange(
+  listener: (status: FreeRelayFallbackStatus) => void,
+): () => void {
+  fallbackStatusListeners.add(listener);
+  try {
+    listener({ ...fallbackStatus });
+  } catch {
+    /* noop */
+  }
+  return () => {
+    fallbackStatusListeners.delete(listener);
+  };
+}
+
+export function hasFallbackAttempt(ndk: NDK): boolean {
+  return getState(ndk).attemptedAt != null;
+}
+
+export function recordFallbackAttempt(ndk: NDK): number {
+  const state = getState(ndk);
+  const now = Date.now();
+  state.attemptedAt = now;
+  state.unreachable = false;
+  state.warned = false;
+  updateStatus({ lastAttemptAt: now, unreachable: false });
+  return now;
+}
+
+export function isFallbackUnreachable(ndk: NDK): boolean {
+  return getState(ndk).unreachable;
+}
+
+export function markFallbackUnreachable(
+  ndk: NDK,
+  context: FreeRelayFallbackContext,
+  error?: Error,
+) {
+  const state = getState(ndk);
+  if (!state.unreachable) {
+    state.unreachable = true;
+  }
+  if (!state.warned) {
+    state.warned = true;
+    const scope = context === "watchdog" ? "watchdog" : "bootstrap";
+    const suffix = error?.message ? ` (${error.message})` : "";
+    console.warn(`[NDK] fallback relay pool unreachable during ${scope}${suffix}`);
+  }
+  updateStatus({ unreachable: true });
+}
+
+export function resetFallbackState(ndk: NDK) {
+  const state = getState(ndk);
+  if (state.attemptedAt == null && !state.unreachable && !state.warned) {
+    return;
+  }
+  state.attemptedAt = null;
+  state.unreachable = false;
+  state.warned = false;
+  updateStatus({ lastAttemptAt: null, unreachable: false });
+}
+
+export const __testing = {
+  clearTelemetry() {
+    fallbackStatusListeners.clear();
+    fallbackStatus = { lastAttemptAt: null, unreachable: false };
+  },
+  getState,
+};

--- a/test/ndk-fallback.spec.ts
+++ b/test/ndk-fallback.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { FREE_RELAYS } from "../src/config/relays";
+
+class FakePool {
+  relays = new Map<string, any>();
+  on = vi.fn();
+  off = vi.fn();
+}
+
+class FakeNdk {
+  pool = new FakePool();
+  addExplicitRelay = vi.fn((url: string) => {
+    this.pool.relays.set(url, { url, connected: false });
+  });
+  connect = vi.fn(async () => {});
+}
+
+describe("free relay fallback", () => {
+  beforeEach(async () => {
+    const fallbackModule = await import("../src/nostr/freeRelayFallback");
+    fallbackModule.__testing.clearTelemetry();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("only appends free relays once per failure cycle", async () => {
+    const consoleWarn = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    const ndkModule = await import("../src/boot/ndk");
+    const safeConnectSpy = vi
+      .spyOn(ndkModule, "safeConnect")
+      .mockResolvedValue(new Error("connect failed"));
+
+    const ndk = new FakeNdk();
+    ndk.pool.relays.set("wss://primary", { url: "wss://primary", connected: false });
+
+    await ndkModule.__testing.ensureFreeRelayFallback(ndk as any, "bootstrap");
+
+    expect(ndk.addExplicitRelay).toHaveBeenCalledTimes(FREE_RELAYS.length);
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+    expect(ndkModule.getFreeRelayFallbackStatus().unreachable).toBe(true);
+
+    ndk.addExplicitRelay.mockClear();
+    consoleWarn.mockClear();
+    safeConnectSpy.mockClear();
+
+    await ndkModule.__testing.ensureFreeRelayFallback(ndk as any, "bootstrap");
+
+    expect(ndk.addExplicitRelay).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+
+    const fallbackModule = await import("../src/nostr/freeRelayFallback");
+    fallbackModule.resetFallbackState(ndk as any);
+    fallbackModule.__testing.clearTelemetry();
+
+    ndk.pool.relays.clear();
+
+    await ndkModule.__testing.ensureFreeRelayFallback(ndk as any, "bootstrap");
+
+    expect(ndk.addExplicitRelay).toHaveBeenCalledTimes(FREE_RELAYS.length);
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it("relay watchdog avoids repeated fallback bursts", async () => {
+    vi.useFakeTimers();
+    const consoleWarn = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const consoleDebug = vi
+      .spyOn(console, "debug")
+      .mockImplementation(() => undefined);
+
+    const fallbackModule = await import("../src/nostr/freeRelayFallback");
+    fallbackModule.__testing.clearTelemetry();
+
+    const ndk = new FakeNdk();
+    ndk.pool.relays.set("wss://primary", { url: "wss://primary", connected: false });
+    ndk.connect.mockImplementation(async () => {
+      throw new Error("connect failed");
+    });
+
+    const { RelayWatchdog } = await import("../src/js/nostr-runtime");
+    const watchdog = new RelayWatchdog(ndk as any, {
+      heartbeatIntervalMs: 50,
+      heartbeatAckTimeoutMs: 100,
+      reconnectDelayMs: 100,
+    });
+
+    try {
+      watchdog.start(1, FREE_RELAYS);
+
+      await Promise.resolve();
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(ndk.addExplicitRelay).toHaveBeenCalledTimes(FREE_RELAYS.length);
+      expect(consoleWarn).toHaveBeenCalledTimes(1);
+
+      ndk.addExplicitRelay.mockClear();
+      consoleWarn.mockClear();
+
+      vi.advanceTimersByTime(5000);
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(ndk.addExplicitRelay).not.toHaveBeenCalled();
+      expect(consoleWarn).not.toHaveBeenCalled();
+    } finally {
+      watchdog.stop();
+      consoleDebug.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add shared fallback relay tracking and telemetry helpers so fallback relays are only appended once per cycle
- update NDK boot and relay watchdog logic to skip repeated fallback bursts and warn when the pool is unreachable
- cover the new behavior with watchdog/boot vitest specs

## Testing
- pnpm test -- ndk-fallback

------
https://chatgpt.com/codex/tasks/task_e_68de3d50ecd08330a840465410ac1fae