### PR TITLE
Allow Creator Studio before welcome gate

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -44,6 +44,7 @@ export default route(async function (/* { store, ssrContext } */) {
       to.matched.some((r) => r.name === "PublicCreatorProfile") ||
       to.path.startsWith("/creator/");
     const isPublicDiscover = to.path === "/find-creators";
+    const isCreatorStudio = to.path.startsWith("/creator-studio");
     const restore = useRestoreStore();
 
     const env = import.meta.env.VITE_APP_ENV;
@@ -56,7 +57,8 @@ export default route(async function (/* { store, ssrContext } */) {
       !restore.restoringState &&
       to.path !== "/restore" &&
       !isPublicProfile &&
-      !isPublicDiscover
+      !isPublicDiscover &&
+      !isCreatorStudio
     ) {
       next({ path: "/welcome", query: { first: "1" } });
       return;


### PR DESCRIPTION
## Summary
- update the welcome guard to treat `/creator-studio` and its subroutes as public
- ensure new visitors can reach Creator Studio without seeing the welcome flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2394bdefc8330bee1cf4e72818d97