### PR TITLE
Limit custom-link Nutzap lookups to Fundstr relays

### DIFF
--- a/src/nostr/relayClient.ts
+++ b/src/nostr/relayClient.ts
@@ -488,11 +488,14 @@ export async function queryNutzapProfile(
   const filters: Filter[] = [
     { kinds: [10019], authors: [pubkey], limit: 1 },
   ];
-  const events = await queryNostr(filters, {
+  const queryOptions: QueryOptions = {
     preferFundstr: true,
     fanout: opts.fanout,
-    allowFanoutFallback: opts.allowFanoutFallback ?? false,
-  });
+  };
+  if (opts.allowFanoutFallback) {
+    queryOptions.allowFanoutFallback = true;
+  }
+  const events = await queryNostr(filters, queryOptions);
   return pickLatestReplaceable(events, { kind: 10019, pubkey });
 }
 
@@ -509,11 +512,14 @@ export async function queryNutzapTiers(
       limit: 2,
     },
   ];
-  const events = await queryNostr(filters, {
+  const queryOptions: QueryOptions = {
     preferFundstr: true,
     fanout: opts.fanout,
-    allowFanoutFallback: opts.allowFanoutFallback ?? false,
-  });
+  };
+  if (opts.allowFanoutFallback) {
+    queryOptions.allowFanoutFallback = true;
+  }
+  const events = await queryNostr(filters, queryOptions);
   return pickLatestAddrReplaceable(events, {
     kind: [30019, 30000],
     pubkey,

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -219,7 +219,7 @@ export default defineComponent({
       }
       refreshingTiers.value = true;
       try {
-        await creators.fetchTierDefinitions(creatorHex);
+        await creators.fetchTierDefinitions(creatorHex, { fundstrOnly: true });
       } finally {
         refreshingTiers.value = false;
         if (!hasInitialTierData.value) {

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -163,7 +163,7 @@ export const useCreatorsStore = defineStore("creators", {
 
     async fetchTierDefinitions(
       creatorNpub: string,
-      opts: { relayHints?: string[] } = {},
+      opts: { relayHints?: string[]; fundstrOnly?: boolean } = {},
     ) {
       this.tierFetchError = false;
 
@@ -196,6 +196,7 @@ export const useCreatorsStore = defineStore("creators", {
           .map((url) => url.trim())
           .filter((url) => !!url),
       );
+      const fundstrOnly = opts.fundstrOnly === true;
 
       let event: RelayEvent | null = null;
       let lastError: unknown = null;
@@ -211,7 +212,7 @@ export const useCreatorsStore = defineStore("creators", {
         try {
           event = await queryNutzapTiers(hex, {
             fanout: Array.from(relayHints),
-            allowFanoutFallback: true,
+            allowFanoutFallback: !fundstrOnly,
           });
         } catch (e) {
           lastError = e;
@@ -219,7 +220,7 @@ export const useCreatorsStore = defineStore("creators", {
         }
       }
 
-      if (!event) {
+      if (!event && !fundstrOnly) {
         try {
           const discovered = await fallbackDiscoverRelays(hex);
           for (const url of discovered) relayHints.add(url);

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -867,6 +867,7 @@ export async function anyRelayReachable(relays: string[]): Promise<boolean> {
  */
 export async function fetchNutzapProfile(
   npubOrHex: string,
+  opts: { fundstrOnly?: boolean } = {},
 ): Promise<NutzapProfile | null> {
   let hex: string;
   try {
@@ -874,6 +875,8 @@ export async function fetchNutzapProfile(
   } catch (e) {
     throw new Error("Invalid npub");
   }
+
+  const fundstrOnly = opts.fundstrOnly === true;
 
   if (nutzapProfileCache.has(hex)) {
     return nutzapProfileCache.get(hex) || null;
@@ -887,7 +890,7 @@ export async function fetchNutzapProfile(
     lastError = e;
   }
 
-  if (!event) {
+  if (!event && !fundstrOnly) {
     try {
       const discovered = await fallbackDiscoverRelays(hex);
       if (discovered.length) {


### PR DESCRIPTION
## Summary
- add a `fundstrOnly` option to Nutzap profile/tier fetching helpers and skip relay discovery when requested
- default Nutzap relay client queries to Fundstr unless callers explicitly opt into fan-out fallbacks
- ensure the public creator pages request Fundstr-only lookups so custom links stay on first-party relays

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dec21d7e1083308fd0de063d09e46e