### PR TITLE
docs(wotathon): add NIP-85 submission package

### DIFF
--- a/docs/fundstr-nip85-use-cases-2026-04.md
+++ b/docs/fundstr-nip85-use-cases-2026-04.md
@@ -1,0 +1,163 @@
+# Fundstr NIP-85 Use Cases 2026-04
+
+## Overview
+
+Fundstr currently consumes NIP-85 trusted assertions from a pinned `nostr.band` provider and uses them in real creator discovery and profile flows.
+
+The goal is not to change payment truth or subscription entitlement. The goal is to make trust useful before supporters take action.
+
+## Provider configuration
+
+- Provider label: `nostr.band`
+- Relay: `wss://nip85.nostr.band`
+- Current metric surfaced: `rank`
+- Supported assertion kind: `30382`
+
+## User-facing NIP-85 use-cases
+
+### 1. Public creator profile trust chip
+
+What it does:
+
+- shows `Trusted rank <n>` on public creator profiles when a valid provider assertion exists
+
+Why it matters:
+
+- gives supporters a visible trust signal before they message, donate, or subscribe
+
+Current implementation files:
+
+- `src/stores/nostr.ts`
+- `src/pages/PublicCreatorProfilePage.vue`
+
+### 2. Public creator profile trust explainer
+
+What it does:
+
+- adds a compact info popover next to trusted rank
+- explains that the score is provider-signed
+- links to the NIP-85 spec and provider resource
+
+Why it matters:
+
+- makes the trust signal inspectable and explainable
+
+Current implementation files:
+
+- `src/pages/PublicCreatorProfilePage.vue`
+
+### 3. Discovery sort by trusted rank
+
+What it does:
+
+- adds a `Trusted rank` sort mode to `Find Creators`
+- ranks creators by provider-signed trust score when available
+
+Why it matters:
+
+- makes NIP-85 useful before a profile click
+- turns trust into a discovery primitive
+
+Current implementation files:
+
+- `src/stores/nostr.ts`
+- `src/stores/creators.ts`
+- `src/pages/FindCreators.vue`
+
+### 4. Trusted-rank chips on creator cards
+
+What it does:
+
+- shows `Trusted rank <n>` directly on discovery cards
+
+Why it matters:
+
+- keeps the trust signal visible inside creator search/discovery grids
+
+Current implementation files:
+
+- `src/components/CreatorCard.vue`
+- `src/stores/creators.ts`
+
+## Data flow
+
+1. Resolve creator pubkeys
+2. Read NIP-85 rank assertions from the pinned provider relay
+3. Normalize and validate rank values
+4. Attach trusted metrics in parallel to creator rows
+5. Use the metrics in:
+   - profile chips
+   - profile popover context
+   - discovery sorting
+   - creator-card chips
+
+## Guardrails
+
+Fundstr does not currently use NIP-85 for:
+
+- payment verification
+- subscription entitlement
+- unlock rules
+- wallet balances
+- creator ownership/authentication
+
+This is intentional. NIP-85 is being used as a discovery and trust-context layer only.
+
+## Acceptance criteria achieved
+
+### Product behavior
+
+- trusted-rank visible on public creator profiles
+- explainer popover opens and links work
+- `Trusted rank` sort appears in discovery when trusted metrics exist
+- trusted-rank chips render on creator cards
+- missing trusted-rank data does not break UI
+
+### Technical behavior
+
+- native profile/follower fields are not overwritten
+- trusted metrics remain parallel data
+- provider relay is pinned
+- invalid or missing rank values are ignored silently
+
+## Test coverage
+
+Relevant test files:
+
+- `test/vitest/__tests__/PublicCreatorProfilePage.phonebook.spec.ts`
+- `test/vitest/__tests__/creators.spec.ts`
+- `test/vitest/__tests__/creatorCard.discovery.spec.ts`
+
+Validation completed:
+
+- focused NIP-85 specs passed
+- full `pnpm test` passed
+- full `pnpm build` passed
+
+## Proof artifacts
+
+Local verification screenshots:
+
+- `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-nip85-verification-2026-04-07/find-creators-trusted-rank.png`
+- `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-nip85-verification-2026-04-07/find-creators-trusted-rank-card-focus.png`
+- `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-nip85-verification-2026-04-07/public-profile-trusted-rank.png`
+
+Live verification screenshots:
+
+- `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-live-evidence-2026-04-07-postmerge/live-find-creators-trusted-rank-query.png`
+- `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-live-evidence-2026-04-07-postmerge/live-public-profile-trusted-rank.png`
+
+## Best demo framing
+
+Use this message consistently:
+
+> Fundstr helps supporters discover creators they can trust by applying portable NIP-85 trust metrics directly to discovery and patronage decisions.
+
+## Remaining strongest improvements
+
+If more time exists before submission:
+
+1. Add a public-facing demo video
+2. Add a public-facing technical explainer
+3. Improve openness by publishing at least a small public NIP-85 example/helper
+4. Optionally add provider selection or personalized provider support later

--- a/docs/wotathon-submission-2026-04.md
+++ b/docs/wotathon-submission-2026-04.md
@@ -1,0 +1,144 @@
+# Wotathon Submission 2026-04
+
+## Goal
+
+Position Fundstr as a credible `NIP-85 Excellence` entry for Wotathon by framing it as a trust-aware creator discovery and patronage client on Nostr.
+
+## Submission angle
+
+Fundstr uses portable, provider-signed NIP-85 trust metrics to help supporters discover creators, evaluate trust context, and make better patronage decisions before they message, donate, or subscribe.
+
+This is the strongest story because Fundstr is already a real creator-support product. Instead of treating trust as an abstract score, Fundstr applies trust where economic decisions happen.
+
+## Best prize target
+
+- `NIP-85 Excellence (Trusted Assertions)`
+
+This is the most realistic target because the current work is consumer-side NIP-85 integration, not a new trust-scoring engine or provider.
+
+## Current Fundstr NIP-85 use-cases
+
+Live on production:
+
+1. Trusted-rank chip on public creator profiles
+2. Trust explainer popover with links to NIP-85 and provider resources
+3. Trusted-rank sort on `Find Creators`
+4. Trusted-rank chips on creator discovery cards
+
+## Why Fundstr fits Wotathon
+
+Wotathon is explicitly about building open source libraries, relays, and applications that advance Web of Trust and integrate portable trust metrics into Nostr clients.
+
+Fundstr fits as an application/client because it demonstrates that NIP-85 is useful in real creator discovery and patronage flows.
+
+Strong points:
+
+- live production deployment
+- real user-facing client use-cases
+- clear business model sustainability
+- real creator economy context
+- portable external trust consumption rather than private scoring
+
+Weak point:
+
+- Fundstr is not open source yet
+
+This is likely not an automatic disqualifier, but it does weaken the `Documentation & Openness` scoring category.
+
+## Open-source / openness note
+
+Fundstr is not fully open source today.
+
+Submission guidance:
+
+- do not claim full open-source status if it is not true
+- publish strong public documentation
+- publish screenshots and a demo video
+- publish a public technical explanation of the NIP-85 integration
+- if possible, publish a small standalone public example or helper module for the NIP-85 reader logic
+
+Recommended wording:
+
+> Fundstr is not yet fully open source. For this submission, we are publishing public documentation, demo assets, and technical details for our NIP-85 integration, and we plan to open more of this work over time.
+
+## Suggested submission title
+
+`Fundstr: Portable Trust for Creator Discovery and Patronage on Nostr`
+
+## Suggested one-paragraph submission summary
+
+Fundstr is a Nostr-native creator support client that applies NIP-85 Trusted Assertions to creator discovery and patronage decisions. Instead of keeping trust as an abstract score, Fundstr uses portable, provider-signed NIP-85 metrics to improve creator discovery, profile context, and supporter decision-making before messaging, donating, or subscribing. This demonstrates a practical, user-facing NIP-85 application with clear product value and a sustainable business model.
+
+## Judging criteria mapping
+
+### Functional Readiness
+
+- shipped to production
+- profile and discovery UX are live
+
+### Depth & Innovation
+
+- multiple consumer-side NIP-85 use-cases
+- trust applied directly to creator support decisions
+
+### Interoperability
+
+- consumes external provider-signed assertions
+- does not replace trust with a private opaque score
+
+### Decentralizing Ecosystem Impact
+
+- adds one more real trust-aware Nostr client
+- makes NIP-85 useful in a creator economy context
+
+### Documentation & Openness
+
+- must be strengthened with public-facing writeups and demo materials
+
+### Business Model Sustainability
+
+- strong fit because Fundstr is already a real creator-support product
+
+## Submission checklist
+
+Before submission, make sure all of these exist:
+
+1. Live product URL
+2. Demo video
+3. Screenshots
+4. Public technical writeup
+5. Feature list of NIP-85 use-cases
+6. Honest openness note
+7. Contact / submission text ready for Formstr
+
+## Demo flow
+
+1. Open `Find Creators`
+2. Switch sort mode to `Trusted rank`
+3. Show trusted-rank chips on creator cards
+4. Open a creator profile
+5. Show trusted-rank chip and info popover
+6. Show the user can inspect both the NIP-85 spec and provider resource
+7. End on the donate / message / subscribe context
+
+## Evidence
+
+Current local evidence paths on this machine:
+
+- Discovery screenshots:
+  - `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-nip85-verification-2026-04-07/find-creators-trusted-rank.png`
+  - `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-nip85-verification-2026-04-07/find-creators-trusted-rank-hero.png`
+  - `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-nip85-verification-2026-04-07/find-creators-trusted-rank-card-focus.png`
+- Profile screenshot:
+  - `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-nip85-verification-2026-04-07/public-profile-trusted-rank.png`
+- Live production discovery screenshots:
+  - `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-live-evidence-2026-04-07-postmerge/live-find-creators-trusted-rank-query.png`
+  - `/home/ai_dev/Desktop/AI-Apps/Websites/Fundstr-main-wotathon-nip85-20260407/artifacts/wotathon-live-evidence-2026-04-07-postmerge/live-public-profile-trusted-rank.png`
+
+## Immediate next steps
+
+1. Merge this documentation PR
+2. Produce a short public demo video
+3. Prepare the submission text in Formstr
+4. Publish or share public-facing screenshots and writeup
+5. Decide whether any part of the NIP-85 integration can be opened publicly before submission


### PR DESCRIPTION
Capture Fundstr's Wotathon positioning, NIP-85 use-cases, evidence paths, and immediate submission steps so the project can move quickly under deadline pressure.