### PR TITLE
Refactor creator profile landing layout

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1772,6 +1772,9 @@ export const messages = {
         infrastructure: "Infrastructure trust",
         faq: "FAQ",
       },
+      summary: {
+        title: "Creator overview",
+      },
       noAbout: "This creator hasn't shared an about section yet.",
       noTiers: "Creator has not published any subscription tiers yet.",
       noFaq: "No FAQs published yet.",


### PR DESCRIPTION
## Summary
- restyle the public creator profile page around a concise summary card and tier list
- move infrastructure, how-it-works, and FAQ content into collapsible sections and hide guest paywall previews by default
- add a summary heading i18n key plus vitest coverage for the new guest/banner behaviour

## Testing
- pnpm vitest run test/publicCreatorProfilePage.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0f0ea0b4883308a2d4a9f5e4fd911