### PR TITLE
Prioritize primary relay for creator data fallback

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -1059,14 +1059,18 @@
 
           if (signal.aborted) return;
 
-          updateStatusIfPending("Profile not found. Discovering user's relays...");
+          if (!signal.aborted) {
+            updateStatusIfPending("Profile not found. Discovering user's relays...");
+          }
           const userRelays = await findUserRelayList(pubkey, signal);
           if (signal.aborted) return;
 
           if (userRelays.length > 0) {
-            updateStatusIfPending(
-              `Searching ${userRelays.length} newly discovered relays...`,
-            );
+            if (!signal.aborted) {
+              updateStatusIfPending(
+                `Searching ${userRelays.length} newly discovered relays...`,
+              );
+            }
             const userRelayPromise = observeProfilesPromise(
               fetchProfilesFromRelays(userRelays, filter, signal),
               signal,
@@ -1076,9 +1080,11 @@
             if (signal.aborted) return;
           }
 
-          updateStatusIfPending(
-            "Still not found. Consulting public indexers for more relays...",
-          );
+          if (!signal.aborted) {
+            updateStatusIfPending(
+              "Still not found. Consulting public indexers for more relays...",
+            );
+          }
           const indexedRelays = await fetchRelayListFromIndexer(pubkey, signal);
           if (signal.aborted) return;
 
@@ -1095,7 +1101,11 @@
             if (signal.aborted) return;
           }
 
-          updateStatusIfPending("Still not found. Checking nostr.band directly...");
+          if (!signal.aborted) {
+            updateStatusIfPending(
+              "Still not found. Checking nostr.band directly...",
+            );
+          }
           const indexerProfilePromise = fetchProfileFromIndexer(pubkey, signal);
           observeProfilesPromise(
             indexerProfilePromise.then((profile) => (profile ? [profile] : [])),
@@ -1106,9 +1116,11 @@
           if (signal.aborted) return;
 
           if (!indexerProfile) {
-            updateStatusIfPending(
-              "Last attempt: Consulting Primal cache...",
-            );
+            if (!signal.aborted) {
+              updateStatusIfPending(
+                "Last attempt: Consulting Primal cache...",
+              );
+            }
             const primalProfilePromise = fetchProfileFromPrimal(pubkey, signal);
             observeProfilesPromise(
               primalProfilePromise.then((profile) =>


### PR DESCRIPTION
## Summary
- enforce a relay.fundstr.me-first flow for tier fetching with an explicit fallback hook and timeout constant
- refine the profile fallback helper to log contextual warnings and trigger UI escalation only when the primary query fails
- surface guarded status updates in the creator search iframe so users know when additional relays or indexers are queried

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2126e38b48330bef0b5453d55c11f