### PR TITLE
Force Fundstr-only NDK mode on share routes

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -11,6 +11,7 @@ const __dirname = path.dirname(__filename)
 export default configure(() => ({
   // 1. 'node-globals' boot file is removed. This is correct.
   boot: [
+    'fundstr-share-route',
     'welcomeGate',
     'cashu',
     'i18n',

--- a/src/boot/fundstr-share-route.ts
+++ b/src/boot/fundstr-share-route.ts
@@ -1,0 +1,36 @@
+import { boot } from "quasar/wrappers";
+import type { RouteLocationNormalized } from "vue-router";
+import {
+  isFundstrShareRouteActive,
+  setFundstrOnlyRouteOverride,
+  syncNdkRelaysWithMode,
+} from "boot/ndk";
+
+function routeHasShareMeta(route: RouteLocationNormalized): boolean {
+  return route.matched.some((record) => Boolean(record.meta?.nutzapShare));
+}
+
+async function applyShareMode(to: RouteLocationNormalized) {
+  const shareActive = routeHasShareMeta(to);
+  const currentlyActive = isFundstrShareRouteActive();
+  if (shareActive === currentlyActive) {
+    return;
+  }
+  setFundstrOnlyRouteOverride(shareActive);
+  try {
+    await syncNdkRelaysWithMode();
+  } catch (err) {
+    console.debug("[fundstr-share-route] failed to sync NDK mode", err);
+  }
+}
+
+export default boot(({ router }) => {
+  router.beforeResolve((to, _from, next) => {
+    void applyShareMode(to).then(next, next);
+  });
+
+  const initialRoute = router.currentRoute.value;
+  if (initialRoute) {
+    void applyShareMode(initialRoute);
+  }
+});

--- a/src/composables/useNdk.ts
+++ b/src/composables/useNdk.ts
@@ -6,6 +6,7 @@ import {
   type CreateReadOnlyOptions,
   setFundstrOnlyRuntimeOverride,
   rebuildNdk as bootRebuildNdk,
+  isFundstrShareRouteActive,
 } from "boot/ndk";
 import { useNostrStore } from "stores/nostr";
 
@@ -34,6 +35,8 @@ export async function useNdk(
   let targetMode: "default" | "fundstr-only";
   if (requestedMode) {
     targetMode = requestedMode;
+  } else if (isFundstrShareRouteActive()) {
+    targetMode = "fundstr-only";
   } else if (cached) {
     targetMode = cachedMode;
   } else {

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -45,7 +45,7 @@ import { filterHealthyRelays } from "src/utils/relayHealth";
 import { DEFAULT_RELAYS, FREE_RELAYS, VETTED_OPEN_WRITE_RELAYS } from "src/config/relays";
 import { publishToRelaysWithAcks, selectPublishRelays, PublishReport, RelayResult } from "src/nostr/publish";
 import { sanitizeRelayUrls } from "src/utils/relay";
-import { getNdk } from "src/boot/ndk";
+import { getNdk, isFundstrShareRouteActive } from "src/boot/ndk";
 import { getTrustedTime } from "src/utils/time";
 import {
   notifyApiError,
@@ -1492,11 +1492,13 @@ export const useNostrStore = defineStore("nostr", {
           : opts.fundstrOnly === false
             ? "default"
             : undefined;
-      const desiredMode = requestedMode ?? this.readOnlyMode ?? "default";
+      const shareRouteActive = isFundstrShareRouteActive();
+      const desiredModeBase = requestedMode ?? this.readOnlyMode ?? "default";
+      const desiredMode = shareRouteActive ? "fundstr-only" : desiredModeBase;
       const modeChanged = this.readOnlyMode !== desiredMode;
       const ndk = await useNdk({
         requireSigner: false,
-        fundstrOnly: opts.fundstrOnly,
+        fundstrOnly: shareRouteActive ? true : opts.fundstrOnly,
       });
       if (modeChanged) {
         this.connected = false;


### PR DESCRIPTION
## Summary
- add a router boot hook that enables the Fundstr-only relay override while visiting share routes
- ensure NDK bootstrap logic returns a read-only Fundstr-only client when the share flag is active
- update NDK consumers to honor the share mode when initializing read-only connections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e024e5e8908330964ca5f06a32eb4e