### PR TITLE
Allow guests to access the Creator Studio

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -90,7 +90,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item v-if="!isGuest" clickable @click="gotoCreatorStudio">
+      <q-item clickable @click="gotoCreatorStudio">
         <q-item-section avatar>
           <q-icon name="dashboard_customize" />
         </q-item-section>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -44,6 +44,7 @@ export default route(async function (/* { store, ssrContext } */) {
       to.matched.some((r) => r.name === "PublicCreatorProfile") ||
       to.path.startsWith("/creator/");
     const isPublicDiscover = to.path === "/find-creators";
+    const isCreatorStudio = to.path === "/creator-studio";
     const restore = useRestoreStore();
 
     const env = import.meta.env.VITE_APP_ENV;
@@ -56,7 +57,8 @@ export default route(async function (/* { store, ssrContext } */) {
       !restore.restoringState &&
       to.path !== "/restore" &&
       !isPublicProfile &&
-      !isPublicDiscover
+      !isPublicDiscover &&
+      !isCreatorStudio
     ) {
       next({ path: "/welcome", query: { first: "1" } });
       return;


### PR DESCRIPTION
## Summary
- expose the Creator Studio link in the navigation drawer for all users
- allow routing to /creator-studio without completing the welcome flow

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e2417f2b0c8330a5327d57ee8656ab