### PR TITLE
Enable Nutzap relay WebSocket writes in production and staging

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -9,7 +9,7 @@ VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.fundstr.me
 VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.fundstr.me
 
 # Control WS writes (enable in staging/prod once verified)
-VITE_NUTZAP_ALLOW_WSS_WRITES=false
+VITE_NUTZAP_ALLOW_WSS_WRITES=true
 
 # Timeouts (ms)
 VITE_NUTZAP_WS_TIMEOUT_MS=4000

--- a/.env.staging
+++ b/.env.staging
@@ -9,7 +9,7 @@ VITE_NUTZAP_PRIMARY_RELAY_WSS=wss://relay.fundstr.me
 VITE_NUTZAP_PRIMARY_RELAY_HTTP=https://relay.fundstr.me
 
 # Control WS writes (enable in staging/prod once verified)
-VITE_NUTZAP_ALLOW_WSS_WRITES=false
+VITE_NUTZAP_ALLOW_WSS_WRITES=true
 
 # Timeouts (ms)
 VITE_NUTZAP_WS_TIMEOUT_MS=4000


### PR DESCRIPTION
## Summary
- flip `VITE_NUTZAP_ALLOW_WSS_WRITES` to true for staging and production builds so the client prefers relay WebSocket acknowledgements
- attempted to verify WebSocket publishing via nostr-tools, but the relay currently responds with HTTP 403 during the upgrade handshake and needs follow-up with the relay service

## Testing
- not run (env var change only)

------
https://chatgpt.com/codex/tasks/task_e_68e4de67e7d48330818f04d05b6727bd