### PR TITLE
Add relay fallback for public creator profile loading

### DIFF
--- a/test/publicCreatorProfilePage.spec.ts
+++ b/test/publicCreatorProfilePage.spec.ts
@@ -153,6 +153,9 @@ describe("PublicCreatorProfilePage", () => {
       profileEvent: null,
       followers: 5,
       following: 3,
+      profileDetails: null,
+      relayHints: [],
+      fetchedFromFallback: false,
     });
     creatorsStore = reactive({
       tiersMap: reactive({}),
@@ -209,7 +212,10 @@ describe("PublicCreatorProfilePage", () => {
 
     expect(fetchTierDefinitions).toHaveBeenCalled();
     expect(fetchTierDefinitions.mock.calls[0][0]).toBe(sampleHex);
-    expect(fetchTierDefinitions.mock.calls[0][1]).toEqual({ fundstrOnly: true });
+    expect(fetchTierDefinitions.mock.calls[0][1]).toEqual({
+      fundstrOnly: true,
+      relayHints: [],
+    });
     expect(wrapper.vm.selectedTier?.id).toBe("tier-1");
     expect(wrapper.vm.showSubscribeDialog).toBe(true);
     expect(router.currentRoute.value.query.tierId).toBeUndefined();
@@ -229,7 +235,10 @@ describe("PublicCreatorProfilePage", () => {
     const wrapper = mountPage(router);
     await flushPromises();
 
-    expect(fetchTierDefinitions).toHaveBeenCalledWith(sampleHex, { fundstrOnly: true });
+    expect(fetchTierDefinitions).toHaveBeenCalledWith(sampleHex, {
+      fundstrOnly: true,
+      relayHints: [],
+    });
     expect(wrapper.vm.creatorHex).toBe(sampleHex);
     expect(wrapper.vm.creatorNpub).toBe(nip19.npubEncode(sampleHex));
   });

--- a/test/vitest/__tests__/creators-tiers.spec.ts
+++ b/test/vitest/__tests__/creators-tiers.spec.ts
@@ -25,10 +25,16 @@ vi.mock("../../../src/stores/dexie", () => {
     put: vi.fn().mockResolvedValue(undefined),
     delete: vi.fn().mockResolvedValue(undefined),
   };
+  const profileCollection = {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
   const cashuDb = {
     open: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
     creatorsTierDefinitions: tierCollection,
+    nutzapProfiles: profileCollection,
   };
   return {
     cashuDb,


### PR DESCRIPTION
## Summary
- add fallback relay discovery and logging to the Fundstr profile/tier fetch pipeline
- surface a fallback status banner on the public creator profile page and reuse relay hints when fetching tiers
- update the preload job and unit tests to exercise the new fallback behaviour

## Testing
- pnpm test
- pnpm vitest run test/publicCreatorProfilePage.spec.ts test/vitest/__tests__/creators-tiers.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e64469534483309cba86518e36fe16