### PR TITLE
Fix custom relay defaults and UI runtime errors

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -327,7 +327,7 @@
         pingRelay,
         configureRelayDefaults,
         getRelayDefaults,
-      } from "./relayHealth.js";
+      } from "./relayHealth.js?v=20240528";
 
       const normalizeRelayUrl = (value) => {
         if (typeof value !== "string") return null;

--- a/public/relayHealth.js
+++ b/public/relayHealth.js
@@ -211,6 +211,15 @@ export async function pingRelay(url) {
   return false;
 }
 
+if (typeof window !== "undefined") {
+  window.FundstrRelayHealth = {
+    configureRelayDefaults,
+    getRelayDefaults,
+    filterHealthyRelays,
+    pingRelay,
+  };
+}
+
 export async function filterHealthyRelays(relays) {
   const key = relays.slice().sort().join("|");
   const cached = filterCache.get(key);

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -627,6 +627,9 @@ export default defineComponent({
         this.addingMint = false;
       }
     },
+    formatCurrency(amount, unit) {
+      return useUiStore().formatCurrency(amount, unit);
+    },
     mintClass(mint) {
       return new MintClass(mint);
     },

--- a/src/nutzap/onepage/NutzapExplorerPanel.vue
+++ b/src/nutzap/onepage/NutzapExplorerPanel.vue
@@ -187,14 +187,22 @@ import type { Event as NostrEvent, Filter as NostrFilter } from 'nostr-tools';
 import { multiRelaySearch, mergeRelayHints } from './multiRelaySearch';
 import { sanitizeRelayUrls } from 'src/utils/relay';
 
-const DEFAULT_RELAYS = ['wss://relay.primal.net'];
+const DEFAULT_RELAYS = ['wss://relay.fundstr.me'];
 
-const props = defineProps<{
-  modelValue: string;
-  loadingAuthor: boolean;
-  tierAddressPreview: string;
-  condensed?: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    modelValue?: string;
+    loadingAuthor?: boolean;
+    tierAddressPreview?: string;
+    condensed?: boolean;
+  }>(),
+  {
+    modelValue: "",
+    loadingAuthor: false,
+    tierAddressPreview: "",
+    condensed: false,
+  },
+);
 
 const emit = defineEmits<{
   (event: 'update:modelValue', value: string): void;
@@ -204,8 +212,9 @@ const emit = defineEmits<{
 const condensed = computed(() => Boolean(props.condensed));
 
 const authorModel = computed({
-  get: () => props.modelValue,
-  set: value => emit('update:modelValue', value),
+  get: () => (typeof props.modelValue === "string" ? props.modelValue : ""),
+  set: (value: string | null | undefined) =>
+    emit("update:modelValue", typeof value === "string" ? value : ""),
 });
 
 const query = ref('');

--- a/src/nutzap/relayConfig.ts
+++ b/src/nutzap/relayConfig.ts
@@ -10,12 +10,12 @@ function pickRelayEnv(value: unknown, fallback: string): string {
 
 export const NUTZAP_RELAY_WSS = pickRelayEnv(
   import.meta.env.VITE_NUTZAP_PRIMARY_RELAY_WSS,
-  'wss://relay.primal.net',
+  'wss://relay.fundstr.me',
 );
 
 export const NUTZAP_RELAY_HTTP = pickRelayEnv(
   import.meta.env.VITE_NUTZAP_PRIMARY_RELAY_HTTP,
-  'https://relay.primal.net',
+  'https://relay.fundstr.me',
 );
 
 export const NUTZAP_ALLOW_WSS_WRITES =


### PR DESCRIPTION
## Summary
- add a local formatCurrency helper so MintSettings renders balances without crashing
- harden the Nutzap explorer panel defaults and point its relay list at relay.fundstr.me
- version the find-creators relay health import, expose helpers on window, and default Nutzap relay config to Fundstr

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e3839d8b408330ae8bc5ebfe00c58a