### PR TITLE
Adjust find creators status messages for indexer fallbacks

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -1077,7 +1077,7 @@
           }
 
           updateStatusIfPending(
-            "Still not found. Consulting nostr.band indexer for relay locations...",
+            "Still not found. Consulting public indexers for more relays...",
           );
           const indexedRelays = await fetchRelayListFromIndexer(pubkey, signal);
           if (signal.aborted) return;
@@ -1107,7 +1107,7 @@
 
           if (!indexerProfile) {
             updateStatusIfPending(
-              "Last attempt: Consulting Primal, the most powerful indexer...",
+              "Last attempt: Consulting Primal cache...",
             );
             const primalProfilePromise = fetchProfileFromPrimal(pubkey, signal);
             observeProfilesPromise(


### PR DESCRIPTION
## Summary
- update the relay indexer status message to reference public indexers
- change the Primal fallback text to mention the cache lookup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e20dd0ae74833093258eb7c259c69b