### PR TITLE
Ensure Nutzap profile republish targets selected relays

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1246,6 +1246,21 @@ export async function publishNutzapProfile(opts: {
       content: JSON.stringify({ v: 1, ...body }),
       created_at: createdAt,
     });
+    if (relays.length) {
+      try {
+        const relaySet = await urlsToRelaySet(relays);
+        if (relaySet) {
+          const ndkEvent = new NDKEvent(ndk, result.event as any);
+          await waitForRelaySetConnectivity(relaySet);
+          await publishWithTimeout(ndkEvent, relaySet);
+        }
+      } catch (relayErr) {
+        console.warn(
+          "[nostr] Failed to publish Nutzap profile to selected relays",
+          relayErr,
+        );
+      }
+    }
     return result.event.id;
   } catch (e: any) {
     notifyError(e?.message ?? String(e));


### PR DESCRIPTION
## Summary
- delegate the creator hub store’s Nutzap profile publish helper to `publishNostrEvent` so HTTP fallback is available
- add regression coverage for the auto republish path when the websocket publish times out
- ensure Nutzap profiles continue to broadcast to any relays requested by the caller when delegating to the shared publish helper

## Testing
- pnpm test
- pnpm vitest run test/vitest/__tests__/CreatorStudioPage.publish.spec.ts
- pnpm vitest run test/vitest/__tests__/creatorHub.spec.ts (fails: module mocking order error)


------
https://chatgpt.com/codex/tasks/task_e_68e610e0404083309d38c2ea3e543216