### PR TITLE
Fix Creator Hub navigation visibility

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -77,7 +77,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item v-if="!isGuest" clickable @click="gotoCreatorHub">
+      <q-item clickable @click="gotoCreatorHub">
         <q-item-section avatar>
           <CreatorHubIcon class="themed-icon q-icon" />
         </q-item-section>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -44,6 +44,7 @@ export default route(async function (/* { store, ssrContext } */) {
       to.matched.some((r) => r.name === "PublicCreatorProfile") ||
       to.path.startsWith("/creator/");
     const isPublicDiscover = to.path === "/find-creators";
+    const isCreatorHub = to.path === "/creator-hub";
     const restore = useRestoreStore();
 
     const env = import.meta.env.VITE_APP_ENV;
@@ -56,7 +57,8 @@ export default route(async function (/* { store, ssrContext } */) {
       !restore.restoringState &&
       to.path !== "/restore" &&
       !isPublicProfile &&
-      !isPublicDiscover
+      !isPublicDiscover &&
+      !isCreatorHub
     ) {
       next({ path: "/welcome", query: { first: "1" } });
       return;


### PR DESCRIPTION
## Summary
- ensure the Creator Hub drawer link is always visible so users can find the page
- allow routing to /creator-hub even before the welcome flow has been completed

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68e222978fb4833094d235dfa47ce3f8