### PR TITLE
Pin public creator profiles to the Fundstr relay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@ VITE_DONATION_LIGHTNING=lightning_address_here
 VITE_DONATION_BITCOIN=bitcoin_address_here
 
 # Nutzap isolated relay (WSS first, HTTP fallback)
-VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.primal.net
-VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.primal.net
+VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.fundstr.me
+VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.fundstr.me
 
 # Control WS writes (enable in staging/prod once verified)
 VITE_NUTZAP_ALLOW_WSS_WRITES=false

--- a/.env.production
+++ b/.env.production
@@ -4,8 +4,8 @@ VITE_DONATION_LIGHTNING=lightning_address_here
 VITE_DONATION_BITCOIN=bitcoin_address_here
 
 # Nutzap isolated relay (WSS first, HTTP fallback)
-VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.primal.net
-VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.primal.net
+VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.fundstr.me
+VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.fundstr.me
 
 # Control WS writes (enable in staging/prod once verified)
 VITE_NUTZAP_ALLOW_WSS_WRITES=false

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ URLs. If not defined, the search falls back to a short curated list defined in
 ```
 wss://relay.damus.io/
 wss://nos.lol/
-wss://relay.primal.net/
+wss://relay.fundstr.me/
 wss://relay.snort.social/
 ```
 
@@ -287,8 +287,8 @@ isolated relay flow:
 1. **Build & Typecheck** – `pnpm install` then `pnpm build` (or the equivalent npm commands).
 2. **Relay Smoke Tests** – ensure the dedicated relay is reachable:
    ```bash
-   curl -sH 'Accept: application/nostr+json' https://relay.primal.net/ | jq .
-   curl -s 'https://relay.primal.net/req?filters=%5B%5D'
+   curl -sH 'Accept: application/nostr+json' https://relay.fundstr.me/ | jq .
+   curl -s 'https://relay.fundstr.me/req?filters=%5B%5D'
    ```
 3. **Page Behaviour** – load `/nutzap-profile`, publish tiers and profile, and verify the
    publish acknowledgements (`via=ws` or `via=http`). Block WebSockets to confirm the HTTP

--- a/docs/relay-access.md
+++ b/docs/relay-access.md
@@ -9,14 +9,14 @@ Publishes must send a fully signed NIP-01 event to /event; the client validates 
 ## Transport flow
 
 1. The client always **prefers the isolated Fundstr relay**
-   (`wss://relay.primal.net`).
+   (`wss://relay.fundstr.me`).
 2. Every query begins with a WebSocket REQ/EOSE round-trip. Connections are
    bounded by a ~1.5&nbsp;s timeout to keep the UI responsive.
 3. If the socket cannot be opened or returns no events, the client
    automatically performs the same query over HTTP:
-   `https://relay.primal.net/req?filters=…`.
+   `https://relay.fundstr.me/req?filters=…`.
 4. When Fundstr returns no data the client **can** fan out across a vetted pool
-  of public relays (`relay.primal.net`, `relay.snort.social`, `nos.lol`,
+ of public relays (`relay.fundstr.me`, `relay.snort.social`, `nos.lol`,
   `relay.damus.io`). This behaviour is opt-in via
    `allowFanoutFallback`—Fundstr-first flows (including Creator Studio load /
    refresh) stay pinned to the first-party relay unless callers explicitly pass
@@ -27,7 +27,7 @@ All fetches, including the service-worker passthrough, use
 responses are never cached.
 
 Publishing Nutzap events uses a direct HTTP POST to
-`https://relay.primal.net/event`. The relay responds with a JSON payload shaped
+`https://relay.fundstr.me/event`. The relay responds with a JSON payload shaped
 like `{ ok, id, accepted, message }`. Callers must treat a publish as successful
 **only** when `accepted === true`. When `accepted` is false the provided relay
 `message` should be surfaced to the user verbatim.

--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -11,7 +11,7 @@
     <script type="application/json" id="fundstr-relay-config">
       {
         "primary": "wss://relay.fundstr.me",
-        "paid": ["wss://relay.primal.net"]
+        "paid": ["wss://relay.fundstr.me"]
       }
     </script>
     <script type="application/json" id="fundstr-primal-config">

--- a/public/relayConfig.js
+++ b/public/relayConfig.js
@@ -1,5 +1,5 @@
 const DEFAULT_PRIMARY_RELAY = "wss://relay.fundstr.me";
-const DEFAULT_PAID_RELAYS = ["wss://relay.primal.net"];
+const DEFAULT_PAID_RELAYS = ["wss://relay.fundstr.me"];
 
 // Criteria for curated open relays:
 // 1. Operators publish an explicit allowlist or policy permitting third-party web clients.

--- a/scripts/update-featured-creators.js
+++ b/scripts/update-featured-creators.js
@@ -12,7 +12,7 @@ function NostrWebSocket(url, opts) {
 useWebSocketImplementation(NostrWebSocket);
 
 const DEFAULT_RELAYS = [
-  'wss://relay.primal.net',
+  'wss://relay.fundstr.me',
   'wss://relay.damus.io',
   'wss://relay.snort.social',
   'wss://nos.lol',

--- a/src-pwa/custom-service-worker.js
+++ b/src-pwa/custom-service-worker.js
@@ -36,7 +36,7 @@ if (process.env.MODE !== "ssr" || process.env.PROD) {
 
 registerRoute(
   ({ url }) =>
-    url.origin === "https://relay.primal.net" &&
+    url.origin === "https://relay.fundstr.me" &&
     (url.pathname.startsWith("/req") || url.pathname.startsWith("/event")),
   new NetworkOnly({
     fetchOptions: {

--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -266,7 +266,9 @@ async function createReadOnlyNdk(opts: CreateReadOnlyOptions = {}): Promise<NDK>
   if (!opts.fundstrOnly) {
     mergeDefaultRelays(ndk);
   }
-  mustConnectRequiredRelays(ndk);
+  if (!fundstrOnly) {
+    mustConnectRequiredRelays(ndk);
+  }
   await safeConnect(ndk);
   if (!fundstrOnly) {
     healthyPromise.then(async (healthy) => {
@@ -311,7 +313,9 @@ export async function createSignedNdk(signer: NDKSigner): Promise<NDK> {
   const ndk = new NDK({ explicitRelayUrls: bootstrapRelays });
   attachRelayErrorHandlers(ndk);
   mergeDefaultRelays(ndk);
-  mustConnectRequiredRelays(ndk);
+  if (!fundstrOnly) {
+    mustConnectRequiredRelays(ndk);
+  }
   ndk.signer = signer;
   await safeConnect(ndk);
   if (!fundstrOnly) {

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -1,5 +1,5 @@
-export const FUNDSTR_PRIMARY_RELAY = 'wss://relay.primal.net';
-export const FUNDSTR_PRIMARY_RELAY_HTTP = 'https://relay.primal.net';
+export const FUNDSTR_PRIMARY_RELAY = 'wss://relay.fundstr.me';
+export const FUNDSTR_PRIMARY_RELAY_HTTP = 'https://relay.fundstr.me';
 export const PRIMARY_RELAY = FUNDSTR_PRIMARY_RELAY;
 
 export const FALLBACK_RELAYS: string[] = [

--- a/src/layouts/PublicProfileLayout.vue
+++ b/src/layouts/PublicProfileLayout.vue
@@ -1,0 +1,31 @@
+<template>
+  <q-layout view="hhh lpR lff" class="bg-surface-1 text-1 public-profile-layout">
+    <q-page-container class="public-profile-layout__page text-body1">
+      <router-view />
+    </q-page-container>
+  </q-layout>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "PublicProfileLayout",
+});
+</script>
+
+<style scoped>
+.public-profile-layout {
+  min-height: 100vh;
+}
+
+.public-profile-layout__page {
+  display: flex;
+  justify-content: center;
+  padding: 2.5rem 1rem 3.5rem;
+}
+
+.public-profile-layout__page > :deep(*) {
+  flex: 1;
+}
+</style>

--- a/src/nostr/relays.ts
+++ b/src/nostr/relays.ts
@@ -1,6 +1,6 @@
 export const REQUIRED_DM_RELAYS = [
   'wss://relay.damus.io',
-  'wss://relay.primal.net',
+  'wss://relay.fundstr.me',
 ] as const;
 
 export const DM_BLOCKLIST = new Set<string>([

--- a/src/nutzap/onepage/NutzapExplorerPanel.vue
+++ b/src/nutzap/onepage/NutzapExplorerPanel.vue
@@ -187,7 +187,7 @@ import type { Event as NostrEvent, Filter as NostrFilter } from 'nostr-tools';
 import { multiRelaySearch, mergeRelayHints } from './multiRelaySearch';
 import { sanitizeRelayUrls } from 'src/utils/relay';
 
-const DEFAULT_RELAYS = ['wss://relay.primal.net'];
+const DEFAULT_RELAYS = ['wss://relay.fundstr.me'];
 
 const props = defineProps<{
   modelValue: string;

--- a/src/nutzap/onepage/NutzapLegacyExplorer.vue
+++ b/src/nutzap/onepage/NutzapLegacyExplorer.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="legacy-explorer column q-gutter-md">
     <div class="text-caption text-2">
-      Run a single-relay REQ against relay.primal.net and watch for EOSE or timeout.
+      Run a single-relay REQ against relay.fundstr.me and watch for EOSE or timeout.
     </div>
 
     <q-input

--- a/src/nutzap/onepage/useRelayConnection.ts
+++ b/src/nutzap/onepage/useRelayConnection.ts
@@ -70,7 +70,7 @@ export function useRelayConnection() {
 
     if (mode === 'production') {
       logInfo(logMessage);
-      const expectedHost = 'relay.primal.net';
+      const expectedHost = 'relay.fundstr.me';
       if (wsUrl !== '(empty)' && !wsUrl.includes(expectedHost)) {
         console.warn(
           `[Nutzap] Unexpected production relay WebSocket URL: ${wsUrl}`,

--- a/src/nutzap/relayConfig.ts
+++ b/src/nutzap/relayConfig.ts
@@ -10,12 +10,12 @@ function pickRelayEnv(value: unknown, fallback: string): string {
 
 export const NUTZAP_RELAY_WSS = pickRelayEnv(
   import.meta.env.VITE_NUTZAP_PRIMARY_RELAY_WSS,
-  'wss://relay.primal.net',
+  'wss://relay.fundstr.me',
 );
 
 export const NUTZAP_RELAY_HTTP = pickRelayEnv(
   import.meta.env.VITE_NUTZAP_PRIMARY_RELAY_HTTP,
-  'https://relay.primal.net',
+  'https://relay.fundstr.me',
 );
 
 export const NUTZAP_ALLOW_WSS_WRITES =

--- a/src/nutzap/types.ts
+++ b/src/nutzap/types.ts
@@ -11,6 +11,6 @@ export type NutzapProfileContent = {
   v: number;
   p2pk: string; // hex P2PK pubkey
   mints: string[]; // URLs
-  relays: string[]; // e.g. ["wss://relay.primal.net"]
+  relays: string[]; // e.g. ["wss://relay.fundstr.me"]
   tierAddr?: string; // e.g. "30000:<pubkey>:tiers" or naddr form
 };

--- a/src/pages/NutzapProfilePage.vue
+++ b/src/pages/NutzapProfilePage.vue
@@ -9,7 +9,7 @@
               <span class="status-label text-caption text-weight-medium">{{ relayStatusLabel }}</span>
             </div>
             <div class="status-meta text-body2 text-2">
-              Isolated relay: relay.primal.net (WS → HTTP fallback)
+              Isolated relay: relay.fundstr.me (WS → HTTP fallback)
             </div>
           </div>
           <div class="profile-readiness" role="status" aria-live="polite">
@@ -1635,7 +1635,7 @@ async function publishAll() {
         : '';
     const profileSummary = profileEventId
       ? `Profile published — id ${profileEventId}${profileRelayMessage}`
-      : `Profile published to relay.primal.net.${profileRelayMessage}`;
+      : `Profile published to relay.fundstr.me.${profileRelayMessage}`;
 
     lastPublishInfo.value = `${tierSummary} ${profileSummary}`.trim();
 

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -338,11 +338,13 @@ export default defineComponent({
 <style scoped>
 .public-profile {
   min-height: 100%;
+  width: 100%;
 }
 
 .public-profile__inner {
-  max-width: 1100px;
+  max-width: 960px;
   margin: 0 auto;
+  width: 100%;
 }
 
 .public-profile__banner {
@@ -354,9 +356,17 @@ export default defineComponent({
   display: flex;
   gap: 1.5rem;
   align-items: center;
-  padding: 1.75rem;
+  padding: 2rem;
   border-radius: 1.5rem;
   margin-bottom: 2.5rem;
+  border: 1px solid var(--surface-contrast-border);
+  box-shadow: 0 22px 45px rgba(15, 23, 42, 0.28);
+  background: linear-gradient(
+    135deg,
+    rgba(57, 97, 252, 0.15),
+    rgba(81, 183, 250, 0.05)
+  );
+  backdrop-filter: blur(12px);
 }
 
 .public-profile__avatar {
@@ -420,13 +430,18 @@ export default defineComponent({
 .public-profile__content {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 2.5rem;
 }
 
 .public-profile__section {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  padding: 2rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--surface-contrast-border);
+  background: var(--surface-2);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.22);
 }
 
 .public-profile__section-header {
@@ -445,6 +460,8 @@ export default defineComponent({
   justify-content: center;
   align-items: center;
   text-align: center;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .public-profile__tier-list {
@@ -457,11 +474,16 @@ export default defineComponent({
   .public-profile__header {
     flex-direction: column;
     align-items: flex-start;
+    padding: 1.5rem;
   }
 
   .public-profile__avatar {
     width: 96px;
     height: 96px;
+  }
+
+  .public-profile__section {
+    padding: 1.5rem;
   }
 }
 </style>

--- a/src/pages/nutzap-profile/README-NutzapProfile.md
+++ b/src/pages/nutzap-profile/README-NutzapProfile.md
@@ -2,7 +2,7 @@
 
 This page publishes a creator's Nutzap payment profile (kind **10019**) and the
 companion tier catalog (kinds **30019** canonical, **30000** legacy fallback)
-to the Fundstr relay at `relay.primal.net`. The helper module
+to the Fundstr relay at `relay.fundstr.me`. The helper module
 `src/pages/nutzap-profile/nostrHelpers.ts` centralises relay endpoints, signing,
 and read/write helpers so the page can provide production-grade UX around the
 Nostr primitives.
@@ -14,7 +14,7 @@ Nostr primitives.
 * **Tags**
   * Required: `['t','nutzap-profile']`, `['client','fundstr']`
   * For each mint: `['mint','<https-url>','sat']`
-  * Optional but encouraged: relay hints `['relay','wss://relay.primal.net']`,
+  * Optional but encouraged: relay hints `['relay','wss://relay.fundstr.me']`,
     canonical link to the tier PRE `['a','<kind>:<pubkey>:tiers']`,
     `['name','…']`, `['picture','…']`
 * **Content** — JSON string:
@@ -24,7 +24,7 @@ Nostr primitives.
     "v": 1,
     "p2pk": "<hex Cashu P2PK>",
     "mints": ["https://mint.example", "https://mint2.example"],
-    "relays": ["wss://relay.primal.net", "wss://another.example"],
+    "relays": ["wss://relay.fundstr.me", "wss://another.example"],
     "tierAddr": "30019:<author_hex>:tiers"
   }
   ```
@@ -68,13 +68,13 @@ to legacy mode.
      `['EOSE', <subId>]` or a **3 second** timeout elapses (see
      `WS_FIRST_TIMEOUT_MS`).
    * When no events arrive (or the request times out), fall back to
-     `GET https://relay.primal.net/req?filters=<urlencoded JSON>` with the
+     `GET https://relay.fundstr.me/req?filters=<urlencoded JSON>` with the
      `HTTP_FALLBACK_TIMEOUT_MS` deadline and return the JSON body
      (`{ ok: true, events:[…] }`).
 2. **Writes** call `publishNostrEvent(template)`.
    * Sign the template either via `window.nostr.signEvent` or the NDK signer.
    * Validate the signed event with `isNostrEvent` before sending.
-   * POST the event to `https://relay.primal.net/event` and only treat the
+   * POST the event to `https://relay.fundstr.me/event` and only treat the
      publish as successful when the relay acknowledges with `{"ok":true,
      "accepted":true, ...}`.
 
@@ -87,11 +87,11 @@ Replace `$AUTH` with the 64-char lowercase pubkey that signed the events.
 
 ```bash
 # Latest Nutzap profile (kind 10019)
-curl -sS --get 'https://relay.primal.net/req' \
+curl -sS --get 'https://relay.fundstr.me/req' \
   --data-urlencode 'filters=[{"kinds":[10019],"authors":["'$AUTH'"],"limit":1}]' | jq .
 
 # Latest Nutzap tiers (canonical 30019)
-curl -sS --get 'https://relay.primal.net/req' \
+curl -sS --get 'https://relay.fundstr.me/req' \
   --data-urlencode 'filters=[{"kinds":[30019],"authors":["'$AUTH'"],"#d":["tiers"],"limit":1}]' | jq .
 ```
 

--- a/src/pages/nutzap-profile/__tests__/nostrHelpers.spec.ts
+++ b/src/pages/nutzap-profile/__tests__/nostrHelpers.spec.ts
@@ -8,8 +8,8 @@ import {
 
 vi.hoisted(() => {
   vi.stubEnv('VITE_NUTZAP_ALLOW_WSS_WRITES', 'true');
-  vi.stubEnv('VITE_NUTZAP_PRIMARY_RELAY_WSS', 'wss://relay.primal.net');
-  vi.stubEnv('VITE_NUTZAP_PRIMARY_RELAY_HTTP', 'https://relay.primal.net');
+  vi.stubEnv('VITE_NUTZAP_PRIMARY_RELAY_WSS', 'wss://relay.fundstr.me');
+  vi.stubEnv('VITE_NUTZAP_PRIMARY_RELAY_HTTP', 'https://relay.fundstr.me');
   vi.stubEnv('VITE_NUTZAP_WS_TIMEOUT_MS', '500');
   vi.stubEnv('VITE_NUTZAP_HTTP_TIMEOUT_MS', '75');
   return undefined;
@@ -21,7 +21,7 @@ afterAll(() => {
 
 const ndkMock = vi.hoisted(() => {
   const listeners = new Map<string, Set<(relay: any) => void>>();
-  const relay = { url: 'wss://relay.primal.net', connected: false };
+  const relay = { url: 'wss://relay.fundstr.me', connected: false };
   const pool = {
     relays: new Map([[relay.url, relay]]),
     on(event: string, cb: (relay: any) => void) {
@@ -463,8 +463,8 @@ describe('relay endpoint defaults', () => {
     vi.stubEnv('VITE_NUTZAP_PRIMARY_RELAY_WSS', '\n');
 
     const { FUNDSTR_REQ_URL, FUNDSTR_WS_URL } = await import('../nostrHelpers');
-    expect(FUNDSTR_WS_URL).toBe('wss://relay.primal.net');
-    expect(FUNDSTR_REQ_URL).toBe('https://relay.primal.net/req');
+    expect(FUNDSTR_WS_URL).toBe('wss://relay.fundstr.me');
+    expect(FUNDSTR_REQ_URL).toBe('https://relay.fundstr.me/req');
   });
 });
 

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -24,7 +24,7 @@ const routes = [
   },
   {
     path: "/creator/:npubOrHex",
-    component: () => import("layouts/FullscreenLayout.vue"),
+    component: () => import("layouts/PublicProfileLayout.vue"),
     children: [
       {
         path: "",

--- a/test/nutzap-explorer-panel.relays.spec.ts
+++ b/test/nutzap-explorer-panel.relays.spec.ts
@@ -66,7 +66,7 @@ describe('NutzapExplorerPanel relay handling', () => {
 
     const vm = wrapper.vm as NutzapExplorerPanelVm;
 
-    vm.relayInput = `wss://relay.primal.net\n${manualRelay}`;
+    vm.relayInput = `wss://relay.fundstr.me\n${manualRelay}`;
     vm.query = encodedProfile;
 
     await vm.runSearch();
@@ -74,11 +74,11 @@ describe('NutzapExplorerPanel relay handling', () => {
 
     expect(multiRelaySearchMock).toHaveBeenCalledTimes(1);
     const options = multiRelaySearchMock.mock.calls[0][0];
-    expect(options.relays).toEqual(['wss://relay.primal.net', manualRelay]);
+    expect(options.relays).toEqual(['wss://relay.fundstr.me', manualRelay]);
     expect(options.additionalRelays).toEqual(pointerRelays);
 
     expect(vm.activeRelays).toEqual([
-      'wss://relay.primal.net',
+      'wss://relay.fundstr.me',
       manualRelay,
       ...pointerRelays,
     ]);

--- a/test/vitest/__tests__/NutzapProfilePage.spec.ts
+++ b/test/vitest/__tests__/NutzapProfilePage.spec.ts
@@ -83,7 +83,7 @@ var shared: SharedState | null = null;
 function ensureShared(): SharedState {
   if (!shared) {
     shared = {
-      relayUrlRef: ref("wss://relay.primal.net"),
+      relayUrlRef: ref("wss://relay.fundstr.me"),
       relayStatusRef: ref("connected"),
       relayAutoReconnectRef: ref(false),
       relayActivityRef: ref([]),
@@ -203,8 +203,8 @@ const pickLatestReplaceableMock = vi.fn(() => null);
 const pickLatestParamReplaceableMock = vi.fn(() => null);
 
 vi.mock("../../../src/pages/nutzap-profile/nostrHelpers", () => ({
-  FUNDSTR_WS_URL: "wss://relay.primal.net",
-  FUNDSTR_REQ_URL: "https://relay.primal.net/req",
+  FUNDSTR_WS_URL: "wss://relay.fundstr.me",
+  FUNDSTR_REQ_URL: "https://relay.fundstr.me/req",
   WS_FIRST_TIMEOUT_MS: 5000,
   HTTP_FALLBACK_TIMEOUT_MS: 8000,
   publishTiers: (...args: any[]) => ensureShared().publishTiersToRelayMock(...args),
@@ -336,7 +336,7 @@ beforeEach(() => {
   state.disconnectRelayMock.mockReset();
   state.clearRelayActivityMock.mockReset();
   state.logActivityMock.mockReset();
-  state.relayUrlRef.value = "wss://relay.primal.net";
+  state.relayUrlRef.value = "wss://relay.fundstr.me";
   state.relayStatusRef.value = "connected";
   state.relayAutoReconnectRef.value = false;
   state.relayActivityRef.value = [];
@@ -401,7 +401,7 @@ describe("NutzapProfilePage explore summary", () => {
     const relayChips = summaryCard.findAll('[data-testid="explore-relay-chip"]');
     expect(relayChips.length).toBeGreaterThanOrEqual(2);
     expect(relayChips.map(node => node.text())).toEqual(
-      expect.arrayContaining(["wss://relay.alt", "wss://relay.primal.net"])
+      expect.arrayContaining(["wss://relay.alt", "wss://relay.fundstr.me"])
     );
 
     const tierItems = summaryCard.findAll('[data-testid="explore-tier-item"]');

--- a/test/vitest/__tests__/useCreatorHub.publish.spec.ts
+++ b/test/vitest/__tests__/useCreatorHub.publish.spec.ts
@@ -266,13 +266,13 @@ describe("publishProfileBundle", () => {
     profileStoreMock.pubkey = "creator-pub";
     profileStoreMock.relays = [
       "wss://relay.other",
-      "wss://relay.primal.net",
+      "wss://relay.fundstr.me",
     ];
     filterHealthyRelaysMock.mockImplementation(async (relays: string[]) =>
-      relays.filter((url) => url === "wss://relay.primal.net"),
+      relays.filter((url) => url === "wss://relay.fundstr.me"),
     );
     selectPublishRelaysMock.mockReturnValueOnce({
-      targets: ["wss://relay.other", "wss://relay.primal.net"],
+      targets: ["wss://relay.other", "wss://relay.fundstr.me"],
       usedFallback: [],
     });
 
@@ -291,7 +291,7 @@ describe("publishProfileBundle", () => {
 
     expect(buildKind10019NutzapProfileMock).toHaveBeenCalled();
     const [, payload] = buildKind10019NutzapProfileMock.mock.calls.at(-1)!;
-    expect(payload.relays).toEqual(["wss://relay.primal.net"]);
+    expect(payload.relays).toEqual(["wss://relay.fundstr.me"]);
     expect(publishToRelaysWithAcksMock).toHaveBeenCalled();
     expect(vm.publishReport.anySuccess).toBe(true);
 
@@ -301,11 +301,11 @@ describe("publishProfileBundle", () => {
   it("counts Fundstr HTTP fallback ack as success when websocket publish fails", async () => {
     profileStoreMock.pubkey = "creator-pub";
     profileStoreMock.relays = [
-      "wss://relay.primal.net",
+      "wss://relay.fundstr.me",
       "wss://relay.other",
     ];
     selectPublishRelaysMock.mockReturnValueOnce({
-      targets: ["wss://relay.primal.net", "wss://relay.other"],
+      targets: ["wss://relay.fundstr.me", "wss://relay.other"],
       usedFallback: [],
     });
     fundstrRelayClientMock.publish.mockResolvedValueOnce({
@@ -322,7 +322,7 @@ describe("publishProfileBundle", () => {
     });
     publishToRelaysWithAcksMock.mockImplementation(async (_ndk: any, _event: any, relays: string[]) => ({
       perRelay: relays.map((url) =>
-        url === "wss://relay.primal.net"
+        url === "wss://relay.fundstr.me"
           ? { relay: url, status: "timeout" }
           : { relay: url, status: "ok" },
       ),
@@ -343,7 +343,7 @@ describe("publishProfileBundle", () => {
 
     expect(fundstrRelayClientMock.publish).toHaveBeenCalled();
     const fundstrResult = vm.publishReport.byRelay.find(
-      (r: any) => r.url === "wss://relay.primal.net",
+      (r: any) => r.url === "wss://relay.fundstr.me",
     );
     expect(fundstrResult?.ack).toBe(true);
     expect(fundstrResult?.ok).toBe(true);


### PR DESCRIPTION
## Summary
- update all Nutzap relay defaults, docs, and tests to point at relay.fundstr.me instead of relay.primal.net
- keep the Fundstr-only runtime from connecting to DM fallback relays by skipping the extra pools when that mode is active
- introduce a lightweight PublicProfileLayout plus refreshed styling for the public creator profile page so share links render a focused tier view without the main app chrome

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e014b409f883309961aa00d5fa5847