### PR TITLE
Ensure theme updates require loaded find creators iframe

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -863,13 +863,6 @@ watch(tierFetchError, (val) => {
   }
 });
 
-watch(
-  () => $q.dark.isActive,
-  () => {
-    sendTheme();
-  },
-);
-
 watch(showTierDialog, (val) => {
   if (!val) {
     nutzapProfile.value = null;


### PR DESCRIPTION
## Summary
- remove the redundant $q.dark.isActive watcher from FindCreators.vue
- rely on the existing watcher that guards sendTheme() with iframeLoaded and keep the initial load message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e204a117f883308a4732a3541ec76c