### PR TITLE
Limit explorer default relay list

### DIFF
--- a/src/nutzap/onepage/NutzapExplorerPanel.vue
+++ b/src/nutzap/onepage/NutzapExplorerPanel.vue
@@ -168,6 +168,7 @@
           type="textarea"
           autogrow
           label="Relay list"
+          :placeholder="DEFAULT_RELAYS.join('\n')"
           hint="Comma or newline separated"
         />
         <q-banner class="bg-surface-2 text-2">
@@ -186,7 +187,7 @@ import type { Event as NostrEvent, Filter as NostrFilter } from 'nostr-tools';
 import { multiRelaySearch, mergeRelayHints } from './multiRelaySearch';
 import { sanitizeRelayUrls } from 'src/utils/relay';
 
-const DEFAULT_RELAYS = ['wss://relay.fundstr.me', 'wss://relay.damus.io'];
+const DEFAULT_RELAYS = ['wss://relay.fundstr.me'];
 
 const props = defineProps<{
   modelValue: string;

--- a/test/nutzap-explorer-panel.relays.spec.ts
+++ b/test/nutzap-explorer-panel.relays.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick, type ComponentPublicInstance } from 'vue';
+import { nip19 } from 'nostr-tools';
+import NutzapExplorerPanel from 'src/nutzap/onepage/NutzapExplorerPanel.vue';
+
+const { multiRelaySearchMock } = vi.hoisted(() => ({
+  multiRelaySearchMock: vi.fn(),
+}));
+
+vi.mock('src/nutzap/onepage/multiRelaySearch', async () => {
+  const actual = await vi.importActual<typeof import('src/nutzap/onepage/multiRelaySearch')>(
+    'src/nutzap/onepage/multiRelaySearch',
+  );
+
+  return {
+    ...actual,
+    multiRelaySearch: multiRelaySearchMock,
+  };
+});
+
+type NutzapExplorerPanelVm = ComponentPublicInstance & {
+  query: string;
+  relayInput: string;
+  activeRelays: string[];
+  runSearch: () => Promise<void>;
+};
+
+describe('NutzapExplorerPanel relay handling', () => {
+  beforeEach(() => {
+    multiRelaySearchMock.mockReset();
+  });
+
+  it('keeps the default relay while merging user and pointer relay hints', async () => {
+    const pointerRelays = ['wss://relay.pointer.one', 'wss://relay.pointer.two'];
+    const manualRelay = 'wss://relay.extra.example';
+    const encodedProfile = nip19.nprofileEncode({
+      pubkey: 'f'.repeat(64),
+      relays: pointerRelays,
+    });
+
+    multiRelaySearchMock.mockResolvedValue({ events: [], usedRelays: [], timedOut: false });
+
+    const wrapper = mount(NutzapExplorerPanel, {
+      props: {
+        modelValue: '',
+        loadingAuthor: false,
+        tierAddressPreview: '',
+      },
+      global: {
+        stubs: {
+          'q-input': true,
+          'q-btn-toggle': true,
+          'q-btn': true,
+          'q-banner': true,
+          'q-table': true,
+          'q-inner-loading': true,
+          'q-drawer': true,
+          'q-toolbar': true,
+          'q-toolbar-title': true,
+          'q-separator': true,
+          'q-td': true,
+        },
+      },
+    });
+
+    const vm = wrapper.vm as NutzapExplorerPanelVm;
+
+    vm.relayInput = `wss://relay.fundstr.me\n${manualRelay}`;
+    vm.query = encodedProfile;
+
+    await vm.runSearch();
+    await nextTick();
+
+    expect(multiRelaySearchMock).toHaveBeenCalledTimes(1);
+    const options = multiRelaySearchMock.mock.calls[0][0];
+    expect(options.relays).toEqual(['wss://relay.fundstr.me', manualRelay]);
+    expect(options.additionalRelays).toEqual(pointerRelays);
+
+    expect(vm.activeRelays).toEqual([
+      'wss://relay.fundstr.me',
+      manualRelay,
+      ...pointerRelays,
+    ]);
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- restrict the explorer defaults to the Fundstr relay and update the relay textarea placeholder
- add a regression test that ensures manual and pointer relays are merged with the Fundstr default

## Testing
- pnpm vitest run test/nutzap-explorer-panel.relays.spec.ts
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68de4e5382fc83308aafbdf4b5cd4e0e