### PR TITLE
Add Nutzap explainer content and tooltips

### DIFF
--- a/src/components/NutzapExplainer.vue
+++ b/src/components/NutzapExplainer.vue
@@ -1,0 +1,125 @@
+<template>
+  <section class="nutzap-explainer bg-surface-2 text-1" aria-labelledby="nutzap-explainer-heading">
+    <div class="nutzap-explainer__header">
+      <h3 id="nutzap-explainer-heading" class="nutzap-explainer__title">
+        {{ t("FindCreators.explainers.heading") }}
+      </h3>
+      <p class="nutzap-explainer__intro text-2">
+        {{ t("FindCreators.explainers.intro") }}
+      </p>
+    </div>
+    <q-timeline color="accent" layout="comfortable" class="nutzap-explainer__timeline">
+      <q-timeline-entry
+        v-for="step in steps"
+        :key="step.key"
+        :title="step.title"
+        class="nutzap-explainer__entry"
+      >
+        <p class="nutzap-explainer__body text-2">{{ step.body }}</p>
+      </q-timeline-entry>
+    </q-timeline>
+    <div v-if="isGuest" class="nutzap-explainer__cta">
+      <q-btn
+        color="primary"
+        unelevated
+        class="nutzap-explainer__cta-btn"
+        :label="t('FindCreators.explainers.ctaLabel')"
+        :aria-label="t('FindCreators.explainers.ctaAria')"
+        @click="emit('start-onboarding')"
+      />
+      <p class="nutzap-explainer__cta-hint text-2">
+        {{ t("FindCreators.explainers.ctaHint") }}
+      </p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
+
+defineOptions({ name: "NutzapExplainer" });
+
+const props = defineProps<{ isGuest?: boolean }>();
+const emit = defineEmits<{ (e: "start-onboarding"): void }>();
+
+const { t } = useI18n();
+
+const stepKeys = ["subscriptions", "trustedMints", "relays"] as const;
+
+type StepKey = (typeof stepKeys)[number];
+
+type StepContent = { title: string; body: string; key: StepKey };
+
+const steps = computed<StepContent[]>(() =>
+  stepKeys.map((key) => ({
+    key,
+    title: t(`FindCreators.explainers.steps.${key}.title`),
+    body: t(`FindCreators.explainers.steps.${key}.body`),
+  })),
+);
+
+const isGuest = computed(() => props.isGuest === true);
+</script>
+
+<style scoped>
+.nutzap-explainer {
+  border: 1px solid var(--surface-contrast-border);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.nutzap-explainer__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.nutzap-explainer__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.nutzap-explainer__intro {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.nutzap-explainer__timeline {
+  padding-left: 0;
+}
+
+.nutzap-explainer__entry :deep(.q-timeline__subtitle) {
+  font-weight: 600;
+  color: var(--text-1);
+}
+
+.nutzap-explainer__body {
+  margin: 0.35rem 0 0;
+  line-height: 1.5;
+}
+
+.nutzap-explainer__cta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.nutzap-explainer__cta-btn {
+  align-self: flex-start;
+}
+
+.nutzap-explainer__cta-hint {
+  margin: 0;
+}
+
+@media (max-width: 600px) {
+  .nutzap-explainer {
+    padding: 1rem 1.25rem;
+  }
+}
+</style>

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1311,6 +1311,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1310,6 +1310,40 @@ export const messages = {
       invalid_creator_pubkey: "Invalid creator pubkey",
       subscription_failed: "Subscription failed",
     },
+    explainers: {
+      heading: "How Nutzap subscriptions work",
+      intro:
+        "Here's how Nutzap keeps your support flowing with ecash you control.",
+      ctaLabel: "@:CreatorHub.profile.finishSetup",
+      ctaAria: "Finish onboarding to subscribe",
+      ctaHint:
+        "Complete onboarding to connect your wallet, choose mints, and start supporting creators.",
+      steps: {
+        subscriptions: {
+          title: "Subscriptions you control",
+          body:
+            "Choose a tier and Nutzap signs zap payments from your wallet on the cadence you set—funds only move with your approval.",
+        },
+        trustedMints: {
+          title: "Trusted mints",
+          body:
+            "You fund your wallet from mints you trust. Only those mints can issue the ecash your subscriptions will spend.",
+        },
+        relays: {
+          title: "Relay delivery",
+          body:
+            "Relays carry the signed invoices and receipts between you and the creator while keeping your keys private.",
+        },
+      },
+      tooltips: {
+        p2pk:
+          "Creators publish a P2PK key so you can send ecash to them directly from your wallet.",
+        trustedMints:
+          "These are the mints the creator trusts. Connect with at least one compatible mint before subscribing.",
+        relays:
+          "Relays deliver the zap instructions and acknowledgements that power each subscription payment.",
+      },
+    },
   },
   ChooseExistingTokenDialog: {
     title: "Choose token",

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -89,6 +89,11 @@
                   </p>
                 </div>
               </div>
+              <NutzapExplainer
+                class="tier-dialog__explainer"
+                :is-guest="isGuest"
+                @start-onboarding="goToWelcome"
+              />
               <div class="tier-list">
                 <div
                   v-if="loadingTiers"
@@ -203,15 +208,60 @@
                 </div>
                 <div v-if="nutzapProfile" class="info-panel__body">
                   <div v-if="nutzapProfile.p2pkPubkey" class="info-subsection">
-                    <div class="info-subsection__label text-2">P2PK public key</div>
+                    <div class="info-subsection__label text-2">
+                      <span>{{ $t('CreatorHub.profile.p2pkLabel') }}</span>
+                      <q-btn
+                        flat
+                        dense
+                        round
+                        size="sm"
+                        class="info-subsection__info-btn"
+                        icon="info"
+                        :aria-label="$t('FindCreators.explainers.tooltips.p2pk')"
+                      >
+                        <q-tooltip anchor="top middle" self="bottom middle">
+                          {{ $t('FindCreators.explainers.tooltips.p2pk') }}
+                        </q-tooltip>
+                      </q-btn>
+                    </div>
                     <code class="info-subsection__value">{{ nutzapProfile.p2pkPubkey }}</code>
                   </div>
                   <div class="info-subsection">
-                    <div class="info-subsection__label text-2">Trusted mints</div>
+                    <div class="info-subsection__label text-2">
+                      <span>{{ $t('CreatorHub.profile.trustedMintsLabel') }}</span>
+                      <q-btn
+                        flat
+                        dense
+                        round
+                        size="sm"
+                        class="info-subsection__info-btn"
+                        icon="info"
+                        :aria-label="$t('FindCreators.explainers.tooltips.trustedMints')"
+                      >
+                        <q-tooltip anchor="top middle" self="bottom middle">
+                          {{ $t('FindCreators.explainers.tooltips.trustedMints') }}
+                        </q-tooltip>
+                      </q-btn>
+                    </div>
                     <MintSafetyList :mints="nutzapProfile.trustedMints" />
                   </div>
                   <div class="info-subsection">
-                    <div class="info-subsection__label text-2">Relays</div>
+                    <div class="info-subsection__label text-2">
+                      <span>{{ $t('CreatorHub.profile.relaysLabel') }}</span>
+                      <q-btn
+                        flat
+                        dense
+                        round
+                        size="sm"
+                        class="info-subsection__info-btn"
+                        icon="info"
+                        :aria-label="$t('FindCreators.explainers.tooltips.relays')"
+                      >
+                        <q-tooltip anchor="top middle" self="bottom middle">
+                          {{ $t('FindCreators.explainers.tooltips.relays') }}
+                        </q-tooltip>
+                      </q-btn>
+                    </div>
                     <RelayBadgeList :relays="nutzapProfile.relays" />
                   </div>
                 </div>
@@ -252,8 +302,11 @@ import MediaPreview from "components/MediaPreview.vue";
 import NostrRelayErrorBanner from "components/NostrRelayErrorBanner.vue";
 import MintSafetyList from "components/MintSafetyList.vue";
 import RelayBadgeList from "components/RelayBadgeList.vue";
+import NutzapExplainer from "components/NutzapExplainer.vue";
 
-defineOptions({ components: { MediaPreview, MintSafetyList, RelayBadgeList } });
+defineOptions({
+  components: { MediaPreview, MintSafetyList, RelayBadgeList, NutzapExplainer },
+});
 import { useSendTokensStore } from "stores/sendTokensStore";
 import { useDonationPresetsStore } from "stores/donationPresets";
 import { useCreatorsStore } from "stores/creators";
@@ -269,6 +322,7 @@ import {
   QBanner,
   QSeparator,
   QPage,
+  QTooltip,
   useQuasar,
 } from "quasar";
 import { nip19 } from "nostr-tools";
@@ -283,6 +337,7 @@ import {
 import type { PrefillCreatorCacheEntry } from "stores/creators";
 import { usePriceStore } from "stores/price";
 import { useUiStore } from "stores/ui";
+import { useWelcomeStore } from "stores/welcome";
 import {
   daysToFrequency,
   type SubscriptionFrequency,
@@ -315,6 +370,7 @@ const route = useRoute();
 const $q = useQuasar();
 const priceStore = usePriceStore();
 const uiStore = useUiStore();
+const welcomeStore = useWelcomeStore();
 const tiers = computed(() => creators.tiersMap[dialogPubkey.value] || []);
 const CUSTOM_LINK_WS_TIMEOUT_MS = Math.min(WS_FIRST_TIMEOUT_MS, 1200);
 let usedFundstrOnly = false;
@@ -324,6 +380,7 @@ const selectedTier = ref<any>(null);
 const nutzapProfile = ref<NutzapProfileDetails | null>(null);
 const loadingProfile = ref(false);
 const lastRelayHints = ref<string[]>([]);
+const isGuest = computed(() => !welcomeStore.welcomeCompleted);
 let tierTimeout: ReturnType<typeof setTimeout> | null = null;
 type HeroMetadata = {
   displayName?: string;
@@ -429,6 +486,10 @@ function extractHeroMetadata(source: any): HeroMetadata {
 
   return metadata;
 }
+
+const goToWelcome = () => {
+  void router.push({ path: "/welcome", query: { first: "1" } });
+};
 
 function updateHeroMetadata(source: any, options: { preserveExisting?: boolean } = {}) {
   const { preserveExisting = false } = options;
@@ -1059,6 +1120,10 @@ onBeforeUnmount(() => {
   margin: 0.35rem 0 0;
 }
 
+.tier-dialog__explainer {
+  margin-bottom: 1.5rem;
+}
+
 .tier-list__state {
   display: flex;
   flex-direction: column;
@@ -1230,6 +1295,28 @@ onBeforeUnmount(() => {
   font-size: 0.85rem;
   letter-spacing: 0.02em;
   text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.info-subsection__info-btn {
+  color: var(--text-2);
+  min-width: 0;
+  padding: 0;
+}
+
+.info-subsection__info-btn :deep(.q-btn__content) {
+  padding: 0;
+}
+
+.info-subsection__info-btn :deep(.q-icon) {
+  font-size: 1rem;
+}
+
+.info-subsection__info-btn:focus-visible {
+  outline: 2px solid var(--accent-500);
+  outline-offset: 2px;
 }
 
 .info-subsection__value {

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -101,6 +101,11 @@
             <q-spinner-hourglass />
           </div>
           <template v-else>
+            <NutzapExplainer
+              class="profile-tier-explainer"
+              :is-guest="isGuest"
+              @start-onboarding="gotoWelcome"
+            />
             <q-banner
               v-if="tierFetchError && !tiers.length"
               class="profile-page__banner bg-surface-2"
@@ -226,21 +231,60 @@
                 {{ $t('CreatorHub.profile.infrastructureDetails') }}
               </h3>
               <div v-if="profile.p2pkPubkey" class="profile-card__row">
-                <span class="profile-card__label text-2">{{
-                  $t('CreatorHub.profile.p2pkLabel')
-                }}</span>
+                <div class="profile-card__label text-2">
+                  <span>{{ $t('CreatorHub.profile.p2pkLabel') }}</span>
+                  <q-btn
+                    flat
+                    dense
+                    round
+                    size="sm"
+                    class="profile-card__info-btn"
+                    icon="info"
+                    :aria-label="$t('FindCreators.explainers.tooltips.p2pk')"
+                  >
+                    <q-tooltip anchor="top middle" self="bottom middle">
+                      {{ $t('FindCreators.explainers.tooltips.p2pk') }}
+                    </q-tooltip>
+                  </q-btn>
+                </div>
                 <code class="profile-card__value">{{ profile.p2pkPubkey }}</code>
               </div>
               <div class="profile-card__row">
-                <span class="profile-card__label text-2">{{
-                  $t('CreatorHub.profile.trustedMintsLabel')
-                }}</span>
+                <div class="profile-card__label text-2">
+                  <span>{{ $t('CreatorHub.profile.trustedMintsLabel') }}</span>
+                  <q-btn
+                    flat
+                    dense
+                    round
+                    size="sm"
+                    class="profile-card__info-btn"
+                    icon="info"
+                    :aria-label="$t('FindCreators.explainers.tooltips.trustedMints')"
+                  >
+                    <q-tooltip anchor="top middle" self="bottom middle">
+                      {{ $t('FindCreators.explainers.tooltips.trustedMints') }}
+                    </q-tooltip>
+                  </q-btn>
+                </div>
                 <MintSafetyList :mints="trustedMints" />
               </div>
               <div class="profile-card__row">
-                <span class="profile-card__label text-2">{{
-                  $t('CreatorHub.profile.relaysLabel')
-                }}</span>
+                <div class="profile-card__label text-2">
+                  <span>{{ $t('CreatorHub.profile.relaysLabel') }}</span>
+                  <q-btn
+                    flat
+                    dense
+                    round
+                    size="sm"
+                    class="profile-card__info-btn"
+                    icon="info"
+                    :aria-label="$t('FindCreators.explainers.tooltips.relays')"
+                  >
+                    <q-tooltip anchor="top middle" self="bottom middle">
+                      {{ $t('FindCreators.explainers.tooltips.relays') }}
+                    </q-tooltip>
+                  </q-btn>
+                </div>
                 <RelayBadgeList :relays="relayList" />
               </div>
             </article>
@@ -323,6 +367,7 @@ import PaywalledContent from "components/PaywalledContent.vue";
 import MediaPreview from "components/MediaPreview.vue";
 import MintSafetyList from "components/MintSafetyList.vue";
 import RelayBadgeList from "components/RelayBadgeList.vue";
+import NutzapExplainer from "components/NutzapExplainer.vue";
 import { isTrustedUrl } from "src/utils/sanitize-url";
 import { useClipboard } from "src/composables/useClipboard";
 import { useWelcomeStore } from "stores/welcome";
@@ -336,6 +381,7 @@ export default defineComponent({
     SetupRequiredDialog,
     MintSafetyList,
     RelayBadgeList,
+    NutzapExplainer,
   },
   setup() {
     const route = useRoute();
@@ -961,6 +1007,10 @@ export default defineComponent({
   gap: 1rem;
 }
 
+.profile-tier-explainer {
+  margin-bottom: 1.5rem;
+}
+
 .profile-tier__description {
   margin: 0;
 }
@@ -1032,6 +1082,28 @@ export default defineComponent({
   text-transform: uppercase;
   font-size: 0.75rem;
   letter-spacing: 0.08em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.profile-card__info-btn {
+  color: var(--text-2);
+  min-width: 0;
+  padding: 0;
+}
+
+.profile-card__info-btn :deep(.q-btn__content) {
+  padding: 0;
+}
+
+.profile-card__info-btn :deep(.q-icon) {
+  font-size: 1rem;
+}
+
+.profile-card__info-btn:focus-visible {
+  outline: 2px solid var(--accent-500);
+  outline-offset: 2px;
 }
 
 .profile-card__value {


### PR DESCRIPTION
## Summary
- add a reusable NutzapExplainer timeline with guest onboarding CTA for the find creators dialog and public profile tiers
- explain P2PK keys, trusted mints, and relay lists with accessible info tooltips in both views
- expand the i18n bundle with plain-language Nutzap subscription copy across all locales

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df871a497c8330a71226f277ad004f