### PR TITLE
Update Fundstr relay endpoints to new host

### DIFF
--- a/docs/relay-access.md
+++ b/docs/relay-access.md
@@ -9,14 +9,14 @@ Publishes must send a fully signed NIP-01 event to /event; the client validates 
 ## Transport flow
 
 1. The client always **prefers the isolated Fundstr relay**
-   (`wss://relay.primal.net`).
+   (`wss://relay.fundstr.me`).
 2. Every query begins with a WebSocket REQ/EOSE round-trip. Connections are
    bounded by a ~1.5&nbsp;s timeout to keep the UI responsive.
 3. If the socket cannot be opened or returns no events, the client
    automatically performs the same query over HTTP:
-   `https://relay.primal.net/req?filters=…`.
+   `https://relay.fundstr.me/req?filters=…`.
 4. When Fundstr returns no data the client **can** fan out across a vetted pool
-  of public relays (`relay.primal.net`, `relay.snort.social`, `nos.lol`,
+  of public relays (`relay.fundstr.me`, `relay.snort.social`, `nos.lol`,
   `relay.damus.io`). This behaviour is opt-in via
    `allowFanoutFallback`—Fundstr-first flows (including Creator Studio load /
    refresh) stay pinned to the first-party relay unless callers explicitly pass
@@ -27,7 +27,7 @@ All fetches, including the service-worker passthrough, use
 responses are never cached.
 
 Publishing Nutzap events uses a direct HTTP POST to
-`https://relay.primal.net/event`. The relay responds with a JSON payload shaped
+`https://relay.fundstr.me/event`. The relay responds with a JSON payload shaped
 like `{ ok, id, accepted, message }`. Callers must treat a publish as successful
 **only** when `accepted === true`. When `accepted` is false the provided relay
 `message` should be surfaced to the user verbatim.

--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -1,5 +1,5 @@
-export const FUNDSTR_PRIMARY_RELAY = 'wss://relay.primal.net';
-export const FUNDSTR_PRIMARY_RELAY_HTTP = 'https://relay.primal.net';
+export const FUNDSTR_PRIMARY_RELAY = 'wss://relay.fundstr.me';
+export const FUNDSTR_PRIMARY_RELAY_HTTP = 'https://relay.fundstr.me';
 export const PRIMARY_RELAY = FUNDSTR_PRIMARY_RELAY;
 
 export const FALLBACK_RELAYS: string[] = [

--- a/src/nutzap/onepage/NutzapExplorerPanel.vue
+++ b/src/nutzap/onepage/NutzapExplorerPanel.vue
@@ -186,8 +186,9 @@ import { nip19 } from 'nostr-tools';
 import type { Event as NostrEvent, Filter as NostrFilter } from 'nostr-tools';
 import { multiRelaySearch, mergeRelayHints } from './multiRelaySearch';
 import { sanitizeRelayUrls } from 'src/utils/relay';
+import { FUNDSTR_WS_URL } from '../relayEndpoints';
 
-const DEFAULT_RELAYS = ['wss://relay.primal.net'];
+const DEFAULT_RELAYS = [FUNDSTR_WS_URL];
 
 const props = withDefaults(
   defineProps<{


### PR DESCRIPTION
## Summary
- point Fundstr relay constants to relay.fundstr.me
- update Nutzap explorer defaults and telemetry checks to use the shared FUNDSTR_WS_URL constant
- refresh relay access documentation for the new endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4dd02bf008330a34cfb103a2fc548