### PR TITLE
Add shared relay config for static finder

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -323,7 +323,8 @@
 
     <script type="module" defer>
       import { filterHealthyRelays, pingRelay } from "./relayHealth.js";
-      const FUNDSTR_RELAY = "wss://relay.primal.net";
+      import { NUTZAP_RELAY_WSS } from "./relayConfig.js";
+      const FUNDSTR_RELAY = NUTZAP_RELAY_WSS;
       const DEFAULT_RELAYS = [
         FUNDSTR_RELAY,
         "wss://relay.damus.io",

--- a/public/relayConfig.js
+++ b/public/relayConfig.js
@@ -1,0 +1,8 @@
+export const NUTZAP_RELAY_WSS = 'wss://relay.primal.net';
+export const NUTZAP_RELAY_HTTP = 'https://relay.primal.net';
+export const NUTZAP_ALLOW_WSS_WRITES = false;
+export const NUTZAP_WS_TIMEOUT_MS = 4000;
+export const NUTZAP_HTTP_TIMEOUT_MS = 5000;
+export const NUTZAP_PROFILE_KIND = 10019;
+export const NUTZAP_TIERS_KIND = 30019;
+export const LEGACY_NUTZAP_TIERS_KIND = 30000;

--- a/public/relayHealth.js
+++ b/public/relayHealth.js
@@ -1,4 +1,6 @@
-const FUNDSTR_RELAY = "wss://relay.primal.net";
+import { NUTZAP_RELAY_WSS } from "./relayConfig.js";
+
+const FUNDSTR_RELAY = NUTZAP_RELAY_WSS;
 const BASE_FREE_RELAYS = [
   "wss://relay.damus.io",
   "wss://relay.snort.social",


### PR DESCRIPTION
## Summary
- add a public relayConfig.js that mirrors the SPA relay defaults for embeds
- update relayHealth and the find-creators entrypoint to read the shared config

## Testing
- pnpm dlx @quasar/cli build -m spa

------
https://chatgpt.com/codex/tasks/task_e_68e21a39db888330ab1e83d75434c593