### PR TITLE
Remove unused TypeScript import from UI store

### DIFF
--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -12,8 +12,6 @@ import {
 import { Clipboard } from "@capacitor/clipboard";
 import { Haptics, ImpactStyle } from "@capacitor/haptics";
 
-import ts from "typescript";
-
 const unitTickerShortMap = {
   sat: "sats",
   usd: "USD",


### PR DESCRIPTION
## Summary
- remove the unused TypeScript runtime import from the UI store so it is no longer bundled
- verify the production bundle no longer references the TypeScript package

## Testing
- pnpm lint
- pnpm test
- pnpm dlx @quasar/cli build -m spa

------
https://chatgpt.com/codex/tasks/task_e_68dfa3e5d340833087ad1462890a6d99