### PR TITLE
Improve relay retry strategy and diagnostics

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -187,6 +187,23 @@
         color: #b7791f;
         font-weight: 600;
       }
+      .relay-log {
+        margin: 0.75rem auto 0;
+        padding: 0.75rem 1rem;
+        background-color: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 0.5rem;
+        color: #4a5568;
+        font-size: 0.875rem;
+        list-style: none;
+        width: min(100%, clamp(320px, 85vw, 1100px));
+      }
+      .relay-log.hidden {
+        display: none;
+      }
+      .relay-log li + li {
+        margin-top: 0.5rem;
+      }
       .retry-button {
         margin: 0 auto;
         margin-top: -1rem;
@@ -324,6 +341,7 @@
       </div>
 
       <p id="relayWarning" class="relay-warning hidden"></p>
+      <ul id="relayDiagnostics" class="relay-log hidden"></ul>
       <div class="relay-info">Connecting to: <span id="relayList"></span></div>
     </div>
 
@@ -334,7 +352,12 @@
         getDefaultRelayList,
         getRelayConfig,
       } from "./relayConfig.js";
-      import { filterHealthyRelays, pingRelay } from "./relayHealth.js";
+      import {
+        filterHealthyRelays,
+        getRelayDiagnosticsSnapshot,
+        pingRelay,
+      } from "./relayHealth.js";
+      import { createExponentialBackoffScheduler } from "./retryScheduler.js";
 
       const relayConfig = getRelayConfig();
       const FUNDSTR_RELAY = relayConfig.primary;
@@ -345,6 +368,9 @@
       const primaryRelayLabel = `${primaryRelayHost} relay`;
       const statusMessageElement = document.getElementById("statusMessage");
       const relayWarningElement = document.getElementById("relayWarning");
+      const relayDiagnosticsElement = document.getElementById(
+        "relayDiagnostics",
+      );
       const retryButtonElement = document.getElementById("retryButton");
       const relayListElement = document.getElementById("relayList");
       // --- Nostr Tools ---
@@ -398,59 +424,172 @@
 
       const EMPTY_RESULT_CODE = "EMPTY_RESULT";
 
-      let relayFailureCount = 0;
-      async function refreshRelays() {
-        try {
-          const healthy = await filterHealthyRelays(DEFAULT_RELAYS);
-          const fundstrReachable = await pingRelay(FUNDSTR_RELAY);
-          const prioritized = [
-            FUNDSTR_RELAY,
-            ...healthy.filter((relay) => relay !== FUNDSTR_RELAY),
-          ];
-          RELAYS = prioritized;
-          relayFailureCount = 0;
-          renderRelayList(RELAYS);
-          statusMessageElement.classList.add("hidden");
-          if (fundstrReachable) {
-            relayWarningElement.classList.add("hidden");
-            relayWarningElement.textContent = "";
-          } else {
-            const activeBackups = RELAYS.slice(1);
-            const fallbackList = activeBackups.length
-              ? formatRelayList(activeBackups)
-              : curatedBackups.length
-              ? formatRelayList(curatedBackups)
-              : paidBackupHosts.length
-              ? `opt-in paid relays (${formatRelayList(paidBackupHosts)})`
-              : "no backups available";
-            relayWarningElement.textContent =
-              fallbackList === "no backups available"
-                ? `${primaryRelayLabel} is temporarily unreachable and no backups are configured yet.`
-                : `${primaryRelayLabel} is temporarily unreachable. We'll keep retrying while using ${fallbackList}.`;
-            relayWarningElement.classList.remove("hidden");
-          }
-        } catch {
-          relayFailureCount++;
-          if (relayFailureCount >= 3) {
-            console.error(
-              "[find-creators] no reachable relays:",
-              formatRelayList(DEFAULT_RELAYS),
-            );
-            const curatedBackupList = curatedBackups.length
-              ? formatRelayList(curatedBackups)
-              : null;
-            statusMessageElement.textContent = curatedBackupList
-              ? `Network error: could not reach ${primaryRelayLabel} or curated backups (${curatedBackupList}).`
-              : `Network error: could not reach ${primaryRelayLabel} and no curated backups are configured.`;
-            statusMessageElement.classList.remove("hidden");
-            relayWarningElement.classList.add("hidden");
-            relayWarningElement.textContent = "";
-            clearInterval(relayInterval);
-          }
-        }
+      const monitoredRelaySet = new Set([
+        ...DEFAULT_RELAYS,
+        ...curatedBackups,
+        ...paidBackups,
+        FUNDSTR_RELAY,
+      ]);
+
+      function getMonitoredDiagnostics() {
+        const snapshot = getRelayDiagnosticsSnapshot();
+        return snapshot
+          .filter((entry) => monitoredRelaySet.has(entry.url))
+          .sort((a, b) => {
+            if (a.url === b.url) return 0;
+            if (a.url === FUNDSTR_RELAY) return -1;
+            if (b.url === FUNDSTR_RELAY) return 1;
+            return a.url.localeCompare(b.url);
+          });
       }
-      const relayInterval = setInterval(refreshRelays, 30000);
-      refreshRelays();
+
+      function describeDiagnostic(entry) {
+        const host = describeRelay(entry.url);
+        if (entry.status === "ok") {
+          return `${host}: reachable`;
+        }
+        const typeLabel = (entry.type || entry.status || "error").replace(
+          /-/g,
+          " ",
+        );
+        const codeLabel = entry.code ? ` (code: ${entry.code})` : "";
+        const messageText = entry.message
+          ? ` — ${entry.message}`
+          : entry.softFailure
+          ? " — relay restricted this origin"
+          : "";
+        return `${host}: ${typeLabel}${codeLabel}${messageText}`;
+      }
+
+      function renderRelayDiagnostics(diagnostics) {
+        if (!relayDiagnosticsElement) return;
+        relayDiagnosticsElement.innerHTML = "";
+        if (!diagnostics.length) {
+          relayDiagnosticsElement.classList.add("hidden");
+          return;
+        }
+        diagnostics.forEach((entry) => {
+          const li = document.createElement("li");
+          li.textContent = describeDiagnostic(entry);
+          relayDiagnosticsElement.appendChild(li);
+        });
+        relayDiagnosticsElement.classList.remove("hidden");
+      }
+
+      function summarizeProbe(result) {
+        if (!result || result.ok) {
+          return "reachable";
+        }
+        if (result.error?.type === "restricted-origin" || result.softFailure) {
+          return "origin restricted";
+        }
+        const typeLabel = (result.error?.type || "error").replace(/-/g, " ");
+        const codeLabel = result.error?.code ? ` (code: ${result.error.code})` : "";
+        return `${typeLabel}${codeLabel}`;
+      }
+
+      function computeFallbackDescriptor(activeBackups) {
+        if (activeBackups.length) return formatRelayList(activeBackups);
+        if (curatedBackups.length) return formatRelayList(curatedBackups);
+        if (paidBackupHosts.length)
+          return `opt-in paid relays (${formatRelayList(paidBackupHosts)})`;
+        return "no backups available";
+      }
+
+      function describeLastError(diagnostics) {
+        if (!diagnostics.length) return "unknown error";
+        const [first] = diagnostics;
+        const host = describeRelay(first.url);
+        const typeLabel = (first.type || first.status || "error").replace(
+          /-/g,
+          " ",
+        );
+        const codeLabel = first.code ? ` (code: ${first.code})` : "";
+        return `${host} → ${typeLabel}${codeLabel}`;
+      }
+
+      async function refreshRelays() {
+        const healthy = await filterHealthyRelays(DEFAULT_RELAYS);
+        const fundstrProbe = await pingRelay(FUNDSTR_RELAY);
+        const prioritized = [
+          FUNDSTR_RELAY,
+          ...healthy.filter((relay) => relay !== FUNDSTR_RELAY),
+        ];
+        RELAYS = Array.from(new Set(prioritized));
+        renderRelayList(RELAYS);
+
+        const diagnostics = getMonitoredDiagnostics();
+        const failingDiagnostics = diagnostics.filter(
+          (entry) => entry.status === "error",
+        );
+
+        if (fundstrProbe.ok) {
+          relayWarningElement.classList.add("hidden");
+          relayWarningElement.textContent = "";
+          renderRelayDiagnostics([]);
+        } else {
+          const activeBackups = RELAYS.slice(1);
+          const fallbackDescriptor = computeFallbackDescriptor(activeBackups);
+          const probeSummary = summarizeProbe(fundstrProbe);
+          relayWarningElement.textContent =
+            fallbackDescriptor === "no backups available"
+              ? `${primaryRelayLabel} is temporarily unreachable (${probeSummary}) and no backups are configured yet.`
+              : `${primaryRelayLabel} is temporarily unreachable (${probeSummary}). We'll keep retrying while using ${fallbackDescriptor}.`;
+          relayWarningElement.classList.remove("hidden");
+          renderRelayDiagnostics(failingDiagnostics);
+        }
+
+        const hasReachable = diagnostics.some((entry) => entry.status === "ok");
+        if (!hasReachable && diagnostics.length) {
+          const error = new Error("No reachable relays detected");
+          error.diagnostics = diagnostics;
+          throw error;
+        }
+
+        statusMessageElement.classList.add("hidden");
+        return { healthy, fundstrProbe };
+      }
+
+      const relayRefreshScheduler = createExponentialBackoffScheduler(
+        () => refreshRelays(),
+        {
+          initialRetryDelayMs: 5000,
+          maxRetryDelayMs: 180000,
+          successDelayMs: 30000,
+          onFailure: (_error, { nextDelay }) => {
+            const diagnostics = getMonitoredDiagnostics();
+            const failingDiagnostics = diagnostics.filter(
+              (entry) => entry.status === "error",
+            );
+            renderRelayDiagnostics(failingDiagnostics);
+
+            const fallbackDescriptor = computeFallbackDescriptor(RELAYS.slice(1));
+            const nextRetrySeconds = Math.max(1, Math.round(nextDelay / 1000));
+            const lastErrorSummary = describeLastError(failingDiagnostics);
+
+            relayWarningElement.textContent =
+              fallbackDescriptor === "no backups available"
+                ? `${primaryRelayLabel} remains unreachable (${lastErrorSummary}). Retrying in ${nextRetrySeconds}s with no backups available.`
+                : `${primaryRelayLabel} remains unreachable (${lastErrorSummary}). Retrying in ${nextRetrySeconds}s while monitoring ${fallbackDescriptor}.`;
+            relayWarningElement.classList.remove("hidden");
+
+            statusMessageElement.textContent =
+              fallbackDescriptor === "no backups available"
+                ? `Network error: could not reach ${primaryRelayLabel} and no curated backups are configured.`
+                : `Network error: could not reach ${primaryRelayLabel} or backups (${fallbackDescriptor}).`;
+            statusMessageElement.classList.remove("hidden");
+          },
+          onSuccess: () => {
+            statusMessageElement.classList.add("hidden");
+          },
+        },
+      );
+
+      relayRefreshScheduler.start();
+
+      window.addEventListener("beforeunload", () => {
+        relayRefreshScheduler.stop();
+      });
 
       const FEATURED_NPUBS = [
         "npub1aljmhjp5tqrw3m60ra7t3u8uqq223d6rdg9q0h76a8djd9m4hmvsmlj82m",

--- a/public/relayHealth.js
+++ b/public/relayHealth.js
@@ -20,6 +20,98 @@ let allFailedWarned = false;
 const CACHE_TTL_MS = 60_000;
 const pingCache = new Map();
 const filterCache = new Map();
+const relayDiagnostics = new Map();
+
+const SOFT_FAILURE_CODES = new Set([1008, 1013, 4403]);
+
+function classifyCloseEvent(event) {
+  const { code, reason } = event ?? {};
+  if (!event) {
+    return {
+      error: {
+        type: "unknown-close",
+        message: "Connection closed unexpectedly",
+      },
+      softFailure: false,
+    };
+  }
+
+  const normalizedReason = typeof reason === "string" ? reason : "";
+  const reasonLower = normalizedReason.toLowerCase();
+  if (SOFT_FAILURE_CODES.has(code) || /restricted|origin/.test(reasonLower)) {
+    return {
+      error: {
+        type: "restricted-origin",
+        code: code || 403,
+        message:
+          normalizedReason ||
+          "Relay rejected the connection due to origin restrictions.",
+      },
+      softFailure: true,
+    };
+  }
+
+  if (code === 1015) {
+    return {
+      error: {
+        type: "tls-error",
+        code,
+        message:
+          normalizedReason ||
+          "TLS handshake failed while establishing the WebSocket connection.",
+      },
+      softFailure: false,
+    };
+  }
+
+  if (code === 1006) {
+    return {
+      error: {
+        type: "abnormal-closure",
+        code,
+        message:
+          normalizedReason ||
+          "Connection closed before the handshake could complete.",
+      },
+      softFailure: false,
+    };
+  }
+
+  return {
+    error: {
+      type: "closed",
+      code,
+      message:
+        normalizedReason || "Connection closed before the relay responded.",
+    },
+    softFailure: false,
+  };
+}
+
+function recordRelaySuccess(url) {
+  relayDiagnostics.set(url, {
+    status: "ok",
+    timestamp: Date.now(),
+  });
+}
+
+function recordRelayFailure(url, error, softFailure) {
+  relayDiagnostics.set(url, {
+    status: "error",
+    timestamp: Date.now(),
+    type: error?.type ?? "error",
+    code: error?.code,
+    message: error?.message ?? "Unknown failure",
+    softFailure: Boolean(softFailure),
+  });
+}
+
+export function getRelayDiagnosticsSnapshot() {
+  return Array.from(relayDiagnostics.entries()).map(([url, info]) => ({
+    url,
+    ...info,
+  }));
+}
 
 function scheduleFailureLog() {
   if (aggregateTimer) return;
@@ -29,7 +121,13 @@ function scheduleFailureLog() {
     aggregateTimer = null;
     if (!entries.length) return;
     const summary = entries
-      .map(([u, c]) => (c > 1 ? `${u} (x${c})` : u))
+      .map(([u, { count, error }]) => {
+        const suffix = count > 1 ? ` (x${count})` : "";
+        if (error?.type) {
+          return `${u}${suffix} [${error.type}]`;
+        }
+        return `${u}${suffix}`;
+      })
       .join(", ");
     for (const [u] of entries) {
       alreadyReported.add(u);
@@ -41,72 +139,110 @@ function scheduleFailureLog() {
 export async function pingRelay(url) {
   const cached = pingCache.get(url);
   const now = Date.now();
-  if (cached && now - cached.ts < CACHE_TTL_MS) return cached.ok;
+  if (cached && now - cached.ts < CACHE_TTL_MS) {
+    return { ...cached.result };
+  }
 
   const isFundstr = url === FUNDSTR_RELAY;
   const attemptOnce = (timeoutMs) =>
     new Promise((resolve) => {
       let settled = false;
+      let timer = null;
       let ws;
+
+      const finalize = (result) => {
+        if (settled) return;
+        settled = true;
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        try {
+          if (ws && ws.readyState === WebSocket.OPEN) {
+            ws.close();
+          }
+        } catch {}
+        resolve(result);
+      };
+
       try {
-        ws = new WebSocket(url);
-      } catch {
-        resolve(false);
+        ws = new WebSocket(url, "nostr");
+      } catch (error) {
+        finalize({
+          ok: false,
+          error: {
+            type: "constructor-error",
+            message: error?.message || "WebSocket constructor failed",
+          },
+          softFailure: false,
+        });
         return;
       }
-      const timer = setTimeout(() => {
-        if (!settled) {
-          settled = true;
-          if (ws.readyState === WebSocket.OPEN) {
-            try {
-              ws.close();
-            } catch {}
-          } else if (ws.readyState === WebSocket.CONNECTING) {
-            ws.onopen = () => {
-              try {
-                ws.close();
-              } catch {}
-            };
-          }
-          resolve(false);
-        }
+
+      timer = setTimeout(() => {
+        finalize({
+          ok: false,
+          error: {
+            type: "timeout",
+            message: `Timed out after ${timeoutMs}ms while waiting for relay response`,
+          },
+          softFailure: false,
+        });
       }, timeoutMs);
+
       ws.onopen = () => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(timer);
-          ws.close();
-          resolve(true);
-        }
+        finalize({ ok: true });
       };
+
       ws.onerror = () => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(timer);
-          resolve(false);
-        }
+        finalize({
+          ok: false,
+          error: {
+            type: "network-error",
+            message: "Network error occurred while connecting to relay",
+          },
+          softFailure: false,
+        });
       };
+
+      ws.onclose = (event) => {
+        if (settled) return;
+        const result = classifyCloseEvent(event);
+        finalize({ ok: false, ...result });
+      };
+
       ws.onmessage = (ev) => {
         if (
-          !settled &&
-          typeof ev.data === "string" &&
-          ev.data.startsWith("restricted:")
+          settled ||
+          typeof ev.data !== "string" ||
+          !ev.data.toLowerCase().startsWith("restricted:")
         ) {
-          settled = true;
-          clearTimeout(timer);
-          ws.close();
-          resolve(false);
+          return;
         }
+        finalize({
+          ok: false,
+          error: {
+            type: "restricted-origin",
+            code: 403,
+            message: ev.data,
+          },
+          softFailure: true,
+        });
       };
     });
 
   const maxAttempts = isFundstr ? 5 : 3;
   let delay = isFundstr ? 1500 : 1000;
   let timeoutMs = isFundstr ? 3000 : 1200;
+  let lastResult = { ok: false, error: { type: "unknown" }, softFailure: false };
+
   for (let i = 0; i < maxAttempts; i++) {
-    if (await attemptOnce(timeoutMs)) {
-      pingCache.set(url, { ts: now, ok: true });
-      return true;
+    lastResult = await attemptOnce(timeoutMs);
+    if (lastResult.ok) {
+      recordRelaySuccess(url);
+      const result = { ...lastResult };
+      pingCache.set(url, { ts: now, result });
+      return { ...result };
     }
     if (i < maxAttempts - 1) {
       await new Promise((r) => setTimeout(r, delay));
@@ -115,12 +251,18 @@ export async function pingRelay(url) {
     }
   }
 
+  recordRelayFailure(url, lastResult.error, lastResult.softFailure);
   if (!alreadyReported.has(url)) {
-    reportedFailures.set(url, (reportedFailures.get(url) ?? 0) + maxAttempts);
+    const prev = reportedFailures.get(url) ?? { count: 0, error: null };
+    reportedFailures.set(url, {
+      count: prev.count + maxAttempts,
+      error: lastResult.error,
+    });
     scheduleFailureLog();
   }
-  pingCache.set(url, { ts: now, ok: false });
-  return false;
+  const result = { ...lastResult };
+  pingCache.set(url, { ts: now, result });
+  return { ...result };
 }
 
 export async function filterHealthyRelays(relays) {
@@ -135,9 +277,11 @@ export async function filterHealthyRelays(relays) {
   for (let i = 0; i < relays.length; i += batchSize) {
     const batch = relays.slice(i, i + batchSize);
     const results = await Promise.all(
-      batch.map(async (u) => ((await pingRelay(u)) ? u : null)),
+      batch.map(async (u) => ({ url: u, result: await pingRelay(u) })),
     );
-    const batchHealthy = results.filter((u) => !!u);
+    const batchHealthy = results
+      .filter(({ result }) => result.ok)
+      .map(({ url }) => url);
     healthy.push(...batchHealthy);
   }
   const healthyWithFundstr = ensurePrimary(healthy);

--- a/public/retryScheduler.js
+++ b/public/retryScheduler.js
@@ -1,0 +1,76 @@
+export function createExponentialBackoffScheduler(task, options = {}) {
+  const {
+    initialRetryDelayMs = 5000,
+    maxRetryDelayMs = 300000,
+    successDelayMs = 30000,
+    multiplier = 2,
+    onSuccess,
+    onFailure,
+  } = options;
+
+  let attempt = 0;
+  let active = false;
+  let timerId = null;
+
+  const clearTimer = () => {
+    if (timerId !== null) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+  };
+
+  const scheduleNext = (delay) => {
+    if (!active) return;
+    clearTimer();
+    timerId = setTimeout(runTask, delay);
+  };
+
+  const runTask = async () => {
+    if (!active) return;
+    let nextDelay = successDelayMs;
+    try {
+      const result = await task();
+      attempt = 0;
+      if (typeof onSuccess === "function") {
+        try {
+          onSuccess(result);
+        } catch (hookError) {
+          console.error("[retryScheduler] onSuccess hook failed", hookError);
+        }
+      }
+      nextDelay = successDelayMs;
+    } catch (error) {
+      attempt += 1;
+      const exponent = Math.max(0, attempt - 1);
+      const calculatedDelay = initialRetryDelayMs * Math.pow(multiplier, exponent);
+      nextDelay = Math.min(calculatedDelay, maxRetryDelayMs);
+      if (typeof onFailure === "function") {
+        try {
+          onFailure(error, { attempt, nextDelay });
+        } catch (hookError) {
+          console.error("[retryScheduler] onFailure hook failed", hookError);
+        }
+      }
+    }
+    scheduleNext(nextDelay);
+  };
+
+  return {
+    start() {
+      if (active) return;
+      active = true;
+      attempt = 0;
+      scheduleNext(0);
+    },
+    stop() {
+      active = false;
+      clearTimer();
+    },
+    isRunning() {
+      return active;
+    },
+    getAttempt() {
+      return attempt;
+    },
+  };
+}

--- a/test/public/retryScheduler.spec.ts
+++ b/test/public/retryScheduler.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { createExponentialBackoffScheduler } from "../../public/retryScheduler.js";
+
+describe("createExponentialBackoffScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries with exponential backoff until the task succeeds", async () => {
+    const task = vi.fn();
+    let attempt = 0;
+    task.mockImplementation(async () => {
+      attempt += 1;
+      if (attempt < 3) {
+        throw new Error(`fail-${attempt}`);
+      }
+      return attempt;
+    });
+
+    const onFailure = vi.fn();
+    const onSuccess = vi.fn();
+
+    const scheduler = createExponentialBackoffScheduler(task, {
+      initialRetryDelayMs: 1000,
+      maxRetryDelayMs: 8000,
+      successDelayMs: 60000,
+      onFailure,
+      onSuccess,
+    });
+
+    scheduler.start();
+
+    await vi.runOnlyPendingTimersAsync();
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(onFailure.mock.calls[0][1]).toMatchObject({
+      attempt: 1,
+      nextDelay: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(task).toHaveBeenCalledTimes(2);
+    expect(onFailure).toHaveBeenCalledTimes(2);
+    expect(onFailure.mock.calls[1][1]).toMatchObject({
+      attempt: 2,
+      nextDelay: 2000,
+    });
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(task).toHaveBeenCalledTimes(3);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(task).toHaveBeenCalledTimes(4);
+
+    scheduler.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the find-creators relay poller with an exponential backoff scheduler that surfaces structured relay diagnostics in the iframe
- enhance relay health probing to record close codes, treat restricted origins as soft failures, and expose diagnostics for display
- add a reusable retry scheduler utility and unit coverage that verifies retries continue until recovery

## Testing
- pnpm vitest run test/public/retryScheduler.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfaebd69ac8330989471cb8a986457