### PR TITLE
Fix MintSettings currency formatting helper

### DIFF
--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -582,6 +582,9 @@ export default defineComponent({
     ...mapActions(useWorkersStore, ["clearAllWorkers"]),
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
     ...mapActions(useSwapStore, ["mintAmountSwap"]),
+    formatCurrency(amount, unit) {
+      return useUiStore().formatCurrency(amount, unit);
+    },
     activateMintUrlInternal: async function (mintUrl) {
       this.activatingMintUrl = mintUrl;
       debug(`Activating mint ${this.activatingMintUrl}`);


### PR DESCRIPTION
## Summary
- add a formatCurrency helper on MintSettings so the template can format balances without runtime errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4e41a81e88330babe927ee7a5ae62