### PR TITLE
Enable Fundstr-only relays on staging

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -2,6 +2,7 @@ VITE_APP_ENV=staging
 VITE_API_BASE=https://api-staging.fundstr.me
 VITE_DONATION_LIGHTNING=lightning_address_here
 VITE_DONATION_BITCOIN=bitcoin_address_here
+VITE_FUNDSTR_ONLY_RELAYS=true
 
 # Nutzap isolated relay (WSS first, HTTP fallback)
 VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.fundstr.me


### PR DESCRIPTION
## Summary
- add the `VITE_FUNDSTR_ONLY_RELAYS` flag to the staging environment so Fundstr-only relay mode activates immediately

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df97193d48833096bbdedca6214f83