### PR TITLE
Expand relay fallback when loading creator data

### DIFF
--- a/src/components/ProfileInfoDialog.vue
+++ b/src/components/ProfileInfoDialog.vue
@@ -79,7 +79,23 @@ async function load() {
   following.value = await nostr.fetchFollowingCount(props.pubkey);
   joined.value = await nostr.fetchJoinDate(props.pubkey);
   recentPost.value = await nostr.fetchMostRecentPost(props.pubkey);
-  await creators.fetchTierDefinitions(props.pubkey);
+  let tierFundstrOnly = true;
+  while (true) {
+    let tierError: unknown = null;
+    try {
+      await creators.fetchTierDefinitions(props.pubkey, {
+        fundstrOnly: tierFundstrOnly,
+      });
+    } catch (e) {
+      tierError = e;
+      console.error("Failed to fetch tier definitions", e);
+    }
+    if (tierFundstrOnly && (tierError || creators.tierFetchError)) {
+      tierFundstrOnly = false;
+      continue;
+    }
+    break;
+  }
   tiers.value = creators.tiersMap[props.pubkey] || [];
 }
 

--- a/test/publicCreatorProfilePage.spec.ts
+++ b/test/publicCreatorProfilePage.spec.ts
@@ -33,6 +33,12 @@ vi.mock("components/PaywalledContent.vue", () => ({
 vi.mock("components/MediaPreview.vue", () => ({
   default: defineComponent({ name: "MediaPreview", template: `<div class="media" />` }),
 }));
+vi.mock("components/NutzapExplainer.vue", () => ({
+  default: defineComponent({
+    name: "NutzapExplainer",
+    template: `<div class="nutzap-explainer" />`,
+  }),
+}));
 
 vi.mock("src/utils/profileUrl", () => ({
   buildProfileUrl: (...args: any[]) => buildProfileUrl(...args),
@@ -76,6 +82,7 @@ vi.mock("stores/nostr", () => ({
 }));
 vi.mock("vue-i18n", () => ({
   useI18n: () => ({ t: (key: string) => key }),
+  createI18n: () => ({ global: { t: (key: string) => key } }),
 }));
 
 import PublicCreatorProfilePage from "src/pages/PublicCreatorProfilePage.vue";
@@ -285,6 +292,9 @@ describe("PublicCreatorProfilePage", () => {
       ?.trigger("click");
 
     expect(fetchTierDefinitions).toHaveBeenCalledTimes(2);
+    expect(fetchTierDefinitions).toHaveBeenNthCalledWith(2, sampleHex, {
+      fundstrOnly: false,
+    });
   });
 
   it("shows a friendly error when the pubkey cannot be decoded", async () => {


### PR DESCRIPTION
## Summary
- retry Nutzap profile fetches in FindCreators with wider relay discovery and surface spinner messaging when fallback mode engages
- retry tier definition fetches with fundstr-only and global modes across FindCreators, PublicCreatorProfilePage, and ProfileInfoDialog
- update unit tests to cover the new fallback behaviour and expectations for retry buttons

## Testing
- pnpm test
- pnpm vitest run test/publicCreatorProfilePage.spec.ts
- pnpm vitest run test/findCreators.profile.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e200d3c3ac83309a64bef7082b950f