### PR TITLE
Improve relay handling in find-creators search

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -880,12 +880,14 @@
       ) {
         const timeoutMs = options?.timeout;
         const retries = options?.retries ?? 1;
+        const retryDelay = options?.retryDelay;
         const events = await fetchEventsFromRelays(
           relays,
           filter,
           signal,
           timeoutMs,
           retries,
+          retryDelay,
         );
         const profileMap = new Map();
         events.forEach((event) => {
@@ -922,8 +924,9 @@
 
       function fetchProfilesFromFundstr(filter, signal) {
         return fetchProfilesFromRelays([FUNDSTR_RELAY], filter, signal, {
-          timeout: 1200,
-          retries: 0,
+          timeout: 1000,
+          retries: 2,
+          retryDelay: 350,
         });
       }
 
@@ -933,21 +936,50 @@
         signal,
         timeout = 7000,
         retries = 1,
+        retryDelay = 1000,
       ) {
+        const debounceDelay = 180;
+        const uniqueRelays = [...new Set(relays)].filter(Boolean);
+
         async function attempt() {
           return await new Promise((resolve, reject) => {
             if (signal.aborted)
               return reject(new DOMException("Aborted", "AbortError"));
 
             const events = [];
-            const sub = pool.sub([...new Set(relays)], [filter]);
+            const relayStates = new Map(
+              uniqueRelays.map((relay) => [relay, { hasEvent: false, hasEose: false }]),
+            );
+            let resolved = false;
+            let debounceId = null;
+            let cleanupCalled = false;
+
+            const sub = pool.sub(uniqueRelays, [filter]);
+
+            const resolveRelayUrl = (relayRef) => {
+              if (!relayRef) return undefined;
+              if (typeof relayRef === "string") return relayRef;
+              if (typeof relayRef === "object" && typeof relayRef.url === "string")
+                return relayRef.url;
+              return undefined;
+            };
+
+            let timeoutId = null;
 
             const cleanup = () => {
+              if (cleanupCalled) return;
+              cleanupCalled = true;
               try {
                 sub.unsub();
               } catch (e) {}
               signal.removeEventListener("abort", onAbort);
-              clearTimeout(timeoutId);
+              if (timeoutId !== null) {
+                clearTimeout(timeoutId);
+              }
+              if (debounceId) {
+                clearTimeout(debounceId);
+                debounceId = null;
+              }
             };
 
             const onAbort = () => {
@@ -956,18 +988,66 @@
             };
             signal.addEventListener("abort", onAbort);
 
-            const timeoutId = setTimeout(() => {
+            const finish = () => {
+              if (resolved) return;
+              resolved = true;
               cleanup();
               resolve(events);
-            }, timeout);
+            };
 
-            sub.on("event", (event) => {
+            const scheduleResolveIfComplete = () => {
+              if (resolved) return;
+              if (
+                relayStates.size === 0 ||
+                Array.from(relayStates.values()).every(
+                  (state) => state.hasEvent || state.hasEose,
+                )
+              ) {
+                if (debounceId) clearTimeout(debounceId);
+                debounceId = setTimeout(finish, debounceDelay);
+              }
+            };
+
+            const markRelay = (relayRef, field) => {
+              if (relayStates.size === 0) {
+                scheduleResolveIfComplete();
+                return;
+              }
+
+              const relayUrl = resolveRelayUrl(relayRef);
+              if (relayUrl && relayStates.has(relayUrl)) {
+                const state = relayStates.get(relayUrl);
+                if (!state[field]) {
+                  state[field] = true;
+                  scheduleResolveIfComplete();
+                }
+                return;
+              }
+
+              if (!relayUrl && relayStates.size === 1) {
+                const onlyRelay = relayStates.keys().next().value;
+                if (onlyRelay) {
+                  const state = relayStates.get(onlyRelay);
+                  if (!state[field]) {
+                    state[field] = true;
+                    scheduleResolveIfComplete();
+                  }
+                }
+              }
+            };
+
+            timeoutId = setTimeout(finish, timeout);
+
+            sub.on("event", (event, relayRef) => {
               events.push(event);
+              markRelay(relayRef, "hasEvent");
             });
 
-            sub.on("eose", () => {
-              // Don't resolve on EOSE, wait for full timeout to gather from all relays
+            sub.on("eose", (relayRef) => {
+              markRelay(relayRef, "hasEose");
             });
+
+            scheduleResolveIfComplete();
           });
         }
 
@@ -980,7 +1060,10 @@
           } catch (err) {
             if (err.name === "AbortError" || attemptNum === retries) throw err;
           }
-          await new Promise((res) => setTimeout(res, 1000));
+          const effectiveDelay = retryDelay ?? 1000;
+          if (effectiveDelay > 0) {
+            await new Promise((res) => setTimeout(res, effectiveDelay));
+          }
         }
         return [];
       }


### PR DESCRIPTION
## Summary
- track per-relay responses in `fetchEventsFromRelays` and resolve once each relay has produced data or EOSE
- add a brief debounce to capture late-arriving events without delaying the initial batch
- allow configurable retry delays and shorten Fundstr relay timeouts/back-off for quicker retries

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deccc8f28c83308c485990499ec257