### PR TITLE
Allow Nutzap modules to override Fundstr relay endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,9 @@ VITE_DONATION_LIGHTNING=lightning_address_here
 VITE_DONATION_BITCOIN=bitcoin_address_here
 
 # Nutzap isolated relay (WSS first, HTTP fallback)
-VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.primal.net
-VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.primal.net
+# These URLs are isolated from the global relay list configuration.
+VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.fundstr.me
+VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.fundstr.me
 
 # Control WS writes (enable in staging/prod once verified)
 VITE_NUTZAP_ALLOW_WSS_WRITES=false

--- a/.env.production
+++ b/.env.production
@@ -4,8 +4,9 @@ VITE_DONATION_LIGHTNING=lightning_address_here
 VITE_DONATION_BITCOIN=bitcoin_address_here
 
 # Nutzap isolated relay (WSS first, HTTP fallback)
-VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.primal.net
-VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.primal.net
+# These URLs are isolated from the global relay list configuration.
+VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.fundstr.me
+VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.fundstr.me
 
 # Control WS writes (enable in staging/prod once verified)
 VITE_NUTZAP_ALLOW_WSS_WRITES=false

--- a/.env.staging
+++ b/.env.staging
@@ -4,8 +4,9 @@ VITE_DONATION_LIGHTNING=lightning_address_here
 VITE_DONATION_BITCOIN=bitcoin_address_here
 
 # Nutzap isolated relay (WSS first, HTTP fallback)
-VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.primal.net
-VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.primal.net
+# These URLs are isolated from the global relay list configuration.
+VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.fundstr.me
+VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.fundstr.me
 
 # Control WS writes (enable in staging/prod once verified)
 VITE_NUTZAP_ALLOW_WSS_WRITES=false

--- a/src/nutzap/publish.ts
+++ b/src/nutzap/publish.ts
@@ -3,6 +3,7 @@ import { NUTZAP_PROFILE_KIND, NUTZAP_TIERS_KIND } from './relayConfig';
 import { getNutzapNdk } from './ndkInstance';
 import type { Tier, NutzapProfileContent } from './types';
 import { publishNostr } from '@/nostr/relayClient';
+import { FUNDSTR_REQ_URL, FUNDSTR_WS_URL } from './relayEndpoints';
 import { toPlainNostrEvent } from '@/nostr/eventUtils';
 
 /** Publish kind:10019 Nutzap profile; WS first (if allowed), else HTTP. */
@@ -17,7 +18,10 @@ export async function publishNutzapProfile(
   ev.tags = tags;
   await ev.sign(); // must have signer configured globally or via NDK signer
   const nostrEvent = await toPlainNostrEvent(ev);
-  const ack = await publishNostr(nostrEvent);
+  const ack = await publishNostr(nostrEvent, {
+    httpBase: FUNDSTR_REQ_URL,
+    fundstrWsUrl: FUNDSTR_WS_URL,
+  });
   if (!ack.accepted) {
     throw new Error(ack.message || "Relay rejected Nutzap profile");
   }
@@ -40,7 +44,10 @@ export async function publishTierDefinitions(
   ev.content = JSON.stringify(tiers);
   await ev.sign();
   const nostrEvent = await toPlainNostrEvent(ev);
-  const ack = await publishNostr(nostrEvent);
+  const ack = await publishNostr(nostrEvent, {
+    httpBase: FUNDSTR_REQ_URL,
+    fundstrWsUrl: FUNDSTR_WS_URL,
+  });
   if (!ack.accepted) {
     throw new Error(ack.message || "Relay rejected tier definitions");
   }

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -23,7 +23,11 @@ import {
 } from "@/nostr/relayClient";
 import { fallbackDiscoverRelays } from "@/nostr/discovery";
 import { parseTierDefinitionEvent } from "src/nostr/tiers";
-import { FUNDSTR_REQ_URL, WS_FIRST_TIMEOUT_MS } from "@/nutzap/relayEndpoints";
+import {
+  FUNDSTR_REQ_URL,
+  FUNDSTR_WS_URL,
+  WS_FIRST_TIMEOUT_MS,
+} from "@/nutzap/relayEndpoints";
 import { safeUseLocalStorage } from "src/utils/safeLocalStorage";
 import type { NutzapProfileDetails } from "@/nutzap/profileCache";
 
@@ -559,6 +563,7 @@ export const useCreatorsStore = defineStore("creators", {
       try {
         event = await queryNutzapTiers(hex, {
           httpBase: FUNDSTR_REQ_URL,
+          fundstrWsUrl: FUNDSTR_WS_URL,
           allowFanoutFallback: false,
           wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,
         });
@@ -571,6 +576,7 @@ export const useCreatorsStore = defineStore("creators", {
         try {
           event = await queryNutzapTiers(hex, {
             httpBase: FUNDSTR_REQ_URL,
+            fundstrWsUrl: FUNDSTR_WS_URL,
             fanout: Array.from(relayHints),
             allowFanoutFallback: !fundstrOnly,
             wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,
@@ -588,6 +594,7 @@ export const useCreatorsStore = defineStore("creators", {
           if (relayHints.size) {
             event = await queryNutzapTiers(hex, {
               httpBase: FUNDSTR_REQ_URL,
+              fundstrWsUrl: FUNDSTR_WS_URL,
               fanout: Array.from(relayHints),
               allowFanoutFallback: true,
               wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -79,7 +79,11 @@ import {
 import { mapInternalTierToWire } from "src/nostr/tiers";
 import { buildKind10019NutzapProfile } from "src/nostr/builders";
 import { NutzapProfileSchema, type NutzapProfilePayload } from "src/nostr/nutzapProfile";
-import { FUNDSTR_REQ_URL, WS_FIRST_TIMEOUT_MS } from "@/nutzap/relayEndpoints";
+import {
+  FUNDSTR_REQ_URL,
+  FUNDSTR_WS_URL,
+  WS_FIRST_TIMEOUT_MS,
+} from "@/nutzap/relayEndpoints";
 
 // --- Relay connectivity helpers ---
 export type WriteConnectivity = {
@@ -890,6 +894,7 @@ export async function fetchNutzapProfile(
   try {
     event = await queryNutzapProfile(hex, {
       httpBase: FUNDSTR_REQ_URL,
+      fundstrWsUrl: FUNDSTR_WS_URL,
       allowFanoutFallback: false,
       wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,
     });
@@ -903,6 +908,7 @@ export async function fetchNutzapProfile(
       if (discovered.length) {
         event = await queryNutzapProfile(hex, {
           httpBase: FUNDSTR_REQ_URL,
+          fundstrWsUrl: FUNDSTR_WS_URL,
           fanout: discovered,
           allowFanoutFallback: true,
           wsTimeoutMs: CUSTOM_LINK_WS_TIMEOUT_MS,


### PR DESCRIPTION
## Summary
- allow query helpers to override the Fundstr relay websocket and HTTP endpoints
- pass the Nutzap relay configuration through Nutzap query/publish call sites
- set Nutzap default relay environment variables to relay.fundstr.me and document isolation from the global relay list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4d082b3148330a0a2a20b2a991b51