### PR TITLE
feat(discovery): expand NIP-85 trusted rank usage

### DIFF
--- a/src/components/CreatorCard.vue
+++ b/src/components/CreatorCard.vue
@@ -79,7 +79,7 @@
             </div>
           </div>
           <div
-            v-if="tierSummaryText || followers !== null"
+            v-if="tierSummaryText || followers !== null || trustedRank !== null"
             class="meta-chip-row text-2"
           >
             <span v-if="tierSummaryText" class="meta-chip">
@@ -89,6 +89,10 @@
             <span v-if="followers !== null" class="meta-chip">
               <q-icon name="group" size="14px" class="meta-chip-icon" />
               {{ followers }} followers
+            </span>
+            <span v-if="trustedRank !== null" class="meta-chip">
+              <q-icon name="shield" size="14px" class="meta-chip-icon" />
+              Trusted rank {{ trustedRank }}
             </span>
           </div>
         </div>
@@ -163,6 +167,7 @@ import type { Creator } from "src/lib/fundstrApi";
 import { formatMsatToSats } from "src/lib/fundstrApi";
 import { DONATION_FALLBACK_LOOKUP } from "src/config/donation-eligibility";
 import {
+  creatorTrustedRank,
   creatorHasVerifiedNip05,
   creatorIsFundstrCreator,
   creatorIsSignalOnly,
@@ -294,6 +299,7 @@ const tierSummaryText = computed(() => {
 });
 
 const followers = computed(() => props.profile.followers ?? null);
+const trustedRank = computed(() => creatorTrustedRank(props.profile as any));
 
 const inferredHasTiers = computed(() => {
   if (props.profile.hasTiers !== undefined && props.profile.hasTiers !== null) {
@@ -570,7 +576,9 @@ function handlePrimaryAction() {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  transition: box-shadow 0.25s ease, transform 0.25s ease;
+  transition:
+    box-shadow 0.25s ease,
+    transform 0.25s ease;
   box-shadow: 0 12px 30px -18px rgba(15, 23, 42, 0.45);
   height: 100%;
 }
@@ -659,7 +667,9 @@ function handlePrimaryAction() {
   color: var(--text-2);
   border: 1px solid
     color-mix(in srgb, var(--surface-contrast-border) 55%, transparent);
-  transition: box-shadow 0.15s ease, transform 0.15s ease;
+  transition:
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
 }
 
 .status-chip.accent {
@@ -834,7 +844,10 @@ function handlePrimaryAction() {
   font-weight: 600;
   letter-spacing: 0.01em;
   border-radius: 0.75rem;
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease,
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease,
     transform 0.2s ease;
 }
 

--- a/src/lib/fundstrApi.ts
+++ b/src/lib/fundstrApi.ts
@@ -84,6 +84,14 @@ export interface CreatorTierSummary {
   cheapestPriceMsat: number | null;
 }
 
+export interface CreatorTrustedMetrics {
+  rank: number | null;
+  providerLabel: string | null;
+  providerPubkey: string | null;
+  relayUrl: string | null;
+  createdAt: number | null;
+}
+
 export interface Creator {
   pubkey: string;
   profile: Record<string, unknown> | null;
@@ -107,6 +115,7 @@ export interface Creator {
   hasTiers?: boolean | null;
   isCreator?: boolean | null;
   isPersonal?: boolean | null;
+  trustedMetrics?: CreatorTrustedMetrics | null;
 }
 
 export function withPrefix(path = ""): string {
@@ -249,8 +258,8 @@ export function formatMsatToSats(
     typeof options.maximumFractionDigits === "number"
       ? options.maximumFractionDigits
       : Math.abs(sats) < 1
-      ? 3
-      : 0;
+        ? 3
+        : 0;
 
   const formatter = new Intl.NumberFormat(undefined, {
     minimumFractionDigits: 0,
@@ -425,7 +434,37 @@ function normalizeCreator(entry: unknown): Creator {
     creator.featured = entry.featured;
   }
 
+  const trustedMetrics = normalizeTrustedMetrics(
+    entry.trustedMetrics ?? entry.trusted_metrics,
+  );
+  if (trustedMetrics) {
+    creator.trustedMetrics = trustedMetrics;
+  }
+
   return creator;
+}
+
+function normalizeTrustedMetrics(input: unknown): CreatorTrustedMetrics | null {
+  if (!isRecord(input)) {
+    return null;
+  }
+
+  const rank = toNullableNumber(input.rank);
+  if (rank === null || !Number.isInteger(rank) || rank < 0 || rank > 100) {
+    return null;
+  }
+
+  return {
+    rank,
+    providerLabel: toNullableString(
+      input.providerLabel ?? input.provider_label,
+    ),
+    providerPubkey: toNullableString(
+      input.providerPubkey ?? input.provider_pubkey,
+    ),
+    relayUrl: toNullableString(input.relayUrl ?? input.relay_url),
+    createdAt: toNullableNumber(input.createdAt ?? input.created_at),
+  };
 }
 
 function normalizeMetrics(input: Record<string, unknown>): CreatorMetrics {

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -173,6 +173,13 @@
                     >
                       {{ activeFilterLabel }}
                     </div>
+                    <div
+                      v-if="sortContextHint"
+                      class="text-caption text-2 toolbar-summary__hint"
+                    >
+                      <q-icon name="shield" size="14px" />
+                      <span>{{ sortContextHint }}</span>
+                    </div>
                   </div>
                   <div class="row items-center q-gutter-sm toolbar-controls">
                     <div class="row items-center q-gutter-xs filters-group">
@@ -725,7 +732,7 @@ type FilterKey =
   | "nip05Verified"
   | "fundstrCreator"
   | "signalOnly";
-type SortOption = "relevance" | "followers";
+type SortOption = "relevance" | "followers" | "trustedRank";
 type ViewMode = "grid" | "grouped";
 type ProfileTab = "profile" | "tiers";
 
@@ -810,6 +817,7 @@ const filterChips: { key: FilterKey; label: string }[] = [
 const sortOptions: { label: string; value: SortOption }[] = [
   { label: "Relevance", value: "relevance" },
   { label: "Followers", value: "followers" },
+  { label: "Trusted rank", value: "trustedRank" },
 ];
 
 const activeFilters = ref<Record<FilterKey, boolean>>({
@@ -832,11 +840,33 @@ const hasFollowerMetrics = computed(() =>
       Number.isFinite(profile.followers),
   ),
 );
-const availableSortOptions = computed(() =>
-  hasFollowerMetrics.value
-    ? sortOptions
-    : sortOptions.filter((option) => option.value === "relevance"),
+const hasTrustedRankMetrics = computed(() =>
+  creatorsStore.unfilteredSearchResults.some(
+    (profile) =>
+      typeof profile.trustedMetrics?.rank === "number" &&
+      Number.isFinite(profile.trustedMetrics.rank),
+  ),
 );
+const availableSortOptions = computed(() =>
+  sortOptions.filter((option) => {
+    if (option.value === "relevance") {
+      return true;
+    }
+    if (option.value === "followers") {
+      return hasFollowerMetrics.value;
+    }
+    if (option.value === "trustedRank") {
+      return hasTrustedRankMetrics.value;
+    }
+    return false;
+  }),
+);
+const sortContextHint = computed(() => {
+  if (sortOption.value !== "trustedRank" || !hasTrustedRankMetrics.value) {
+    return "";
+  }
+  return "Using provider-signed NIP-85 trust scores to surface creators.";
+});
 
 const viewModeOptions = [
   { label: "Grid", icon: "grid_view", value: "grid" },
@@ -1215,8 +1245,15 @@ watch(
   { deep: true },
 );
 
-watch(hasFollowerMetrics, (hasFollowers) => {
-  if (!hasFollowers && sortOption.value === "followers") {
+watch([hasFollowerMetrics, hasTrustedRankMetrics, searchResults], () => {
+  if (!creatorsStore.unfilteredSearchResults.length) {
+    return;
+  }
+
+  const supported = availableSortOptions.value.some(
+    (option) => option.value === sortOption.value,
+  );
+  if (!supported) {
     sortOption.value = "relevance";
   }
 });
@@ -1434,8 +1471,8 @@ function redirectToCreatorIfPresent() {
     typeof queryNpub === "string" && queryNpub.trim()
       ? queryNpub.trim()
       : typeof routeNpubOrHex === "string" && routeNpubOrHex.trim()
-      ? routeNpubOrHex.trim()
-      : "";
+        ? routeNpubOrHex.trim()
+        : "";
 
   if (target) {
     void router.replace({
@@ -1662,7 +1699,9 @@ onMounted(() => {
   color: var(--text-2);
   border: 1px solid
     color-mix(in srgb, var(--surface-contrast-border) 55%, transparent);
-  transition: box-shadow 0.15s ease, transform 0.15s ease;
+  transition:
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
 }
 
 .status-chip.accent {
@@ -1757,7 +1796,8 @@ h1 {
   width: 100%;
   border-radius: 16px;
   border: 1px solid var(--surface-contrast-border);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.04),
+  box-shadow:
+    0 12px 24px rgba(15, 23, 42, 0.04),
     0 24px 48px rgba(15, 23, 42, 0.08);
 }
 
@@ -1795,7 +1835,8 @@ h1 {
   border-radius: 26px;
   background: color-mix(in srgb, var(--accent-200) 24%, transparent);
   border: 1px solid var(--surface-contrast-border);
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.06),
+  box-shadow:
+    0 10px 30px rgba(15, 23, 42, 0.06),
     0 18px 46px rgba(15, 23, 42, 0.08);
 }
 
@@ -1896,6 +1937,13 @@ h1 {
   color: var(--accent-600);
   font-weight: 600;
   line-height: 1.2;
+}
+
+.toolbar-summary__hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  line-height: 1.35;
 }
 
 .toolbar-controls {

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -1,7 +1,13 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 import { db } from "./dexie";
-import { getEventHash, signEvent, publishEvent } from "./nostr";
+import {
+  getEventHash,
+  signEvent,
+  publishEvent,
+  useNostrStore,
+  type TrustedUserRank,
+} from "./nostr";
 import { nip19 } from "nostr-tools";
 import { Event as NostrEvent } from "nostr-tools";
 import type { Tier } from "./types";
@@ -60,6 +66,10 @@ type CreatorProfileMetrics = NonNullable<FundstrCreator["metrics"]> & {
   signal_only?: unknown;
 };
 
+type CreatorTrustedMetrics = NonNullable<
+  NonNullable<FundstrCreator["trustedMetrics"]>
+>;
+
 export type CreatorProfile = Omit<FundstrCreator, "tiers" | "metrics"> & {
   tiers?: Tier[];
   metrics?: CreatorProfileMetrics;
@@ -79,7 +89,7 @@ export type CreatorSearchFilters = {
   signalOnly?: boolean;
 };
 
-export type CreatorSearchSort = "relevance" | "followers";
+export type CreatorSearchSort = "relevance" | "followers" | "trustedRank";
 
 const FRESH_RETRY_BASE_MS = 1500;
 const FRESH_RETRY_MAX_MS = 30000;
@@ -391,9 +401,9 @@ function extractProfileDetailsFromDiscovery(
 
   const hasMetadata = Boolean(
     (displayName && displayName.length) ||
-      (name && name.length) ||
-      (about && about.length) ||
-      (picture && picture.length),
+    (name && name.length) ||
+    (about && about.length) ||
+    (picture && picture.length),
   );
 
   if (
@@ -872,8 +882,8 @@ async function fetchFundstrProfileBundleFromDiscovery(
   let finalTierCandidates = tierFreshMatch
     ? [...(tierFreshMatch.fresh ?? [])]
     : tierFallbackSource?.cached
-    ? [...tierFallbackSource.cached]
-    : [];
+      ? [...tierFallbackSource.cached]
+      : [];
   let tierFetchFailed =
     tierLookupFailed ||
     tierLookupBackoff ||
@@ -881,8 +891,8 @@ async function fetchFundstrProfileBundleFromDiscovery(
   let initialTierCandidates = tierFallbackSource?.cached?.length
     ? [...tierFallbackSource.cached]
     : tierFreshMatch?.fresh
-    ? [...tierFreshMatch.fresh]
-    : [];
+      ? [...tierFreshMatch.fresh]
+      : [];
 
   let usedCachedTierFallback = false;
   let usedNutzapTierFallback = false;
@@ -932,8 +942,8 @@ async function fetchFundstrProfileBundleFromDiscovery(
       typeof finalCreator?.pubkey === "string" && finalCreator.pubkey.trim()
         ? finalCreator.pubkey
         : typeof npubQuery === "string" && npubQuery
-        ? npubQuery
-        : tierResults[0]?.id ?? pubkey;
+          ? npubQuery
+          : (tierResults[0]?.id ?? pubkey);
     try {
       const nutzapEvent = await queryNutzapTiers(nutzapQueryInput);
       const recoveredTiers = nutzapEvent?.content
@@ -991,8 +1001,8 @@ async function fetchFundstrProfileBundleFromDiscovery(
   const baseBundle = finalCreatorForBundle
     ? buildBundleFromDiscoveryCreator(finalCreatorForBundle)
     : initialCreatorForBundle
-    ? buildBundleFromDiscoveryCreator(initialCreatorForBundle)
-    : null;
+      ? buildBundleFromDiscoveryCreator(initialCreatorForBundle)
+      : null;
 
   if (!baseBundle) {
     throw new FundstrProfileFetchError(
@@ -1660,7 +1670,7 @@ function mergeProfileRecordWithDetails(
   details: NutzapProfileDetails | null | undefined,
 ): Record<string, any> | null {
   const next: Record<string, any> = profile
-    ? cloneDiscoveryProfile(profile) ?? {}
+    ? (cloneDiscoveryProfile(profile) ?? {})
     : {};
 
   const applyString = (key: string, value: unknown) => {
@@ -1683,7 +1693,7 @@ function mergeProfileRecordWithMeta(
 ): Record<string, any> | null {
   const mergedMeta = mergeMissingProfileMeta(profile ?? {}, fallbackMeta);
   const next: Record<string, any> = profile
-    ? cloneDiscoveryProfile(profile) ?? {}
+    ? (cloneDiscoveryProfile(profile) ?? {})
     : {};
 
   const applyString = (key: string, value: unknown) => {
@@ -1785,16 +1795,16 @@ function normalizeTier(tier: any): Tier {
       typeof tier?.name === "string"
         ? tier.name
         : typeof tier?.title === "string"
-        ? tier.title
-        : "",
+          ? tier.title
+          : "",
     price_sats:
       typeof tier?.price_sats === "number" && Number.isFinite(tier.price_sats)
         ? tier.price_sats
         : typeof tier?.price === "number" && Number.isFinite(tier.price)
-        ? tier.price
-        : amountMsat !== null
-        ? Math.round(amountMsat / 1000)
-        : 0,
+          ? tier.price
+          : amountMsat !== null
+            ? Math.round(amountMsat / 1000)
+            : 0,
     description: typeof tier?.description === "string" ? tier.description : "",
     frequency: normalizeTierFrequency(tier?.frequency ?? tier?.cadence),
     ...(perks && !tier?.benefits ? { benefits: [perks] } : {}),
@@ -1816,21 +1826,25 @@ function cloneCreatorProfile(
     : null;
   const tierSummary = source.tierSummary
     ? { ...source.tierSummary }
-    : source.tierSummary ?? null;
+    : (source.tierSummary ?? null);
   const metrics = source.metrics
     ? { ...source.metrics }
-    : source.metrics ?? undefined;
+    : (source.metrics ?? undefined);
+  const trustedMetrics = isValidTrustedMetrics(source.trustedMetrics)
+    ? { ...source.trustedMetrics }
+    : (source.trustedMetrics ?? null);
   const tiers = Array.isArray(source.tiers)
     ? source.tiers.map((tier) => normalizeTier(tier))
     : source.tiers === undefined
-    ? undefined
-    : [];
+      ? undefined
+      : [];
 
   return {
     ...source,
     profile,
     tierSummary,
     metrics,
+    trustedMetrics,
     tiers,
   };
 }
@@ -1853,6 +1867,116 @@ function isTruthyFlag(value: unknown): boolean {
     return value === 1;
   }
   return false;
+}
+
+function isValidTrustedMetrics(value: unknown): value is CreatorTrustedMetrics {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const rank = (value as CreatorTrustedMetrics).rank;
+  return (
+    typeof rank === "number" &&
+    Number.isInteger(rank) &&
+    rank >= 0 &&
+    rank <= 100
+  );
+}
+
+function toCreatorTrustedMetrics(
+  value: TrustedUserRank | CreatorTrustedMetrics | null | undefined,
+): CreatorTrustedMetrics | null {
+  if (!value) {
+    return null;
+  }
+
+  if (isValidTrustedMetrics(value)) {
+    return { ...value };
+  }
+
+  const rank = value.rank;
+  if (!Number.isInteger(rank) || rank < 0 || rank > 100) {
+    return null;
+  }
+
+  return {
+    rank,
+    providerLabel:
+      typeof value.providerLabel === "string" ? value.providerLabel : null,
+    providerPubkey:
+      typeof value.providerPubkey === "string" ? value.providerPubkey : null,
+    relayUrl: typeof value.relayUrl === "string" ? value.relayUrl : null,
+    createdAt: typeof value.createdAt === "number" ? value.createdAt : null,
+  };
+}
+
+export function creatorTrustedRank(
+  profile: Pick<CreatorProfile, "trustedMetrics"> | null | undefined,
+): number | null {
+  const trustedMetrics = toCreatorTrustedMetrics(profile?.trustedMetrics);
+  return trustedMetrics?.rank ?? null;
+}
+
+function applyTrustedMetricsToCreator(
+  profile: CreatorProfile,
+  trustedRank: TrustedUserRank | null,
+): CreatorProfile {
+  const nextTrustedMetrics =
+    toCreatorTrustedMetrics(trustedRank) ??
+    toCreatorTrustedMetrics(profile.trustedMetrics);
+
+  if (
+    !nextTrustedMetrics &&
+    (profile.trustedMetrics === undefined || profile.trustedMetrics === null)
+  ) {
+    return profile;
+  }
+
+  const nextProfile = cloneCreatorProfile(profile);
+  nextProfile.trustedMetrics = nextTrustedMetrics;
+  return nextProfile;
+}
+
+async function enrichCreatorsWithTrustedMetrics(
+  profiles: CreatorProfile[],
+): Promise<CreatorProfile[]> {
+  const uniquePubkeys = Array.from(
+    new Set(
+      profiles
+        .map((profile) =>
+          typeof profile.pubkey === "string"
+            ? profile.pubkey.trim().toLowerCase()
+            : "",
+        )
+        .filter((pubkey): pubkey is string => /^[0-9a-f]{64}$/.test(pubkey)),
+    ),
+  );
+
+  if (!uniquePubkeys.length) {
+    return profiles;
+  }
+
+  try {
+    const nostrStore = useNostrStore();
+    const trustedRanks = await nostrStore.fetchTrustedUserRanks(uniquePubkeys);
+
+    return profiles.map((profile) => {
+      const pubkey =
+        typeof profile.pubkey === "string"
+          ? profile.pubkey.trim().toLowerCase()
+          : "";
+      return applyTrustedMetricsToCreator(
+        profile,
+        trustedRanks[pubkey] ?? null,
+      );
+    });
+  } catch (error) {
+    console.warn(
+      "[creators] Failed to enrich creators with trusted metrics",
+      error,
+    );
+    return profiles;
+  }
 }
 
 function computeTierSummary(tiers: Tier[] | null | undefined) {
@@ -2206,8 +2330,8 @@ export function creatorHasVerifiedNip05(profile: CreatorProfile): boolean {
 
   return Boolean(
     nip05Value &&
-      verifiedHandle &&
-      nip05Value.trim().toLowerCase() === verifiedHandle.trim().toLowerCase(),
+    verifiedHandle &&
+    nip05Value.trim().toLowerCase() === verifiedHandle.trim().toLowerCase(),
   );
 }
 
@@ -2248,11 +2372,45 @@ function normalizeSearchValue(value: unknown): string {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
 }
 
+export function sortCreatorsByTrustedRank(
+  profiles: CreatorProfile[],
+  query = "",
+): CreatorProfile[] {
+  const normalizedQuery = normalizeSearchValue(query);
+
+  return profiles.slice().sort((a, b) => {
+    const trustedRankDelta =
+      (creatorTrustedRank(b) ?? Number.NEGATIVE_INFINITY) -
+      (creatorTrustedRank(a) ?? Number.NEGATIVE_INFINITY);
+    if (trustedRankDelta !== 0) {
+      return trustedRankDelta;
+    }
+
+    if (normalizedQuery) {
+      const scoreDelta =
+        scoreCreatorRelevance(b, normalizedQuery) -
+        scoreCreatorRelevance(a, normalizedQuery);
+      if (scoreDelta !== 0) {
+        return scoreDelta;
+      }
+    }
+
+    const followerDelta =
+      (b.followers ?? Number.NEGATIVE_INFINITY) -
+      (a.followers ?? Number.NEGATIVE_INFINITY);
+    if (followerDelta !== 0) {
+      return followerDelta;
+    }
+
+    return fallbackName(a).localeCompare(fallbackName(b));
+  });
+}
+
 function profileNameCandidates(profile: CreatorProfile): string[] {
   const profileRecord = (profile?.profile ?? {}) as Record<string, unknown>;
   const metaRecord = (profile?.meta ?? {}) as Record<string, unknown>;
   const nip05 = normalizeSearchValue(profile.nip05);
-  const localHandle = nip05.includes("@") ? nip05.split("@")[0] ?? "" : nip05;
+  const localHandle = nip05.includes("@") ? (nip05.split("@")[0] ?? "") : nip05;
   return [
     normalizeSearchValue(profile.displayName),
     normalizeSearchValue(profile.name),
@@ -2422,6 +2580,10 @@ function applyCreatorFilters(
       );
   }
 
+  if (sort === "trustedRank") {
+    return sortCreatorsByTrustedRank(filtered, query);
+  }
+
   return sortCreatorsByRelevance(filtered, query);
 }
 
@@ -2520,6 +2682,7 @@ function createCreatorFromBundle(
     hasTiers: overrides.hasTiers ?? null,
     isCreator: overrides.isCreator ?? null,
     isPersonal: overrides.isPersonal ?? null,
+    trustedMetrics: toCreatorTrustedMetrics(overrides.trustedMetrics),
   };
 
   return creator;
@@ -2634,7 +2797,7 @@ export const useCreatorsStore = defineStore("creators", {
                   ? tier.media.map((media) => ({ ...media }))
                   : undefined,
               }))
-            : data.tiers ?? null,
+            : (data.tiers ?? null),
         });
       }
       return results;
@@ -2990,9 +3153,11 @@ export const useCreatorsStore = defineStore("creators", {
       this.error = "";
       this.searchStatusMessage = "";
       this.lastSearchQuery = appliedQuery;
-      this.unfilteredSearchResults = merged;
+      const enriched = await enrichCreatorsWithTrustedMetrics(merged);
+
+      this.unfilteredSearchResults = enriched;
       this.searchResults = applyCreatorFilters(
-        merged,
+        enriched,
         options.filters,
         options.sort,
         appliedQuery,
@@ -3232,9 +3397,16 @@ export const useCreatorsStore = defineStore("creators", {
           profiles,
           controller.signal,
         );
-        this.unfilteredSearchResults = mergedProfiles;
-        this.searchResults = applyCreatorFilters(mergedProfiles, filters, sort);
-        this.searchWarnings = applyTierWarnings(mergedProfiles, warnings);
+        const enrichedProfiles =
+          await enrichCreatorsWithTrustedMetrics(mergedProfiles);
+        this.unfilteredSearchResults = enrichedProfiles;
+        this.searchResults = applyCreatorFilters(
+          enrichedProfiles,
+          filters,
+          sort,
+          normalizedQuery,
+        );
+        this.searchWarnings = applyTierWarnings(enrichedProfiles, warnings);
         this.searchStatusMessage = "";
       };
 
@@ -3736,14 +3908,16 @@ export const useCreatorsStore = defineStore("creators", {
           .map((pubkey) => cachedEntries.get(pubkey))
           .filter((profile): profile is CreatorProfile => Boolean(profile));
         if (orderedCached.length) {
-          this.featuredCreators = orderedCached;
-          const cachedSecurityBlocked = orderedCached.some(
+          const enrichedCached =
+            await enrichCreatorsWithTrustedMetrics(orderedCached);
+          this.featuredCreators = enrichedCached;
+          const cachedSecurityBlocked = enrichedCached.some(
             (profile) => profile.tierSecurityBlocked === true,
           );
           if (cachedSecurityBlocked) {
             this.featuredStatusMessage = FIREFOX_TIER_SECURITY_WARNING;
           } else if (
-            orderedCached.some((profile) => profile.tierDataFresh === false)
+            enrichedCached.some((profile) => profile.tierDataFresh === false)
           ) {
             this.featuredStatusMessage = staleTierWarning;
           }
@@ -3843,21 +4017,24 @@ export const useCreatorsStore = defineStore("creators", {
           .map((pubkey) => fetchedMap.get(pubkey) ?? cachedEntries.get(pubkey))
           .filter((profile): profile is CreatorProfile => Boolean(profile));
 
-        this.featuredCreators = combined;
-        const combinedSecurityBlocked = combined.some(
+        const enrichedCombined =
+          await enrichCreatorsWithTrustedMetrics(combined);
+
+        this.featuredCreators = enrichedCombined;
+        const combinedSecurityBlocked = enrichedCombined.some(
           (profile) => profile.tierSecurityBlocked === true,
         );
         if (combinedSecurityBlocked) {
           this.featuredStatusMessage = FIREFOX_TIER_SECURITY_WARNING;
         } else if (
-          combined.some((profile) => profile.tierDataFresh === false)
+          enrichedCombined.some((profile) => profile.tierDataFresh === false)
         ) {
           this.featuredStatusMessage = staleTierWarning;
         } else if (!this.featuredError) {
           this.featuredStatusMessage = "";
         }
 
-        if (!combined.length) {
+        if (!enrichedCombined.length) {
           this.featuredError = "Failed to load featured creators.";
         } else {
           this.featuredError = "";
@@ -3947,9 +4124,11 @@ export const useCreatorsStore = defineStore("creators", {
           combinedMap.set(entry.pubkey, entry.profile);
         }
 
-        this.featuredCreators = pubkeys
-          .map((pubkey) => combinedMap.get(pubkey))
-          .filter((profile): profile is CreatorProfile => Boolean(profile));
+        this.featuredCreators = await enrichCreatorsWithTrustedMetrics(
+          pubkeys
+            .map((pubkey) => combinedMap.get(pubkey))
+            .filter((profile): profile is CreatorProfile => Boolean(profile)),
+        );
       }
 
       this.loadingFeatured = false;

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1136,12 +1136,149 @@ export type TrustedUserRank = {
   createdAt: number | null;
 };
 
+export type TrustedUserRankLookup = Record<string, TrustedUserRank>;
+
 const NIP85_USER_RANK_KIND = 30382;
 const NIP85_RANK_PROVIDER_LABEL = "nostr.band";
 const NIP85_RANK_PROVIDER_RELAY_URL = "wss://nip85.nostr.band";
 const NIP85_RANK_PROVIDER_PUBKEY =
   "4fd5e210530e4f6b2cb083795834bfe5108324f1ed9f00ab73b9e8fcfe5f12fe";
 const NIP85_RANK_TIMEOUT_MS = 3500;
+const NIP85_RANK_BATCH_SIZE = 25;
+
+function normalizeTrustedUserRankPubkey(pubkey: string): string | null {
+  if (typeof pubkey !== "string" || !pubkey.trim()) {
+    return null;
+  }
+
+  try {
+    return toHex(pubkey).trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function parseTrustedUserRankEvent(
+  event: any,
+  allowedSubjects?: Set<string>,
+): { subjectPubkey: string; rank: TrustedUserRank } | null {
+  if (event?.pubkey !== NIP85_RANK_PROVIDER_PUBKEY) {
+    return null;
+  }
+
+  const subjectTag = event.tags?.find(
+    (tag: string[]) => tag[0] === "d" && typeof tag[1] === "string",
+  );
+  const subjectPubkey = normalizeTrustedUserRankPubkey(subjectTag?.[1] ?? "");
+  if (!subjectPubkey) {
+    return null;
+  }
+
+  if (allowedSubjects && !allowedSubjects.has(subjectPubkey)) {
+    return null;
+  }
+
+  const rankTag = event.tags?.find(
+    (tag: string[]) => tag[0] === "rank" && typeof tag[1] === "string",
+  );
+  const parsedRank = Number.parseInt(rankTag?.[1] ?? "", 10);
+  if (!Number.isInteger(parsedRank) || parsedRank < 0 || parsedRank > 100) {
+    return null;
+  }
+
+  return {
+    subjectPubkey,
+    rank: {
+      rank: parsedRank,
+      providerLabel: NIP85_RANK_PROVIDER_LABEL,
+      providerPubkey: NIP85_RANK_PROVIDER_PUBKEY,
+      relayUrl: NIP85_RANK_PROVIDER_RELAY_URL,
+      createdAt: typeof event.created_at === "number" ? event.created_at : null,
+    },
+  };
+}
+
+export async function queryTrustedUserRanks(
+  pubkeys: string[],
+): Promise<TrustedUserRankLookup> {
+  const subjects = Array.from(
+    new Set(
+      (Array.isArray(pubkeys) ? pubkeys : [])
+        .map((pubkey) => normalizeTrustedUserRankPubkey(pubkey))
+        .filter((pubkey): pubkey is string => Boolean(pubkey)),
+    ),
+  );
+
+  if (!subjects.length) {
+    return {};
+  }
+
+  let relaysToQuery = [NIP85_RANK_PROVIDER_RELAY_URL];
+  try {
+    const healthy = await filterHealthyRelays([NIP85_RANK_PROVIDER_RELAY_URL]);
+    if (healthy.includes(NIP85_RANK_PROVIDER_RELAY_URL)) {
+      relaysToQuery = [NIP85_RANK_PROVIDER_RELAY_URL];
+    }
+  } catch {
+    relaysToQuery = [NIP85_RANK_PROVIDER_RELAY_URL];
+  }
+
+  const pool = new SimplePool();
+  const allowedSubjects = new Set(subjects);
+  const results: TrustedUserRankLookup = {};
+
+  try {
+    for (
+      let index = 0;
+      index < subjects.length;
+      index += NIP85_RANK_BATCH_SIZE
+    ) {
+      const chunk = subjects.slice(index, index + NIP85_RANK_BATCH_SIZE);
+      const events = await pool.querySync(
+        relaysToQuery,
+        {
+          kinds: [NIP85_USER_RANK_KIND],
+          authors: [NIP85_RANK_PROVIDER_PUBKEY],
+          "#d": chunk,
+          limit: Math.max(5, chunk.length * 2),
+        } as any,
+        { maxWait: NIP85_RANK_TIMEOUT_MS } as any,
+      );
+
+      const latestBySubject = new Map<string, TrustedUserRank>();
+
+      for (const event of Array.from(events)) {
+        const parsed = parseTrustedUserRankEvent(event, allowedSubjects);
+        if (!parsed) {
+          continue;
+        }
+
+        const existing = latestBySubject.get(parsed.subjectPubkey);
+        const existingCreatedAt =
+          existing?.createdAt ?? Number.NEGATIVE_INFINITY;
+        const parsedCreatedAt =
+          parsed.rank.createdAt ?? Number.NEGATIVE_INFINITY;
+        if (!existing || parsedCreatedAt > existingCreatedAt) {
+          latestBySubject.set(parsed.subjectPubkey, parsed.rank);
+        }
+      }
+
+      for (const [subjectPubkey, rank] of latestBySubject.entries()) {
+        results[subjectPubkey] = rank;
+      }
+    }
+
+    return results;
+  } catch {
+    return {};
+  } finally {
+    try {
+      pool.close(relaysToQuery);
+    } catch {
+      /* ignore close errors */
+    }
+  }
+}
 
 /**
  * Fetches the receiver’s ‘kind:10019’ Nutzap profile.
@@ -3174,73 +3311,14 @@ export const useNostrStore = defineStore("nostr", {
     ): Promise<TrustedUserRank | null> {
       const resolved = this.resolvePubkey(pubkey);
       if (!resolved) return null;
+      const ranks = await queryTrustedUserRanks([resolved]);
+      return ranks[resolved.toLowerCase()] ?? null;
+    },
 
-      let relaysToQuery = [NIP85_RANK_PROVIDER_RELAY_URL];
-      try {
-        const healthy = await filterHealthyRelays([
-          NIP85_RANK_PROVIDER_RELAY_URL,
-        ]);
-        if (healthy.includes(NIP85_RANK_PROVIDER_RELAY_URL)) {
-          relaysToQuery = [NIP85_RANK_PROVIDER_RELAY_URL];
-        }
-      } catch {
-        relaysToQuery = [NIP85_RANK_PROVIDER_RELAY_URL];
-      }
-
-      const pool = new SimplePool();
-      try {
-        const events = await pool.querySync(
-          relaysToQuery,
-          {
-            kinds: [NIP85_USER_RANK_KIND],
-            authors: [NIP85_RANK_PROVIDER_PUBKEY],
-            "#d": [resolved],
-            limit: 5,
-          } as any,
-          { maxWait: NIP85_RANK_TIMEOUT_MS } as any,
-        );
-
-        const latest = Array.from(events)
-          .filter(
-            (event: any) =>
-              event?.pubkey === NIP85_RANK_PROVIDER_PUBKEY &&
-              event.tags?.some(
-                (tag: string[]) => tag[0] === "d" && tag[1] === resolved,
-              ),
-          )
-          .sort(
-            (a: any, b: any) => (b.created_at || 0) - (a.created_at || 0),
-          )[0];
-
-        if (!latest) {
-          return null;
-        }
-
-        const rankTag = latest.tags?.find(
-          (tag: string[]) => tag[0] === "rank" && typeof tag[1] === "string",
-        );
-        const rank = Number.parseInt(rankTag?.[1] ?? "", 10);
-        if (!Number.isInteger(rank) || rank < 0 || rank > 100) {
-          return null;
-        }
-
-        return {
-          rank,
-          providerLabel: NIP85_RANK_PROVIDER_LABEL,
-          providerPubkey: NIP85_RANK_PROVIDER_PUBKEY,
-          relayUrl: NIP85_RANK_PROVIDER_RELAY_URL,
-          createdAt:
-            typeof latest.created_at === "number" ? latest.created_at : null,
-        };
-      } catch {
-        return null;
-      } finally {
-        try {
-          pool.close(relaysToQuery);
-        } catch {
-          /* ignore close errors */
-        }
-      }
+    fetchTrustedUserRanks: async function (
+      pubkeys: string[],
+    ): Promise<TrustedUserRankLookup> {
+      return queryTrustedUserRanks(pubkeys);
     },
 
     fetchRecentNotes: async function (

--- a/test/vitest/__tests__/creatorCard.discovery.spec.ts
+++ b/test/vitest/__tests__/creatorCard.discovery.spec.ts
@@ -1,13 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mount } from '@vue/test-utils';
-import { createPinia, setActivePinia } from 'pinia';
-import { nip19 } from 'nostr-tools';
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { nip19 } from "nostr-tools";
 
-import CreatorCard from 'src/components/CreatorCard.vue';
-import { useCreatorsStore, FEATURED_CREATORS } from 'src/stores/creators';
-import { DONATION_FALLBACK_CREATORS } from 'src/config/donation-eligibility';
+import CreatorCard from "src/components/CreatorCard.vue";
+import { useCreatorsStore, FEATURED_CREATORS } from "src/stores/creators";
+import { DONATION_FALLBACK_CREATORS } from "src/config/donation-eligibility";
 
-const FEATURED_HEX = 'f'.repeat(64);
+const FEATURED_HEX = "f".repeat(64);
 
 const discoveryClientMock = {
   getCreators: vi.fn(),
@@ -16,11 +16,11 @@ const discoveryClientMock = {
   clearCache: vi.fn(),
 };
 
-vi.mock('src/api/fundstrDiscovery', () => ({
+vi.mock("src/api/fundstrDiscovery", () => ({
   useDiscovery: () => discoveryClientMock,
 }));
 
-vi.mock('src/stores/dexie', () => {
+vi.mock("src/stores/dexie", () => {
   const profilesGet = vi.fn(async () => null);
   const profilesPut = vi.fn(async () => undefined);
   const nutzapGet = vi.fn(async () => undefined);
@@ -50,25 +50,26 @@ vi.mock('src/stores/dexie', () => {
   };
 });
 
-vi.mock('@/nostr/relayClient', () => ({
+vi.mock("@/nostr/relayClient", () => ({
   toHex: vi.fn(() => FEATURED_HEX),
 }));
 
 const originalFeaturedCreators = [...FEATURED_CREATORS];
 
-const featuredNpub = 'npub1featuredzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
+const featuredNpub =
+  "npub1featuredzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
 
 const stubs = {
-  'q-badge': { template: '<span class="q-badge"><slot /></span>' },
-  'q-btn': {
-    props: ['label'],
+  "q-badge": { template: '<span class="q-badge"><slot /></span>' },
+  "q-btn": {
+    props: ["label"],
     template: '<button class="q-btn" :data-label="label"><slot /></button>',
   },
-  'q-icon': { template: '<span class="q-icon"><slot /></span>' },
-  'q-tooltip': { template: '<span class="q-tooltip"><slot /></span>' },
+  "q-icon": { template: '<span class="q-icon"><slot /></span>' },
+  "q-tooltip": { template: '<span class="q-tooltip"><slot /></span>' },
 };
 
-describe('CreatorCard featured metadata', () => {
+describe("CreatorCard featured metadata", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
@@ -84,15 +85,15 @@ describe('CreatorCard featured metadata', () => {
         {
           pubkey: FEATURED_HEX,
           profile: {
-            display_name: 'Profile Fallback Name',
-            picture: 'https://example.com/profile-picture.png',
+            display_name: "Profile Fallback Name",
+            picture: "https://example.com/profile-picture.png",
           },
-          displayName: 'Discovery Display Name',
-          name: 'DiscoveryName',
-          about: 'Discovery description',
-          picture: 'https://example.com/discovery-avatar.png',
-          banner: 'https://example.com/discovery-banner.png',
-          nip05: 'creator@example.com',
+          displayName: "Discovery Display Name",
+          name: "DiscoveryName",
+          about: "Discovery description",
+          picture: "https://example.com/discovery-avatar.png",
+          banner: "https://example.com/discovery-banner.png",
+          nip05: "creator@example.com",
           tiers: [],
           cacheHit: false,
           featured: true,
@@ -102,35 +103,41 @@ describe('CreatorCard featured metadata', () => {
   });
 
   afterEach(() => {
-    FEATURED_CREATORS.splice(0, FEATURED_CREATORS.length, ...originalFeaturedCreators);
+    FEATURED_CREATORS.splice(
+      0,
+      FEATURED_CREATORS.length,
+      ...originalFeaturedCreators,
+    );
   });
 
-  it('renders discovery overrides for featured creators', async () => {
+  it("renders discovery overrides for featured creators", async () => {
     const creators = useCreatorsStore();
     await creators.loadFeaturedCreators(true);
 
     expect(creators.featuredCreators).toHaveLength(1);
     const featured = creators.featuredCreators[0];
-    expect(featured.displayName).toBe('Discovery Display Name');
-    expect(featured.picture).toBe('https://example.com/discovery-avatar.png');
+    expect(featured.displayName).toBe("Discovery Display Name");
+    expect(featured.picture).toBe("https://example.com/discovery-avatar.png");
 
     const wrapper = mount(CreatorCard, {
       props: { profile: featured },
       global: { stubs },
     });
 
-    const nameHeading = wrapper.get('.name-row h3');
-    expect(nameHeading.text()).toBe('Discovery Display Name');
+    const nameHeading = wrapper.get(".name-row h3");
+    expect(nameHeading.text()).toBe("Discovery Display Name");
 
-    const avatar = wrapper.get('img.avatar');
-    expect(avatar.attributes('src')).toBe('https://example.com/discovery-avatar.png');
-    expect(avatar.attributes('alt')).toBe('Discovery Display Name');
+    const avatar = wrapper.get("img.avatar");
+    expect(avatar.attributes("src")).toBe(
+      "https://example.com/discovery-avatar.png",
+    );
+    expect(avatar.attributes("alt")).toBe("Discovery Display Name");
   });
 });
 
-describe('CreatorCard donation eligibility signals', () => {
+describe("CreatorCard donation eligibility signals", () => {
   const baseProfile = {
-    pubkey: 'a'.repeat(64),
+    pubkey: "a".repeat(64),
     profile: {},
     followers: null,
     following: null,
@@ -146,31 +153,33 @@ describe('CreatorCard donation eligibility signals', () => {
   const hasDonateButton = (wrapper: ReturnType<typeof mountCard>) =>
     wrapper.findAll('[data-label="Donate"]').length > 0;
 
-  it('shows donate button when lightning address is present', () => {
-    const wrapper = mountCard({ profile: { lud16: 'tip@example.com' } });
+  it("shows donate button when lightning address is present", () => {
+    const wrapper = mountCard({ profile: { lud16: "tip@example.com" } });
     expect(hasDonateButton(wrapper)).toBe(true);
   });
 
-  it('shows donate button when has_nutzap flag is true', () => {
+  it("shows donate button when has_nutzap flag is true", () => {
     const wrapper = mountCard({ profile: { has_nutzap: true } });
     expect(hasDonateButton(wrapper)).toBe(true);
   });
 
-  it('shows donate button when tier summary reports tiers', () => {
-    const wrapper = mountCard({ tierSummary: { count: 2, cheapestPriceMsat: 1000 } });
+  it("shows donate button when tier summary reports tiers", () => {
+    const wrapper = mountCard({
+      tierSummary: { count: 2, cheapestPriceMsat: 1000 },
+    });
     expect(hasDonateButton(wrapper)).toBe(true);
   });
 
-  it('shows donate button for configured fallback creators', () => {
+  it("shows donate button for configured fallback creators", () => {
     const fallbackNpub = DONATION_FALLBACK_CREATORS[0];
     const fallbackHex = (() => {
       try {
         const decoded = nip19.decode(fallbackNpub);
-        if (decoded.type === 'npub' && typeof decoded.data === 'string') {
+        if (decoded.type === "npub" && typeof decoded.data === "string") {
           return decoded.data;
         }
       } catch (error) {
-        console.warn('Failed to decode fallback npub for test', error);
+        console.warn("Failed to decode fallback npub for test", error);
       }
       return baseProfile.pubkey;
     })();
@@ -179,12 +188,12 @@ describe('CreatorCard donation eligibility signals', () => {
     expect(hasDonateButton(wrapper)).toBe(true);
   });
 
-  it('hides donate button when no donation signals exist', () => {
+  it("hides donate button when no donation signals exist", () => {
     const wrapper = mountCard();
     expect(hasDonateButton(wrapper)).toBe(false);
   });
 
-  it('renders cached lightning and tier badges even when tier data is stale', () => {
+  it("renders cached lightning and tier badges even when tier data is stale", () => {
     const wrapper = mountCard({
       tierDataFresh: false,
       cacheHit: true,
@@ -193,8 +202,8 @@ describe('CreatorCard donation eligibility signals', () => {
     });
 
     const chipTexts = wrapper
-      .findAll('.status-chip')
-      .map((chip) => chip.text().replace(/\s+/g, ' ').trim());
+      .findAll(".status-chip")
+      .map((chip) => chip.text().replace(/\s+/g, " ").trim());
 
     expect(chipTexts).toMatchInlineSnapshot(`
       [
@@ -203,5 +212,24 @@ describe('CreatorCard donation eligibility signals', () => {
         "Cache hit",
       ]
     `);
+  });
+
+  it("renders a trusted rank chip when trusted metrics are present", () => {
+    const wrapper = mountCard({
+      trustedMetrics: {
+        rank: 55,
+        providerLabel: "nostr.band",
+        providerPubkey:
+          "4fd5e210530e4f6b2cb083795834bfe5108324f1ed9f00ab73b9e8fcfe5f12fe",
+        relayUrl: "wss://nip85.nostr.band",
+        createdAt: 1712400000,
+      },
+    });
+
+    const chipTexts = wrapper
+      .findAll(".meta-chip")
+      .map((chip) => chip.text().replace(/\s+/g, " ").trim());
+
+    expect(chipTexts).toContain("Trusted rank 55");
   });
 });

--- a/test/vitest/__tests__/creators.spec.ts
+++ b/test/vitest/__tests__/creators.spec.ts
@@ -4,6 +4,7 @@ import {
   useCreatorsStore,
   FEATURED_CREATORS,
   sortCreatorsByRelevance,
+  sortCreatorsByTrustedRank,
 } from "../../../src/stores/creators";
 import { toHex } from "@/nostr/relayClient";
 
@@ -90,6 +91,7 @@ const nostrStoreMock = {
   fetchFollowerCount: vi.fn().mockResolvedValue(10),
   fetchFollowingCount: vi.fn().mockResolvedValue(5),
   fetchJoinDate: vi.fn().mockResolvedValue(123456),
+  fetchTrustedUserRanks: vi.fn().mockResolvedValue({}),
   connected: true,
   lastError: null,
 };
@@ -115,6 +117,8 @@ beforeEach(() => {
   getCreatorsMock.mockResolvedValue({ results: [], warnings: [] });
   getCreatorsByPubkeysMock.mockResolvedValue({ results: [], warnings: [] });
   getUserFromNip05Mock.mockResolvedValue(null);
+  nostrStoreMock.fetchTrustedUserRanks.mockReset();
+  nostrStoreMock.fetchTrustedUserRanks.mockResolvedValue({});
   (nip19.decode as any).mockImplementation((value: string) => ({
     data: value.startsWith("npub") ? "f".repeat(64) : value,
   }));
@@ -266,6 +270,62 @@ describe("Creators store", () => {
     );
 
     expect(sorted[0].pubkey).toBe(exact.pubkey);
+  });
+
+  it("sorts creators by trusted rank before fallback relevance and follower signals", () => {
+    const highest = makeCreator("a".repeat(64), {
+      displayName: "Highest",
+      trustedMetrics: { rank: 91 },
+      followers: 10,
+    });
+    const middle = makeCreator("b".repeat(64), {
+      displayName: "Middle",
+      trustedMetrics: { rank: 75 },
+      followers: 50,
+    });
+    const missing = makeCreator("c".repeat(64), {
+      displayName: "Missing",
+      followers: 500,
+    });
+
+    const sorted = sortCreatorsByTrustedRank([missing, middle, highest], "");
+
+    expect(sorted.map((profile) => profile.pubkey)).toEqual([
+      highest.pubkey,
+      middle.pubkey,
+      missing.pubkey,
+    ]);
+  });
+
+  it("enriches discovery results with trusted metrics during search", async () => {
+    const pubkey = "d".repeat(64);
+    const discoveryCreator = makeCreator(pubkey, {
+      displayName: "Trusted Creator",
+    });
+    getCreatorsMock.mockResolvedValueOnce({
+      results: [discoveryCreator],
+      warnings: [],
+    });
+    nostrStoreMock.fetchTrustedUserRanks.mockResolvedValueOnce({
+      [pubkey]: {
+        rank: 88,
+        providerLabel: "nostr.band",
+        providerPubkey:
+          "4fd5e210530e4f6b2cb083795834bfe5108324f1ed9f00ab73b9e8fcfe5f12fe",
+        relayUrl: "wss://nip85.nostr.band",
+        createdAt: 1712400000,
+      },
+    });
+
+    const creators = useCreatorsStore();
+    await creators.searchCreators("trusted creator", { sort: "trustedRank" });
+
+    expect(nostrStoreMock.fetchTrustedUserRanks).toHaveBeenCalledWith([pubkey]);
+    expect(creators.searchResults).toHaveLength(1);
+    expect(creators.searchResults[0].trustedMetrics).toMatchObject({
+      rank: 88,
+      providerLabel: "nostr.band",
+    });
   });
 
   it("loads featured creators", async () => {


### PR DESCRIPTION
Surface provider-signed trust context in creator discovery so supporters can sort and evaluate creators before opening a profile or spending sats.