### PR TITLE
Ensure build workflow exports VITE_BUILD_ID

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -3,6 +3,11 @@ VITE_API_BASE=https://api.fundstr.me
 VITE_DONATION_LIGHTNING=lightning_address_here
 VITE_DONATION_BITCOIN=bitcoin_address_here
 
+# Set VITE_BUILD_ID (e.g. git SHA + run number) before running `pnpm run build`
+# so the service worker (`sw.js?v=...`) updates every release. CI workflows
+# export this automatically, but manual builds should set it too.
+# VITE_BUILD_ID=manual-1234567
+
 # Nutzap isolated relay (WSS first, HTTP fallback)
 VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.primal.net
 VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.primal.net

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
           corepack enable
           corepack prepare pnpm@10.16.1 --activate
           pnpm --version
+      - name: Set build id for cache busting
+        run: echo "VITE_BUILD_ID=${GITHUB_SHA::7}-${GITHUB_RUN_NUMBER}" >> $GITHUB_ENV
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build


### PR DESCRIPTION
## Summary
- export a unique `VITE_BUILD_ID` in the build workflow so Quasar builds bust the service worker cache
- document the manual `VITE_BUILD_ID` requirement in `.env.production` for local or manual releases

## Testing
- VITE_BUILD_ID=local pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e23f5256248330ad2d238de75492e6