### PR TITLE
Update mint and relay badge surfaces to theme tokens

### DIFF
--- a/src/components/MintSafetyList.vue
+++ b/src/components/MintSafetyList.vue
@@ -51,10 +51,10 @@ const normalizedMints = computed(() =>
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--surface-contrast-border);
+  border: 1px solid transparent;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.02);
-  color: var(--text-1);
+  background: var(--chip-bg);
+  color: var(--chip-text);
 }
 
 .mint-safety-list__icon {

--- a/src/components/RelayBadgeList.vue
+++ b/src/components/RelayBadgeList.vue
@@ -51,10 +51,10 @@ const normalizedRelays = computed(() =>
   align-items: center;
   gap: 0.5rem;
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--surface-contrast-border);
+  border: 1px solid transparent;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.02);
-  color: var(--text-1);
+  background: var(--chip-bg);
+  color: var(--chip-text);
 }
 
 .relay-badge-list__icon {


### PR DESCRIPTION
## Summary
- use the chip background/text tokens for mint safety and relay badge list items to ensure light/dark theme compatibility

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68e106f795d88330870554096b66a7ca