### PR TITLE
Point Creator Studio to relay.fundstr.me

### DIFF
--- a/src/pages/CreatorStudioPage.vue
+++ b/src/pages/CreatorStudioPage.vue
@@ -36,7 +36,7 @@
           <div class="studio-card__header">
             <div>
               <div class="text-subtitle1 text-weight-medium text-1">Relay connection</div>
-              <div class="text-caption text-2">Connect to relay.primal.net with automatic fallback.</div>
+              <div class="text-caption text-2">Connect to relay.fundstr.me with automatic fallback.</div>
             </div>
             <q-btn flat dense icon="science" label="Data explorer" @click="requestExplorerOpen('toolbar')" />
           </div>
@@ -268,7 +268,7 @@
                       @blur="commitRelay"
                     />
                   </div>
-                  <div class="text-caption text-2">Automatically ensures relay.primal.net is included.</div>
+                  <div class="text-caption text-2">Automatically ensures relay.fundstr.me is included.</div>
                 </div>
               </div>
             </div>
@@ -439,7 +439,7 @@
           <div class="studio-card__header">
             <div>
               <div class="text-subtitle1 text-weight-medium text-1">Publish workflow</div>
-              <div class="text-caption text-2">Push profile and tiers to relay.primal.net.</div>
+              <div class="text-caption text-2">Push profile and tiers to relay.fundstr.me.</div>
             </div>
           </div>
           <div class="studio-card__body column q-gutter-md">
@@ -561,7 +561,7 @@
                 </div>
               </div>
               <q-banner class="preview-banner" dense>
-                Publish pushes both events to relay.primal.net. Copy JSON if your publisher requires manual input.
+                Publish pushes both events to relay.fundstr.me. Copy JSON if your publisher requires manual input.
               </q-banner>
             </q-tab-panel>
             <q-tab-panel name="profile">
@@ -642,8 +642,6 @@ import { nip19 } from 'nostr-tools';
 import { useClipboard } from 'src/composables/useClipboard';
 import { buildProfileUrl } from 'src/utils/profileUrl';
 import {
-  FUNDSTR_WS_URL,
-  FUNDSTR_REQ_URL,
   WS_FIRST_TIMEOUT_MS,
   HTTP_FALLBACK_TIMEOUT_MS,
   publishTiers as publishTiersToRelay,
@@ -677,6 +675,9 @@ const CREATOR_STUDIO_WS_TIMEOUT_MS = Math.min(WS_FIRST_TIMEOUT_MS, 1200);
 const HTTP_DEFAULT_ACCEPT =
   'application/nostr+json, application/json;q=0.9, */*;q=0.1';
 
+const CREATOR_STUDIO_RELAY_WS_URL = 'wss://relay.fundstr.me';
+const CREATOR_STUDIO_RELAY_HTTP_URL = 'https://relay.fundstr.me/req';
+
 const authorInput = ref('');
 const displayName = ref('');
 const pictureUrl = ref('');
@@ -691,7 +692,7 @@ const verifyingP2pkPointer = ref(false);
 let previousSelectedP2pkPub = '';
 const cachedMintsText = useLocalStorage<string>('nutzap.profile.mintsDraft', '');
 const mintsText = ref(cachedMintsText.value || '');
-const relaysText = ref(FUNDSTR_WS_URL);
+const relaysText = ref(CREATOR_STUDIO_RELAY_WS_URL);
 const tiers = ref<Tier[]>([]);
 const handleTiersUpdate = (value: Tier[] | unknown) => {
   tiers.value = Array.isArray(value) ? value : [];
@@ -711,7 +712,7 @@ const lastExportTiers = ref('');
 const relayClientRef = shallowRef<FundstrRelayClient | null>(null);
 let relayClientPromise: Promise<FundstrRelayClient> | null = null;
 let relayClientInitSequence = 0;
-let activeRelayUrl = FUNDSTR_WS_URL;
+let activeRelayUrl = CREATOR_STUDIO_RELAY_WS_URL;
 let resolvedRelayUrl: string | null = null;
 
 function setResolvedRelayClient(
@@ -727,7 +728,7 @@ function setResolvedRelayClient(
 }
 
 function ensureRelayClientInitialized(targetUrl = activeRelayUrl): Promise<FundstrRelayClient> {
-  const sanitized = typeof targetUrl === 'string' && targetUrl.trim() ? targetUrl : FUNDSTR_WS_URL;
+  const sanitized = typeof targetUrl === 'string' && targetUrl.trim() ? targetUrl : CREATOR_STUDIO_RELAY_WS_URL;
 
   if (relayClientRef.value && resolvedRelayUrl === sanitized) {
     activeRelayUrl = sanitized;
@@ -995,7 +996,7 @@ function maybeFlagHttpFallbackTimeout(error: unknown) {
     return;
   }
   if (message.toLowerCase().includes('http fallback timed out')) {
-    const detail = `${message}. Confirm ${FUNDSTR_REQ_URL} is reachable or adjust VITE_NUTZAP_PRIMARY_RELAY_HTTP.`;
+    const detail = `${message}. Confirm ${CREATOR_STUDIO_RELAY_HTTP_URL} is reachable or adjust VITE_NUTZAP_PRIMARY_RELAY_HTTP.`;
     flagDiagnosticsAttention('relay', detail, 'warning');
   }
 }
@@ -1026,7 +1027,7 @@ function isAbortError(err: unknown): boolean {
 }
 
 function createHttpFallbackRequest(filters: NostrFilter[]) {
-  const requestUrl = buildHttpRequestUrl(FUNDSTR_REQ_URL, filters);
+  const requestUrl = buildHttpRequestUrl(CREATOR_STUDIO_RELAY_HTTP_URL, filters);
   const controller =
     typeof AbortController !== 'undefined' ? new AbortController() : null;
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -1242,7 +1243,7 @@ const {
   logRelayActivity,
 } = relayTelemetry;
 
-activeRelayUrl = relayConnectionUrl.value || FUNDSTR_WS_URL;
+activeRelayUrl = relayConnectionUrl.value || CREATOR_STUDIO_RELAY_WS_URL;
 
 const activeRelayActivity = computed(() => latestRelayActivity.value);
 const activeRelayActivityTimeLabel = computed(() => {
@@ -1269,7 +1270,7 @@ watch(
 watch(
   relayConnectionUrl,
   nextUrl => {
-    const sanitized = typeof nextUrl === 'string' && nextUrl.trim() ? nextUrl : FUNDSTR_WS_URL;
+    const sanitized = typeof nextUrl === 'string' && nextUrl.trim() ? nextUrl : CREATOR_STUDIO_RELAY_WS_URL;
 
     if (resolvedRelayUrl === sanitized && relayClientRef.value) {
       activeRelayUrl = sanitized;
@@ -1845,7 +1846,7 @@ const relayList = computed(() => {
     .map(s => s.trim())
     .filter(Boolean);
   const set = new Set(entries);
-  set.add(FUNDSTR_WS_URL);
+  set.add(CREATOR_STUDIO_RELAY_WS_URL);
   return Array.from(set);
 });
 
@@ -2307,8 +2308,8 @@ function buildRelayList(rawRelays: string[]) {
   for (const relay of sanitizedEntries) {
     sanitizedSet.add(relay);
   }
-  if (!sanitizedSet.has(FUNDSTR_WS_URL)) {
-    sanitizedSet.add(FUNDSTR_WS_URL);
+  if (!sanitizedSet.has(CREATOR_STUDIO_RELAY_WS_URL)) {
+    sanitizedSet.add(CREATOR_STUDIO_RELAY_WS_URL);
   }
 
   return { sanitized: Array.from(sanitizedSet), dropped: droppedEntries };
@@ -2325,7 +2326,7 @@ function applyProfileEvent(latest: any | null) {
     p2pkPubError.value = '';
     previousSelectedP2pkPub = '';
     mintsText.value = '';
-    relaysText.value = FUNDSTR_WS_URL;
+    relaysText.value = CREATOR_STUDIO_RELAY_WS_URL;
     seedMintsFromStoreIfEmpty();
     return;
   }
@@ -2374,7 +2375,7 @@ function applyProfileEvent(latest: any | null) {
       }
       relaysText.value = sanitized.join('\n');
     } else {
-      relaysText.value = FUNDSTR_WS_URL;
+      relaysText.value = CREATOR_STUDIO_RELAY_WS_URL;
     }
     if (typeof parsed.tierAddr === 'string') {
       const [kindPart, , dPart] = parsed.tierAddr.split(':');
@@ -2401,7 +2402,7 @@ function applyProfileEvent(latest: any | null) {
     mintsText.value = mintTags.map((t: any) => t[1]).join('\n');
   }
   const relayTags = tags.filter((t: any) => Array.isArray(t) && t[0] === 'relay' && t[1]);
-  if ((!relaysText.value || relaysText.value === FUNDSTR_WS_URL) && relayTags.length) {
+  if ((!relaysText.value || relaysText.value === CREATOR_STUDIO_RELAY_WS_URL) && relayTags.length) {
     const rawRelays = relayTags
       .map((t: any) => (typeof t[1] === 'string' ? t[1].trim() : ''))
       .filter(Boolean);
@@ -2521,7 +2522,7 @@ function ensureRelayStatusListenerOnce() {
     return;
   }
 
-  const targetUrl = relayConnectionUrl.value || FUNDSTR_WS_URL;
+  const targetUrl = relayConnectionUrl.value || CREATOR_STUDIO_RELAY_WS_URL;
   void ensureRelayClientInitialized(targetUrl)
     .then(client => {
       attachRelayStatusListener(client);
@@ -2781,7 +2782,7 @@ async function publishAll() {
       try {
         const result = await publishTiersToRelay(tiers.value, tierKind.value, {
           send: publishEventToRelay,
-          relayUrl: relayConnectionUrl.value || FUNDSTR_WS_URL,
+          relayUrl: relayConnectionUrl.value || CREATOR_STUDIO_RELAY_WS_URL,
         });
         return { result, usedFallback: false as const };
       } catch (err) {
@@ -2789,7 +2790,7 @@ async function publishAll() {
           throw err;
         }
         const fallbackResult = await publishTiersToRelay(tiers.value, tierKind.value, {
-          relayUrl: relayConnectionUrl.value || FUNDSTR_WS_URL,
+          relayUrl: relayConnectionUrl.value || CREATOR_STUDIO_RELAY_WS_URL,
         });
         const reason = describeFallbackReason(err);
         fallbackNotices.push(
@@ -2845,7 +2846,7 @@ async function publishAll() {
       try {
         const result = await publishNostrEvent(profileTemplate, {
           send: publishEventToRelay,
-          relayUrl: relayConnectionUrl.value || FUNDSTR_WS_URL,
+          relayUrl: relayConnectionUrl.value || CREATOR_STUDIO_RELAY_WS_URL,
         });
         return { result, usedFallback: false as const };
       } catch (err) {
@@ -2853,7 +2854,7 @@ async function publishAll() {
           throw err;
         }
         const fallbackClient = await ensureRelayClientInitialized(
-          relayConnectionUrl.value || FUNDSTR_WS_URL
+          relayConnectionUrl.value || CREATOR_STUDIO_RELAY_WS_URL
         );
         const fallbackResult = await fallbackClient.publish(profileTemplate);
         const reason = describeFallbackReason(err);
@@ -2890,7 +2891,7 @@ async function publishAll() {
       profileOutcome.usedFallback || profileResult.ack?.via === 'http' ? ' via HTTP fallback' : '';
     const profileSummary = profileEventId
       ? `Profile published${profileFallbackNote} — id ${profileEventId}${profileRelayMessage}`
-      : `Profile published${profileFallbackNote} to relay.primal.net.${profileRelayMessage}`;
+      : `Profile published${profileFallbackNote} to relay.fundstr.me.${profileRelayMessage}`;
 
     lastPublishInfo.value = `${tierSummary} ${profileSummary}`.trim();
 
@@ -2977,7 +2978,7 @@ watch(
 onMounted(() => {
   void ensureSharedSignerInitialized();
   if (!relaysText.value) {
-    relaysText.value = FUNDSTR_WS_URL;
+    relaysText.value = CREATOR_STUDIO_RELAY_WS_URL;
   }
   if (!authorInput.value.trim()) {
     if (routeAuthorQuery.value) {
@@ -2997,7 +2998,7 @@ onMounted(() => {
     void loadAll();
   }
   if (relaySupported) {
-    const initialRelayUrl = relayConnectionUrl.value || FUNDSTR_WS_URL;
+    const initialRelayUrl = relayConnectionUrl.value || CREATOR_STUDIO_RELAY_WS_URL;
     void ensureRelayClientInitialized(initialRelayUrl)
       .then(() => {
         connectRelay();

--- a/test/vitest/__tests__/CreatorStudioPage.publish.spec.ts
+++ b/test/vitest/__tests__/CreatorStudioPage.publish.spec.ts
@@ -138,14 +138,14 @@ function ensureShared(): SharedMocks {
     };
 
     shared = {
-      relayConnectionUrl: ref('wss://relay.primal.net'),
+      relayConnectionUrl: ref('wss://relay.fundstr.me'),
       relayConnectionStatus,
       relayAutoReconnect: ref(false),
       relayActivity: ref([]),
       relayReconnectAttempts: ref(0),
       relayIsConnected: ref(true),
       relayNeedsAttention,
-      relayUrlInput: ref('wss://relay.primal.net'),
+      relayUrlInput: ref('wss://relay.fundstr.me'),
       relayUrlInputValid: ref(true),
       relayUrlInputState: ref(null),
       relayUrlInputMessage: ref(''),
@@ -590,7 +590,9 @@ describe('CreatorStudioPage publishAll fallback', () => {
     await flushPromises();
 
     expect(state.publishTiersToRelayMock).toHaveBeenCalledTimes(2);
-    expect(state.publishTiersToRelayMock.mock.calls[1][2]).toBeUndefined();
+    expect(state.publishTiersToRelayMock.mock.calls[1][2]).toEqual({
+      relayUrl: 'wss://relay.fundstr.me',
+    });
     expect(state.publishEventToRelayMock).toHaveBeenCalledTimes(2);
     expect(state.clientPublishMock).toHaveBeenCalledTimes(1);
     expect(state.logRelayActivityMock).toHaveBeenCalledWith(

--- a/test/vitest/__tests__/CreatorStudioPage.publishBlockers.spec.ts
+++ b/test/vitest/__tests__/CreatorStudioPage.publishBlockers.spec.ts
@@ -148,14 +148,14 @@ function ensureShared(): SharedMocks {
     const storedMintsRef = ref([{ url: 'https://mint.example' }]);
 
     shared = {
-      relayConnectionUrl: ref('wss://relay.primal.net'),
+      relayConnectionUrl: ref('wss://relay.fundstr.me'),
       relayConnectionStatus,
       relayAutoReconnect: ref(false),
       relayActivity: ref([]),
       relayReconnectAttempts: ref(0),
       relayIsConnected: ref(true),
       relayNeedsAttention,
-      relayUrlInput: ref('wss://relay.primal.net'),
+      relayUrlInput: ref('wss://relay.fundstr.me'),
       relayUrlInputValid: ref(true),
       relayUrlInputState: ref(null),
       relayUrlInputMessage: ref(''),


### PR DESCRIPTION
## Summary
- reference relay.fundstr.me directly inside the Creator Studio UI and logic, including HTTP fallback flows
- refresh Creator Studio vitest fixtures and expectations to match the new relay defaults

## Testing
- pnpm vitest run test/vitest/__tests__/CreatorStudioPage.publish.spec.ts test/vitest/__tests__/CreatorStudioPage.publishBlockers.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68df713e178083309e76fb883c88f70a