### PR TITLE
fix(profile): replace broken trusted rank resource link

### DIFF
--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -712,8 +712,8 @@ const TRUSTED_RANK_INFO_LINKS = [
   },
   {
     id: "nostr-band-trust",
-    label: "About nostr.band trust",
-    href: "https://trust.nostr.band",
+    label: "Open nostr.band NIP-85 relay",
+    href: "https://nip85.nostr.band",
   },
 ] as const;
 

--- a/test/vitest/__tests__/PublicCreatorProfilePage.phonebook.spec.ts
+++ b/test/vitest/__tests__/PublicCreatorProfilePage.phonebook.spec.ts
@@ -285,8 +285,8 @@ describe("PublicCreatorProfilePage phonebook enrichment", () => {
         }),
         expect.objectContaining({
           id: "nostr-band-trust",
-          label: "About nostr.band trust",
-          href: "https://trust.nostr.band",
+          label: "Open nostr.band NIP-85 relay",
+          href: "https://nip85.nostr.band",
         }),
       ]),
     );


### PR DESCRIPTION
Point the provider resource link at the reachable nostr.band NIP-85 relay endpoint and update the UI copy to match the actual destination.