### PR TITLE
Refine tier definition fallback flow

### DIFF
--- a/src/components/ProfileInfoDialog.vue
+++ b/src/components/ProfileInfoDialog.vue
@@ -79,22 +79,14 @@ async function load() {
   following.value = await nostr.fetchFollowingCount(props.pubkey);
   joined.value = await nostr.fetchJoinDate(props.pubkey);
   recentPost.value = await nostr.fetchMostRecentPost(props.pubkey);
-  let tierFundstrOnly = true;
-  while (true) {
-    let tierError: unknown = null;
-    try {
-      await creators.fetchTierDefinitions(props.pubkey, {
-        fundstrOnly: tierFundstrOnly,
-      });
-    } catch (e) {
-      tierError = e;
-      console.error("Failed to fetch tier definitions", e);
-    }
-    if (tierFundstrOnly && (tierError || creators.tierFetchError)) {
-      tierFundstrOnly = false;
-      continue;
-    }
-    break;
+  try {
+    await creators.fetchTierDefinitions(props.pubkey, {
+      onFallback: () => {
+        /* no-op fallback hook for dialog context */
+      },
+    });
+  } catch (e) {
+    console.error("Failed to fetch tier definitions", e);
   }
   tiers.value = creators.tiersMap[props.pubkey] || [];
 }


### PR DESCRIPTION
## Summary
- update the creators store to remove the fundstrOnly flag, add an onFallback hook, and tighten the primary relay query behaviour
- adjust tier-loading flows in creator profile views to rely on the new fallback hook and single-shot fetch logic

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e20a36de488330aba00466d1221418