### PR TITLE
Defer Nostr initialization until messenger routes need it

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,7 +20,10 @@ import { useNostrStore } from "src/stores/nostr";
  */
 
 export default route(async function (/* { store, ssrContext } */) {
-  await useNostrStore().loadKeysFromStorage();
+  const nostrStore = useNostrStore();
+  void nostrStore
+    .loadKeysFromStorage()
+    .catch((err) => console.warn("Failed to warm Nostr keys", err));
   const createHistory = process.env.SERVER
     ? createMemoryHistory
     : process.env.VUE_ROUTER_MODE === "history"


### PR DESCRIPTION
## Summary
- avoid gating router creation on synchronous Nostr key loading
- lazily initialise the Nostr signer when the messenger mounts and reuse the result
- show loading and retry states in the messenger UI so actions stay disabled until relays are ready

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df9ea9d13483309a88ad41dd808498