### PR TITLE
Default Nutzap queries to Fundstr endpoints

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -301,7 +301,7 @@ import { nip19 } from "nostr-tools";
 import { queryNutzapProfile, toHex } from "@/nostr/relayClient";
 import type { NostrEvent } from "@/nostr/relayClient";
 import { fallbackDiscoverRelays } from "@/nostr/discovery";
-import { FUNDSTR_REQ_URL, WS_FIRST_TIMEOUT_MS } from "@/nutzap/relayEndpoints";
+import { WS_FIRST_TIMEOUT_MS } from "@/nutzap/relayEndpoints";
 import {
   parseNutzapProfileEvent,
   type NutzapProfileDetails,
@@ -625,7 +625,6 @@ async function fetchProfileWithFallback(
   let event: NostrEvent | null = null;
   try {
     event = await queryNutzapProfile(hex, {
-      httpBase: FUNDSTR_REQ_URL,
       allowFanoutFallback: false,
       wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,
     });
@@ -639,7 +638,6 @@ async function fetchProfileWithFallback(
       for (const url of discovered) relayHints.add(url);
       if (relayHints.size) {
         event = await queryNutzapProfile(hex, {
-          httpBase: FUNDSTR_REQ_URL,
           fanout: Array.from(relayHints),
           allowFanoutFallback: true,
           wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -23,7 +23,7 @@ import {
 } from "@/nostr/relayClient";
 import { fallbackDiscoverRelays } from "@/nostr/discovery";
 import { parseTierDefinitionEvent } from "src/nostr/tiers";
-import { FUNDSTR_REQ_URL, WS_FIRST_TIMEOUT_MS } from "@/nutzap/relayEndpoints";
+import { WS_FIRST_TIMEOUT_MS } from "@/nutzap/relayEndpoints";
 import { safeUseLocalStorage } from "src/utils/safeLocalStorage";
 import type { NutzapProfileDetails } from "@/nutzap/profileCache";
 
@@ -558,7 +558,6 @@ export const useCreatorsStore = defineStore("creators", {
 
       try {
         event = await queryNutzapTiers(hex, {
-          httpBase: FUNDSTR_REQ_URL,
           allowFanoutFallback: false,
           wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,
         });
@@ -570,7 +569,6 @@ export const useCreatorsStore = defineStore("creators", {
       if (!event && relayHints.size) {
         try {
           event = await queryNutzapTiers(hex, {
-            httpBase: FUNDSTR_REQ_URL,
             fanout: Array.from(relayHints),
             allowFanoutFallback: !fundstrOnly,
             wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,
@@ -587,7 +585,6 @@ export const useCreatorsStore = defineStore("creators", {
           for (const url of discovered) relayHints.add(url);
           if (relayHints.size) {
             event = await queryNutzapTiers(hex, {
-              httpBase: FUNDSTR_REQ_URL,
               fanout: Array.from(relayHints),
               allowFanoutFallback: true,
               wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -79,7 +79,7 @@ import {
 import { mapInternalTierToWire } from "src/nostr/tiers";
 import { buildKind10019NutzapProfile } from "src/nostr/builders";
 import { NutzapProfileSchema, type NutzapProfilePayload } from "src/nostr/nutzapProfile";
-import { FUNDSTR_REQ_URL, WS_FIRST_TIMEOUT_MS } from "@/nutzap/relayEndpoints";
+import { WS_FIRST_TIMEOUT_MS } from "@/nutzap/relayEndpoints";
 
 // --- Relay connectivity helpers ---
 export type WriteConnectivity = {
@@ -889,7 +889,6 @@ export async function fetchNutzapProfile(
 
   try {
     event = await queryNutzapProfile(hex, {
-      httpBase: FUNDSTR_REQ_URL,
       allowFanoutFallback: false,
       wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,
     });
@@ -902,7 +901,6 @@ export async function fetchNutzapProfile(
       const discovered = await fallbackDiscoverRelays(hex);
       if (discovered.length) {
         event = await queryNutzapProfile(hex, {
-          httpBase: FUNDSTR_REQ_URL,
           fanout: discovered,
           allowFanoutFallback: true,
           wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,


### PR DESCRIPTION
## Summary
- add optional httpBase/wsTimeout overrides to Nutzap queries with Fundstr defaults
- simplify callers now that Fundstr endpoints are implied
- add a relayClient unit test covering the default Fundstr wiring

## Testing
- pnpm exec vitest run test/vitest/__tests__/relayClient.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0cf3fc1988330b9274eb6a3d9c413