### PR TITLE
Update primary relay defaults to use Fundstr relay

### DIFF
--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -1,5 +1,25 @@
-export const FUNDSTR_PRIMARY_RELAY = 'wss://relay.primal.net';
-export const FUNDSTR_PRIMARY_RELAY_HTTP = 'https://relay.primal.net';
+const DEFAULT_PRIMARY_RELAY = 'wss://relay.fundstr.me';
+const DEFAULT_PRIMARY_RELAY_HTTP = 'https://relay.fundstr.me';
+
+function envString(key: string, fallback: string): string {
+  const raw = (import.meta as any).env?.[key];
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return fallback;
+}
+
+export const FUNDSTR_PRIMARY_RELAY = envString(
+  'VITE_NUTZAP_PRIMARY_RELAY_WSS',
+  DEFAULT_PRIMARY_RELAY,
+);
+export const FUNDSTR_PRIMARY_RELAY_HTTP = envString(
+  'VITE_NUTZAP_PRIMARY_RELAY_HTTP',
+  DEFAULT_PRIMARY_RELAY_HTTP,
+);
 export const PRIMARY_RELAY = FUNDSTR_PRIMARY_RELAY;
 
 export const FALLBACK_RELAYS: string[] = [


### PR DESCRIPTION
## Summary
- default the Fundstr primary relay to relay.fundstr.me for both WSS and HTTP
- allow overriding the primary relay URLs via VITE_NUTZAP_PRIMARY_RELAY_* environment variables so deployments stay configurable

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e0d14f60d88330a13241386919afb7