### PR TITLE
Allow creator studio access pre-onboarding

### DIFF
--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -87,11 +87,17 @@ const showSeedDialog = ref(false)
 const showChecklist = ref(false)
 const { deferredPrompt } = usePwaInstall()
 
+function completeWelcome() {
+  welcome.closeWelcome()
+  markWelcomeSeen()
+}
+
 onMounted(() => {
   const env = import.meta.env.VITE_APP_ENV
   const allow =
     route.query.allow === '1' && (env === 'development' || env === 'staging')
   if (route.path.startsWith('/welcome') && hasSeenWelcome() && !allow) {
+    completeWelcome()
     router.replace('/about')
   }
 })
@@ -106,9 +112,7 @@ function downloadBackup() {
 
 async function finishOnboarding() {
   showChecklist.value = false
-  welcome.closeWelcome()
-  // remember that the welcome flow has been completed on this device
-  markWelcomeSeen()
+  completeWelcome()
   await nextTick()
   router.replace('/about')
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -45,6 +45,7 @@ export default route(async function (/* { store, ssrContext } */) {
       to.path.startsWith("/creator/");
     const isPublicDiscover = to.path === "/find-creators";
     const isCreatorHub = to.path === "/creator-hub";
+    const isCreatorStudio = to.path === "/creator-studio";
     const restore = useRestoreStore();
 
     const env = import.meta.env.VITE_APP_ENV;
@@ -58,7 +59,8 @@ export default route(async function (/* { store, ssrContext } */) {
       to.path !== "/restore" &&
       !isPublicProfile &&
       !isPublicDiscover &&
-      !isCreatorHub
+      !isCreatorHub &&
+      !isCreatorStudio
     ) {
       next({ path: "/welcome", query: { first: "1" } });
       return;

--- a/test/welcomeGate.guard.spec.ts
+++ b/test/welcomeGate.guard.spec.ts
@@ -21,6 +21,7 @@ async function setup({
     { path: '/about', component: {} },
     { path: '/welcome', component: {} },
     { path: '/restore', component: {} },
+    { path: '/creator-studio', component: {} },
   ]
 
   vi.doMock('src/router/routes', () => ({ default: routes }))
@@ -28,7 +29,7 @@ async function setup({
   const oldServer = process.env.SERVER
   process.env.SERVER = '1'
   const createAppRouter = (await import('src/router/index.js')).default
-  const router = createAppRouter()
+  const router = await createAppRouter()
   process.env.SERVER = oldServer
 
   // start router at root
@@ -69,6 +70,18 @@ describe('welcome gate router guard', () => {
     const router = await setup({ seen: true, env: 'development' })
     await router.push('/welcome?allow=1')
     expect(router.currentRoute.value.fullPath).toBe('/welcome?allow=1')
+  })
+
+  it('allows access to /creator-studio before onboarding completion', async () => {
+    const router = await setup({ seen: false })
+    await router.push('/creator-studio')
+    expect(router.currentRoute.value.fullPath).toBe('/creator-studio')
+  })
+
+  it('allows access to /creator-studio after onboarding completion', async () => {
+    const router = await setup({ seen: true })
+    await router.push('/creator-studio')
+    expect(router.currentRoute.value.fullPath).toBe('/creator-studio')
   })
 })
 


### PR DESCRIPTION
## Summary
- whitelist the /creator-studio route in the welcome guard so pre-onboarding users are not redirected to 404
- ensure welcome completion always closes the drawer and records the onboarding state when redirecting returning users
- extend the welcome guard spec to cover creator studio access before and after onboarding

## Testing
- pnpm exec vitest run test/welcomeGate.guard.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e22c646c108330ab737e0183cb1e4c