### PR TITLE
Ensure verified mints activate wallet store

### DIFF
--- a/src/pages/CreatorStudioPage.vue
+++ b/src/pages/CreatorStudioPage.vue
@@ -1363,6 +1363,25 @@ async function handleVerifyP2pkPointer() {
       if (!normalizedExisting.includes(normalizedMintCandidate)) {
         composerMints.value = [...existingEntries, normalizedMintCandidate];
         addedMintUrl = normalizedMintCandidate;
+
+        const storedMintEntries = Array.isArray(storedMints.value) ? storedMints.value : [];
+        const normalizedStored = storedMintEntries
+          .map(entry => (entry && typeof entry.url === 'string' ? normalizeMintUrl(entry.url) : ''))
+          .filter((entry): entry is string => Boolean(entry));
+        const mintExistsInStore = normalizedStored.includes(normalizedMintCandidate);
+
+        if (mintExistsInStore && typeof mintsStore.activateMintUrl === 'function') {
+          try {
+            await mintsStore.activateMintUrl(normalizedMintCandidate, false, true);
+          } catch (err) {
+            console.warn('[nutzap] failed to activate composer mint via store action', err);
+            mintsStore.activeMintUrl = normalizedMintCandidate;
+            storeActiveMintUrl.value = normalizedMintCandidate;
+          }
+        } else {
+          mintsStore.activeMintUrl = normalizedMintCandidate;
+          storeActiveMintUrl.value = normalizedMintCandidate;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- activate the wallet mint when pointer verification adds a new mint in Creator Studio
- extend the Creator Studio publish blockers test harness to cover the new activation flow and adjust mocks

## Testing
- pnpm vitest run test/vitest/__tests__/CreatorStudioPage.publishBlockers.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e60b0a91508330b145129de57a3076