### PR TITLE
Normalize creator studio mint URLs

### DIFF
--- a/test/creatorStudio/mintUrlNormalize.spec.ts
+++ b/test/creatorStudio/mintUrlNormalize.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeMintUrl } from 'src/pages/CreatorStudioPage.vue';
+
+describe('normalizeMintUrl', () => {
+  it('lowercases and trims whitespace', () => {
+    expect(normalizeMintUrl('  HTTPS://Mint.EXAMPLE.COM  ')).toBe('https://mint.example.com');
+  });
+
+  it('removes redundant trailing slashes', () => {
+    expect(normalizeMintUrl('https://mint.example.com/')).toBe('https://mint.example.com');
+    expect(normalizeMintUrl('https://mint.example.com////')).toBe('https://mint.example.com');
+  });
+
+  it('returns empty string for non-string input or empty result', () => {
+    expect(normalizeMintUrl(undefined)).toBe('');
+    expect(normalizeMintUrl('   ')).toBe('');
+  });
+
+  it('preserves intermediate path segments while trimming ending slash', () => {
+    expect(normalizeMintUrl('https://mint.example.com/path/')).toBe('https://mint.example.com/path');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
       "test/creatorSubscribers-page.spec.ts",
       "test/vitest/__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
       "test/*.spec.ts",
+      "test/**/*.spec.ts",
     ],
   },
   resolve: {


### PR DESCRIPTION
## Summary
- add a mint URL normalization helper to CreatorStudioPage and apply it during P2PK verification checks
- allow Vitest to discover nested test specs
- cover the normalization helper with targeted unit tests

## Testing
- pnpm exec vitest run test/creatorStudio/mintUrlNormalize.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68de5a7891f4833080f85e19098fdbc9