### PR TITLE
Refactor Creator Studio signer initialization to use Fundstr-only NDK

### DIFF
--- a/src/nutzap/useNutzapSignerWorkspace.ts
+++ b/src/nutzap/useNutzapSignerWorkspace.ts
@@ -6,6 +6,7 @@ import { useNostrStore } from 'src/stores/nostr';
 
 type UseNutzapSignerWorkspaceOptions = {
   onSignerActivated?: () => void;
+  fundstrOnlySigner?: boolean;
 };
 
 export function useNutzapSignerWorkspace(
@@ -50,7 +51,9 @@ export function useNutzapSignerWorkspace(
 
     ensureSharedSignerPromise = (async () => {
       try {
-        await nostrStore.initSignerIfNotSet();
+        await nostrStore.initSignerIfNotSet({
+          skipRelayConnect: options.fundstrOnlySigner ?? false,
+        });
       } catch (err) {
         console.error('[nutzap] failed to initialize shared signer', err);
       } finally {

--- a/src/pages/CreatorStudioPage.vue
+++ b/src/pages/CreatorStudioPage.vue
@@ -1336,6 +1336,7 @@ const {
       void loadAll();
     }
   },
+  fundstrOnlySigner: true,
 });
 
 const activeIdentitySummary = computed(() => connectedIdentitySummary.value);

--- a/test/vitest/__tests__/CreatorStudioPage.publish.spec.ts
+++ b/test/vitest/__tests__/CreatorStudioPage.publish.spec.ts
@@ -102,6 +102,7 @@ type SharedMocks = {
 };
 
 let shared: SharedMocks | null = null;
+let lastSignerWorkspaceOptions: any = null;
 
 function ensureShared(): SharedMocks {
   if (!shared) {
@@ -233,14 +234,21 @@ it('renders without throwing when relay activity entry is missing', () => {
   const previous = state.latestRelayActivity.value;
   state.latestRelayActivity.value = null;
 
+  let wrapper: ReturnType<typeof shallowMount> | null = null;
   expect(() => {
-    const wrapper = shallowMount(CreatorStudioPage, {
+    wrapper = shallowMount(CreatorStudioPage, {
       global: {
         stubs: creatorStudioStubs,
       },
     });
-    wrapper.unmount();
   }).not.toThrow();
+
+  expect(lastSignerWorkspaceOptions).toEqual({
+    fundstrOnlySigner: true,
+    onSignerActivated: expect.any(Function),
+  });
+
+  wrapper?.unmount();
 
   state.latestRelayActivity.value = previous;
 });
@@ -329,7 +337,8 @@ vi.mock('src/nutzap/useNutzapRelayTelemetry', () => ({
 }));
 
 vi.mock('src/nutzap/useNutzapSignerWorkspace', () => ({
-  useNutzapSignerWorkspace: () => {
+  useNutzapSignerWorkspace: (_authorInput: any, options?: any) => {
+    lastSignerWorkspaceOptions = options;
     const state = ensureShared();
     return {
       pubkey: ref(''),
@@ -384,6 +393,7 @@ vi.mock('../../../src/pages/nutzap-profile/nostrHelpers', async () => {
 
 beforeEach(() => {
   shared = null;
+  lastSignerWorkspaceOptions = null;
   routerResolveMock.mockClear();
   routerPushMock.mockClear();
   notifySuccessMock.mockReset();

--- a/test/vitest/__tests__/useNutzapSignerWorkspace.spec.ts
+++ b/test/vitest/__tests__/useNutzapSignerWorkspace.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { computed, ref } from 'vue';
+
+const captured = {
+  initOptions: [] as any[],
+};
+
+let storeSigner: any = null;
+
+const initSignerIfNotSetMock = vi.fn(async (options?: any) => {
+  captured.initOptions.push(options);
+  nostrStoreMock.signer = { signer: true };
+});
+
+const nostrStoreMock = {
+  npub: '',
+  get signer() {
+    return storeSigner;
+  },
+  set signer(value: any) {
+    storeSigner = value;
+  },
+  initSignerIfNotSet: initSignerIfNotSetMock,
+};
+
+vi.mock('src/stores/nostr', () => ({
+  useNostrStore: () => nostrStoreMock,
+}));
+
+vi.mock('src/nutzap/signer', () => ({
+  useActiveNutzapSigner: () => ({
+    pubkey: computed(() => ''),
+    signer: computed(() => storeSigner),
+  }),
+}));
+
+const ndkInstance = { signer: undefined as any };
+
+vi.mock('src/nutzap/ndkInstance', () => ({
+  getNutzapNdk: () => ndkInstance,
+}));
+
+beforeEach(() => {
+  captured.initOptions = [];
+  storeSigner = null;
+  ndkInstance.signer = undefined;
+  initSignerIfNotSetMock.mockClear();
+});
+
+describe('useNutzapSignerWorkspace', () => {
+  it('skips relay fan-out when fundstrOnlySigner is true', async () => {
+    const { useNutzapSignerWorkspace } = await import('src/nutzap/useNutzapSignerWorkspace');
+
+    const authorInput = ref('');
+    const workspace = useNutzapSignerWorkspace(authorInput, {
+      fundstrOnlySigner: true,
+    });
+
+    await workspace.ensureSharedSignerInitialized();
+
+    expect(captured.initOptions).toEqual([
+      { skipRelayConnect: true },
+    ]);
+    expect(ndkInstance.signer).toEqual({ signer: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add InitSignerBehaviorOptions to the nostr store so we can skip relay fan-out when initialising signers
- update useNutzapSignerWorkspace with a fundstrOnlySigner option and wire Creator Studio to use it
- extend Creator Studio tests and add a dedicated hook test to ensure the Fundstr-only path is exercised

## Testing
- pnpm test
- pnpm vitest run test/vitest/__tests__/useNutzapSignerWorkspace.spec.ts test/vitest/__tests__/CreatorStudioPage.publish.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68de46024e208330acf4e9172b673436