### PR TITLE
Handle cached creator prefill messages

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -1405,6 +1405,17 @@
           if (ev.data?.type === "prefillSearch" && ev.data.npub) {
             searchInputElement.value = ev.data.npub;
             handleSearch(ev.data.npub);
+          } else if (ev.data?.type === "prefillCache") {
+            const creators = Array.isArray(ev.data.creators)
+              ? ev.data.creators.filter(Boolean)
+              : [];
+            if (creators.length > 0) {
+              mergeProfilesIntoCurrent(creators);
+              const orderedProfiles = Array.from(
+                currentSearchProfiles.values(),
+              );
+              renderProfiles(orderedProfiles, resultsListElement, false);
+            }
           } else if (ev.data?.type === "set-theme") {
             document.body.classList.toggle("dark", !!ev.data.dark);
           } else if (ev.data?.type === "relay-config") {


### PR DESCRIPTION
## Summary
- handle `prefillCache` postMessage events in the find creators iframe and merge creator payloads into the current profile cache before re-rendering
- verified the Vue host page continues to debounce duplicate payloads via `lastPrefillSignature`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e364cedadc8330b23e81173cc21305