### PR TITLE
chore: remove unused TypeScript import from UI store

### DIFF
--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -12,8 +12,6 @@ import {
 import { Clipboard } from "@capacitor/clipboard";
 import { Haptics, ImpactStyle } from "@capacitor/haptics";
 
-import ts from "typescript";
-
 const unitTickerShortMap = {
   sat: "sats",
   usd: "USD",


### PR DESCRIPTION
## Summary
- remove the direct TypeScript compiler import from the UI store so it no longer ships in the main bundle

## Testing
- pnpm quasar build -m pwa --analyze

------
https://chatgpt.com/codex/tasks/task_e_68e3a605ef1c833096128f2cdaa866ff