### PR TITLE
Use Fundstr req endpoint for custom link profiles

### DIFF
--- a/src/nostr/relayClient.ts
+++ b/src/nostr/relayClient.ts
@@ -272,8 +272,21 @@ async function wsQuery(
   });
 }
 
+function buildReqUrl(httpBase: string): string {
+  const trimmed = (httpBase || "").trim();
+  const normalized = trimmed.replace(/\/+$/, "");
+  if (!normalized) {
+    return "/req";
+  }
+  if (normalized.toLowerCase().endsWith("/req")) {
+    return normalized;
+  }
+  return `${normalized}/req`;
+}
+
 async function httpReq(httpBase: string, filters: Filter[]): Promise<NostrEvent[]> {
-  const url = `${httpBase}/req?filters=${encodeURIComponent(JSON.stringify(filters))}`;
+  const reqUrl = buildReqUrl(httpBase);
+  const url = `${reqUrl}?filters=${encodeURIComponent(JSON.stringify(filters))}`;
   const res = await fetch(url, {
     method: "GET",
     headers: {

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -79,6 +79,7 @@ import {
 import { mapInternalTierToWire } from "src/nostr/tiers";
 import { buildKind10019NutzapProfile } from "src/nostr/builders";
 import { NutzapProfileSchema, type NutzapProfilePayload } from "src/nostr/nutzapProfile";
+import { FUNDSTR_REQ_URL, WS_FIRST_TIMEOUT_MS } from "@/nutzap/relayEndpoints";
 
 // --- Relay connectivity helpers ---
 export type WriteConnectivity = {
@@ -564,6 +565,8 @@ interface NutzapProfile {
 
 const nutzapProfileCache = new Map<string, NutzapProfile | null>();
 
+const CUSTOM_LINK_WS_TIMEOUT_MS = Math.min(WS_FIRST_TIMEOUT_MS, 1200);
+
 export class RelayConnectionError extends Error {
   constructor(message?: string) {
     super(message ?? "Unable to connect to Nostr relays");
@@ -885,7 +888,11 @@ export async function fetchNutzapProfile(
   let lastError: unknown = null;
 
   try {
-    event = await queryNutzapProfile(hex);
+    event = await queryNutzapProfile(hex, {
+      httpBase: FUNDSTR_REQ_URL,
+      allowFanoutFallback: false,
+      wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,
+    });
   } catch (e) {
     lastError = e;
   }
@@ -895,8 +902,10 @@ export async function fetchNutzapProfile(
       const discovered = await fallbackDiscoverRelays(hex);
       if (discovered.length) {
         event = await queryNutzapProfile(hex, {
+          httpBase: FUNDSTR_REQ_URL,
           fanout: discovered,
           allowFanoutFallback: true,
+          wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,
         });
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- normalize relay client HTTP queries so custom links can provide full /req endpoints
- route custom-link profile and tier lookups through Fundstr's req endpoint with a tighter timeout
- ensure Find Creators dialog passes Fundstr HTTP options before attempting relay fanout

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec53aae0c83308309865fde8a3cf6