### PR TITLE
Prefetch featured creator Nutzap caches

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -10,7 +10,14 @@ const __dirname = path.dirname(__filename)
 
 export default configure(() => ({
   // 1. 'node-globals' boot file is removed. This is correct.
-  boot: ['welcomeGate', 'cashu', 'i18n', 'notify', 'nostr-provider'],
+  boot: [
+    'welcomeGate',
+    'cashu',
+    'i18n',
+    'notify',
+    'nostr-provider',
+    'fundstr-preload',
+  ],
 
   css: ['app.scss', 'base.scss', 'buckets.scss'],
   extras: ['roboto-font', 'material-icons'],

--- a/src/boot/fundstr-preload.ts
+++ b/src/boot/fundstr-preload.ts
@@ -1,0 +1,114 @@
+import { boot } from "quasar/wrappers";
+import { useNostrStore } from "stores/nostr";
+import { useCreatorsStore, FEATURED_CREATORS } from "stores/creators";
+import {
+  queryNutzapProfile,
+  queryNutzapTiers,
+  toHex,
+  type NostrEvent as RelayEvent,
+} from "@/nostr/relayClient";
+import { parseTierDefinitionEvent } from "src/nostr/tiers";
+import { parseNutzapProfileEvent } from "@/nutzap/profileCache";
+import type { Tier } from "stores/types";
+
+function normalizeTier(tier: Tier): Tier {
+  return {
+    ...tier,
+    price_sats: tier.price_sats ?? (tier as any).price ?? 0,
+    ...(tier.perks && !tier.benefits ? { benefits: [tier.perks] } : {}),
+    media: tier.media ? [...tier.media] : [],
+  };
+}
+
+export default boot(async () => {
+  const nostr = useNostrStore();
+  const creators = useCreatorsStore();
+
+  try {
+    await nostr.initNdkReadOnly({ fundstrOnly: true });
+  } catch (e) {
+    console.warn("[fundstr-preload] initNdkReadOnly failed", e);
+  }
+
+  const targets = new Set<string>();
+
+  for (const entry of FEATURED_CREATORS) {
+    try {
+      targets.add(toHex(entry));
+    } catch (e) {
+      console.warn(`[fundstr-preload] invalid featured pubkey: ${entry}`, e);
+    }
+  }
+
+  for (const favorite of creators.favoriteHexPubkeys) {
+    if (typeof favorite === "string" && favorite.length === 64) {
+      targets.add(favorite.toLowerCase());
+    }
+  }
+
+  for (const hex of targets) {
+    if (!hex || hex.length !== 64) continue;
+    await creators.ensureCreatorCacheFromDexie(hex).catch((err) => {
+      console.warn(`[fundstr-preload] failed to hydrate cache for ${hex}`, err);
+    });
+
+    let profileEvent: RelayEvent | null = null;
+    let profileFetched = false;
+    try {
+      profileEvent = await queryNutzapProfile(hex, {
+        allowFanoutFallback: false,
+      });
+      profileFetched = true;
+    } catch (e) {
+      console.warn(`[fundstr-preload] profile fetch failed for ${hex}`, e);
+    }
+
+    if (profileFetched) {
+      const details = parseNutzapProfileEvent(profileEvent);
+      await creators
+        .saveProfileCache(hex, profileEvent, details)
+        .catch((err) =>
+          console.error(`[fundstr-preload] failed to cache profile ${hex}`, err),
+        );
+    }
+
+    let tierEvent: RelayEvent | null = null;
+    let tiersFetched = false;
+    try {
+      tierEvent = await queryNutzapTiers(hex, {
+        allowFanoutFallback: false,
+      });
+      tiersFetched = true;
+    } catch (e) {
+      console.warn(`[fundstr-preload] tier fetch failed for ${hex}`, e);
+    }
+
+    if (tiersFetched) {
+      if (tierEvent) {
+        let tiers: Tier[] = [];
+        try {
+          tiers = parseTierDefinitionEvent(tierEvent).map((tier) =>
+            normalizeTier(tier as Tier),
+          );
+        } catch (e) {
+          console.error(`[fundstr-preload] failed to parse tiers for ${hex}`, e);
+          tiers = [];
+        }
+        await creators
+          .saveTierCache(hex, tiers, tierEvent)
+          .catch((err) =>
+            console.error(`[fundstr-preload] failed to cache tiers ${hex}`, err),
+          );
+      } else {
+        await creators
+          .saveTierCache(hex, [], null)
+          .catch((err) =>
+            console.error(
+              `[fundstr-preload] failed to clear tier cache for ${hex}`,
+              err,
+            ),
+          );
+      }
+    }
+  }
+});

--- a/src/nutzap/profileCache.ts
+++ b/src/nutzap/profileCache.ts
@@ -1,0 +1,82 @@
+import type { NostrEvent } from "@/nostr/relayClient";
+import { NutzapProfileSchema } from "@/nostr/nutzapProfile";
+
+export interface NutzapProfileDetails {
+  p2pkPubkey: string;
+  trustedMints: string[];
+  relays: string[];
+  tierAddr?: string;
+}
+
+export function parseNutzapProfileEvent(
+  event: NostrEvent | null,
+): NutzapProfileDetails | null {
+  if (!event) return null;
+
+  const relays = new Set<string>();
+  const mints: string[] = [];
+  let p2pk = "";
+  let tierAddr: string | undefined;
+
+  if (event.content) {
+    try {
+      const parsedJson = JSON.parse(event.content);
+      const safe = NutzapProfileSchema.safeParse(parsedJson);
+      if (safe.success) {
+        const data = safe.data;
+        if (typeof data.p2pk === "string" && data.p2pk) {
+          p2pk = data.p2pk;
+        }
+        if (Array.isArray(data.mints)) {
+          for (const mint of data.mints) {
+            if (typeof mint === "string" && mint) {
+              mints.push(mint);
+            }
+          }
+        }
+        if (Array.isArray(data.relays)) {
+          for (const relay of data.relays) {
+            if (typeof relay === "string" && relay) {
+              relays.add(relay);
+            }
+          }
+        }
+        if (typeof data.tierAddr === "string" && data.tierAddr) {
+          tierAddr = data.tierAddr;
+        }
+      }
+    } catch (e) {
+      console.warn("[nutzap] failed to parse profile JSON", e);
+    }
+  }
+
+  const tags = Array.isArray(event.tags) ? event.tags : [];
+  for (const tag of tags) {
+    if (tag[0] === "mint" && typeof tag[1] === "string" && tag[1]) {
+      mints.push(tag[1]);
+    }
+    if (tag[0] === "relay" && typeof tag[1] === "string" && tag[1]) {
+      relays.add(tag[1]);
+    }
+    if (!p2pk && tag[0] === "pubkey" && typeof tag[1] === "string" && tag[1]) {
+      p2pk = tag[1];
+    }
+    if (!tierAddr && tag[0] === "a" && typeof tag[1] === "string" && tag[1]) {
+      tierAddr = tag[1];
+    }
+  }
+
+  const uniqueMints = Array.from(new Set(mints.filter((m) => !!m)));
+  const uniqueRelays = Array.from(relays);
+
+  if (!p2pk && uniqueMints.length === 0 && uniqueRelays.length === 0) {
+    return null;
+  }
+
+  return {
+    p2pkPubkey: p2pk,
+    trustedMints: uniqueMints,
+    relays: uniqueRelays,
+    tierAddr,
+  };
+}

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -8,6 +8,7 @@ import { useProofsStore } from "./proofs";
 import { notifyError, notifySuccess } from "../js/notify";
 import type { NostrEvent } from "@nostr-dev-kit/ndk";
 import { frequencyToDays } from "src/constants/subscriptionFrequency";
+import type { NutzapProfileDetails } from "@/nutzap/profileCache";
 
 export interface CachedProfileDexie {
   pubkey: string;
@@ -22,6 +23,15 @@ export interface CreatorTierDefinition {
   tiers: Tier[];
   eventId: string;
   updatedAt: number;
+  /** Raw Nostr event JSON string */
+  rawEventJson?: string;
+}
+
+export interface NutzapProfileCacheEntry {
+  pubkey: string;
+  profile: NutzapProfileDetails | null;
+  eventId?: string | null;
+  updatedAt?: number | null;
   /** Raw Nostr event JSON string */
   rawEventJson?: string;
 }
@@ -115,6 +125,7 @@ export class CashuDexie extends Dexie {
   proofs!: Table<WalletProof>;
   profiles!: Table<CachedProfileDexie>;
   creatorsTierDefinitions!: Table<CreatorTierDefinition, string>;
+  nutzapProfiles!: Table<NutzapProfileCacheEntry, string>;
   subscriptions!: Table<Subscription, string>;
   lockedTokens!: Table<LockedToken, string>;
   subscriberViews!: Table<SubscriberView, string>;
@@ -588,6 +599,20 @@ export class CashuDexie extends Dexie {
         "&id, tokenString, owner, tierId, intervalKey, unlockTs, status, subscriptionEventId, subscriptionId, monthIndex, totalPeriods, autoRedeem, frequency, intervalDays",
       subscriberViews: "&name",
       subscriberViewPrefs: "&id",
+    });
+
+    this.version(24).stores({
+      proofs:
+        "secret, id, C, amount, reserved, quote, bucketId, label, description",
+      profiles: "pubkey",
+      creatorsTierDefinitions: "&creatorNpub, eventId, updatedAt",
+      subscriptions:
+        "&id, creatorNpub, tierId, status, createdAt, updatedAt, frequency, intervalDays",
+      lockedTokens:
+        "&id, tokenString, owner, tierId, intervalKey, unlockTs, status, subscriptionEventId, subscriptionId, monthIndex, totalPeriods, autoRedeem, frequency, intervalDays",
+      subscriberViews: "&name",
+      subscriberViewPrefs: "&id",
+      nutzapProfiles: "&pubkey, updatedAt, eventId",
     });
   }
 }


### PR DESCRIPTION
## Summary
- add a preload boot step that hydrates featured and favorite creator Nutzap profile/tier caches
- extend the creators store and Dexie schema to persist warm Nutzap data and generate iframe prefill payloads
- update the FindCreators view to consume cached data and message the iframe with prefilled creators

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68decea544a48330bd55a2516eb6e7a0