### PR TITLE
Adjust NDK relay selection for fundstr-only mode

### DIFF
--- a/src/nostr/relays.ts
+++ b/src/nostr/relays.ts
@@ -25,7 +25,17 @@ export function buildDmPublishSet(allRelays: string[]): string[] {
   return Array.from(base);
 }
 
-export function mustConnectRequiredRelays(ndkOrPool: any) {
+export type MustConnectRequiredRelaysOptions = {
+  fundstrOnly?: boolean;
+};
+
+export function mustConnectRequiredRelays(
+  ndkOrPool: any,
+  options: MustConnectRequiredRelaysOptions = {},
+) {
+  if (options.fundstrOnly) {
+    return;
+  }
   for (const r of REQUIRED_DM_RELAYS) {
     ndkOrPool.addOrConnect?.(r);
     ndkOrPool.addExplicitRelay?.(r);

--- a/test/vitest/__tests__/ndk.boot.spec.ts
+++ b/test/vitest/__tests__/ndk.boot.spec.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const relayWatchdogInstances: Array<{
+  start: ReturnType<typeof vi.fn>;
+  updateNdk: ReturnType<typeof vi.fn>;
+}> = [];
+
+vi.mock("src/js/nostr-runtime", () => ({
+  RelayWatchdog: vi.fn().mockImplementation(() => {
+    const instance = {
+      start: vi.fn(),
+      updateNdk: vi.fn(),
+    };
+    relayWatchdogInstances.push(instance);
+    return instance;
+  }),
+}));
+
+vi.mock("src/utils/relayHealth", () => ({
+  filterHealthyRelays: vi.fn(async () => []),
+}));
+
+vi.mock("src/nostr/freeRelayFallback", () => ({
+  getFreeRelayFallbackStatus: vi.fn(),
+  onFreeRelayFallbackStatusChange: vi.fn(),
+  hasFallbackAttempt: vi.fn(() => false),
+  isFallbackUnreachable: vi.fn(() => false),
+  markFallbackUnreachable: vi.fn(),
+  recordFallbackAttempt: vi.fn(),
+  resetFallbackState: vi.fn(),
+}));
+
+const settingsStoreMock = {
+  defaultNostrRelays: [] as string[],
+  relayBootstrapMode: undefined as string | undefined,
+};
+
+vi.mock("src/stores/settings", () => ({
+  useSettingsStore: () => settingsStoreMock,
+}));
+
+vi.mock("@nostr-dev-kit/ndk", () => {
+  class FakeNDK {
+    pool: {
+      relays: Map<string, any>;
+      on: ReturnType<typeof vi.fn>;
+      off: ReturnType<typeof vi.fn>;
+    };
+    signer: any;
+
+    constructor(opts: { explicitRelayUrls?: string[] } = {}) {
+      this.pool = {
+        relays: new Map<string, any>(),
+        on: vi.fn(),
+        off: vi.fn(),
+      };
+      for (const url of opts.explicitRelayUrls ?? []) {
+        this.addExplicitRelay(url);
+      }
+    }
+
+    addExplicitRelay(url: string) {
+      if (!this.pool.relays.has(url)) {
+        this.pool.relays.set(url, {
+          url,
+          connected: false,
+          disconnect: vi.fn(),
+        });
+      }
+    }
+
+    addOrConnect(url: string) {
+      this.addExplicitRelay(url);
+    }
+
+    async connect() {
+      for (const relay of this.pool.relays.values()) {
+        relay.connected = true;
+      }
+    }
+
+    subscribe() {
+      return { stop: vi.fn() };
+    }
+  }
+
+  return {
+    __esModule: true,
+    default: FakeNDK,
+    NDKEvent: class {},
+    NDKFilter: class {},
+  };
+});
+
+describe("createReadOnlyNdk", () => {
+  beforeEach(() => {
+    settingsStoreMock.defaultNostrRelays = [];
+    settingsStoreMock.relayBootstrapMode = undefined;
+    relayWatchdogInstances.length = 0;
+  });
+
+  it("registers only the Fundstr relay when fundstrOnly is true", async () => {
+    const { __testing } = await import("../../../src/boot/ndk");
+    const { FUNDSTR_PRIMARY_RELAY } = await import("../../../src/config/relays");
+    const ndk = await __testing.createReadOnlyNdk({ fundstrOnly: true });
+
+    expect([...ndk.pool.relays.keys()]).toEqual([FUNDSTR_PRIMARY_RELAY]);
+    expect(relayWatchdogInstances).toHaveLength(1);
+    expect(relayWatchdogInstances[0].start).toHaveBeenCalledWith(1, [
+      FUNDSTR_PRIMARY_RELAY,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- skip DM relay bootstrap when fundstr-only mode is requested and feed the mode into the relay watchdog
- add an options flag to `mustConnectRequiredRelays` so fundstr-only callers can bypass DM relays
- add a regression test covering `createReadOnlyNdk({ fundstrOnly: true })`

## Testing
- pnpm vitest run test/vitest/__tests__/ndk.boot.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0eb27cbac8330887b65f4b9e2ee2c