### PR TITLE
feat: make Fundstr relay fan-out opt-in

### DIFF
--- a/docs/relay-access.md
+++ b/docs/relay-access.md
@@ -15,10 +15,12 @@ Publishes must send a fully signed NIP-01 event to /event; the client validates 
 3. If the socket cannot be opened or returns no events, the client
    automatically performs the same query over HTTP:
    `https://relay.fundstr.me/req?filters=…`.
-4. When Fundstr returns no data the client fans out across a vetted pool of
-   public relays (`relay.primal.net`, `relay.fundstr.me`, `nos.lol`,
-   `relay.damus.io`). This pool is also used when discovery explicitly prefers
-   public relays.
+4. When Fundstr returns no data the client **can** fan out across a vetted pool
+   of public relays (`relay.primal.net`, `relay.fundstr.me`, `nos.lol`,
+   `relay.damus.io`). This behaviour is opt-in via
+   `allowFanoutFallback`—Fundstr-first flows (including Creator Studio load /
+   refresh) stay pinned to the first-party relay unless callers explicitly pass
+   that flag.
 
 All fetches, including the service-worker passthrough, use
 `cache: 'no-store'` together with `cache-control: no-cache` headers so the
@@ -58,8 +60,11 @@ The relay layer implements deduplication and NIP-01 replaceable semantics:
 
 Helpers are exposed for consumers that want the latest Nutzap profile and tier
 definitions: `queryNutzapProfile` (kind `10019`) and `queryNutzapTiers` (kind
-`30019` with `d:"tiers"`). Both helpers accept npub/hex input and will retry
-against relay hints (NIP-65 or `relay` tags) when Fundstr returns no data.
+`30019` with `d:"tiers"`). Both helpers accept npub/hex input and take an
+optional `{ fanout, allowFanoutFallback }` bag. Creator Studio calls them with
+the default Fundstr-only behaviour, while discovery-driven flows (Find
+Creators, creator store refresh) opt in to fan-out by passing relay hints and
+`allowFanoutFallback: true`.
 
 ## Discovery fallbacks
 

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -332,6 +332,7 @@ async function fetchProfileWithFallback(pubkeyInput: string) {
       if (relayHints.size) {
         event = await queryNutzapProfile(hex, {
           fanout: Array.from(relayHints),
+          allowFanoutFallback: true,
         });
       }
     } catch (e) {

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -211,6 +211,7 @@ export const useCreatorsStore = defineStore("creators", {
         try {
           event = await queryNutzapTiers(hex, {
             fanout: Array.from(relayHints),
+            allowFanoutFallback: true,
           });
         } catch (e) {
           lastError = e;
@@ -225,6 +226,7 @@ export const useCreatorsStore = defineStore("creators", {
           if (relayHints.size) {
             event = await queryNutzapTiers(hex, {
               fanout: Array.from(relayHints),
+              allowFanoutFallback: true,
             });
           }
         } catch (e) {

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -891,7 +891,10 @@ export async function fetchNutzapProfile(
     try {
       const discovered = await fallbackDiscoverRelays(hex);
       if (discovered.length) {
-        event = await queryNutzapProfile(hex, { fanout: discovered });
+        event = await queryNutzapProfile(hex, {
+          fanout: discovered,
+          allowFanoutFallback: true,
+        });
       }
     } catch (e) {
       lastError = e;

--- a/test/findCreators.profile.spec.ts
+++ b/test/findCreators.profile.spec.ts
@@ -207,6 +207,7 @@ describe("FindCreators component behaviour", () => {
     expect(queryNutzapProfile).toHaveBeenNthCalledWith(1, "hex123");
     expect(queryNutzapProfile).toHaveBeenNthCalledWith(2, "hex123", {
       fanout: ["wss://fallback-relay"],
+      allowFanoutFallback: true,
     });
 
     expect(fetchTierDefinitions).toHaveBeenCalledWith("hex123", {


### PR DESCRIPTION
## Summary
- add an `allowFanoutFallback` option so `queryNostr` only fans out beyond Fundstr when callers opt in
- extend the Nutzap helpers and discovery flows to pass the new flag, keeping Creator Studio loads Fundstr-only
- document the new transport option for future consumers of the relay client

## Testing
- pnpm test
- pnpm vitest run test/findCreators.profile.spec.ts test/vitest/__tests__/relayClient.spec.ts *(fails: local Quasar mock lacks a QPage export in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de4c73b7288330b8c27512a9cc5c28