### PR TITLE
Allow Creator Studio link for guests

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -90,7 +90,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item v-if="!isGuest" clickable @click="gotoCreatorStudio">
+      <q-item clickable @click="gotoCreatorStudio">
         <q-item-section avatar>
           <q-icon name="dashboard_customize" />
         </q-item-section>


### PR DESCRIPTION
## Summary
- allow the Creator Studio navigation item to render even if the welcome flow is incomplete so it remains accessible to guests

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2385c80c48330b09cba60f13d9887