### PR TITLE
chore: run deploy builds through pnpm script

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile=false
 
-      - name: Build (Quasar PWA)
-        run: pnpm quasar build -m pwa
+      - name: Build (SPA)
+        run: pnpm run build
 
       - name: Enforce .htaccess with cache headers (in built bundle)
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -33,8 +33,8 @@ jobs:
         run: cp .env.staging .env || true
       - name: Install deps
         run: pnpm install --frozen-lockfile=false
-      - name: Build (Quasar PWA)
-        run: pnpm quasar build -m pwa
+      - name: Build (SPA)
+        run: pnpm run build
       - name: Enforce .htaccess with cache headers (in built bundle)
         run: |
           cat > dist/pwa/.htaccess <<'EOF'

--- a/src-pwa/register-service-worker.js
+++ b/src-pwa/register-service-worker.js
@@ -12,7 +12,7 @@ if (import.meta.env.PROD) {
     cached() { console.log("[PWA] cached"); },
     updatefound() { console.log("[PWA] update found"); },
     updated(reg) {
-      console.log("[PWA] updated, forcing activation");
+      console.log("[PWA] updated");
       if (reg && reg.waiting) reg.waiting.postMessage({ type: "SKIP_WAITING" });
       window.location.reload();
     },


### PR DESCRIPTION
## Summary
- align staging and production workflows to invoke `pnpm run build` so deployments pick up the SPA bundle and generated assets
- update the service worker log message to emit `[PWA] updated` when a fresh cache activates for manual verification

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2433254b083308cd6cceb3fe18c7d