### PR TITLE
feat(discovery): surface trust context and inline creator previews

### DIFF
--- a/src/components/CreatorCard.vue
+++ b/src/components/CreatorCard.vue
@@ -162,8 +162,8 @@
         <div class="action-helper text-2">
           {{
             hasTiers
-              ? "Open the creator page and browse tiers."
-              : "Open the full creator page."
+              ? "Preview the creator and browse tiers."
+              : "Open a quick creator preview."
           }}
         </div>
         <div v-if="!canViewProfile" class="action-helper text-2">
@@ -201,7 +201,7 @@
           class="action-btn action-btn--secondary"
           label="Donate"
           no-caps
-          v-if="hasLightning"
+          v-if="canDonate"
           @click.stop="$emit('donate', profile.pubkey)"
         />
       </div>
@@ -316,6 +316,8 @@ const canViewProfile = computed(() => {
   if (typeof props.profile?.pubkey !== "string") return false;
   return props.profile.pubkey.trim().length > 0;
 });
+
+const canDonate = computed(() => canViewProfile.value);
 
 function onAvatarError(event: Event) {
   (event.target as HTMLImageElement).src = safeImageSrc(

--- a/src/components/CreatorProfileModal.vue
+++ b/src/components/CreatorProfileModal.vue
@@ -186,6 +186,45 @@
                         <div class="highlight-label text-2">Followers</div>
                         <div class="highlight-value">{{ followersDisplay }}</div>
                       </div>
+                      <div
+                        v-if="trustedRankValue !== null"
+                        class="highlight-item highlight-item--full highlight-item--trusted"
+                      >
+                        <div class="highlight-label text-2">Trusted rank (NIP-85)</div>
+                        <div class="highlight-value highlight-value--trusted">
+                          <q-icon name="shield" size="18px" />
+                          <span>{{ trustedRankValue }}</span>
+                        </div>
+                        <div class="highlight-copy text-body2 text-2">
+                          Provider-signed trust context for discovery. Fundstr
+                          does not calculate this score, and it never controls
+                          payments, subscriptions, or access.
+                        </div>
+                        <div
+                          v-if="trustedRankProviderText"
+                          class="highlight-meta text-caption text-2"
+                        >
+                          {{ trustedRankProviderText }}
+                        </div>
+                        <div
+                          v-if="trustedRankFreshness"
+                          class="highlight-meta text-caption text-2"
+                        >
+                          {{ trustedRankFreshness }}
+                        </div>
+                        <div class="trusted-rank-info-links">
+                          <a
+                            v-for="link in trustedRankInfoLinks"
+                            :key="link.id"
+                            class="trusted-rank-info-link"
+                            :href="link.href"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {{ link.label }}
+                          </a>
+                        </div>
+                      </div>
                       <div v-if="lightningAddress" class="highlight-item highlight-item--full">
                         <div class="highlight-label text-2">Lightning address</div>
                         <div class="highlight-value highlight-value--mono">
@@ -414,17 +453,24 @@ import { filterValidMedia } from 'src/utils/validateMedia';
 import type { Tier, TierMedia as TierMediaItem } from 'stores/types';
 import {
   FundstrProfileFetchError,
+  creatorTrustedMetrics,
   creatorIsSignalOnly,
   mergeCreatorProfileWithFallback,
   useCreatorsStore,
 } from 'stores/creators';
 import type { CreatorProfile } from 'stores/creators';
+import {
+  TRUSTED_RANK_INFO_LINKS,
+  formatTrustedRankFreshness,
+  trustedRankProviderLine,
+} from 'src/utils/trustedRank';
 
 const props = defineProps<{
   show: boolean;
   pubkey: string;
   initialProfile?: CreatorProfile | null;
   initialTab?: 'profile' | 'tiers';
+  compact?: boolean;
 }>();
 
 const emit = defineEmits(['close', 'message', 'donate']);
@@ -450,11 +496,12 @@ const tiers = ref<TierDetails[]>([]);
 const showLocal = ref(false);
 const isMobileViewport = computed(() => $q.screen.lt.sm);
 const isDesktopViewport = computed(() => $q.screen.gt.sm);
-const isTwoColumnViewport = computed(() => $q.screen.width >= 1280);
-const isDialogMaximized = computed(() => isMobileViewport.value || isDesktopViewport.value);
+const isTwoColumnViewport = computed(() => !props.compact && $q.screen.width >= 1280);
+const isDialogMaximized = computed(() => isMobileViewport.value || (!props.compact && isDesktopViewport.value));
 const relayFallbackStatus = ref(getFreeRelayFallbackStatus());
 let relayFallbackUnsubscribe: (() => void) | null = null;
 const dialogClasses = computed(() => ({
+  'profile-dialog--compact': props.compact === true,
   'profile-dialog--maximized': isDialogMaximized.value,
   'profile-dialog--mobile': isMobileViewport.value,
   'profile-dialog--desktop': isDesktopViewport.value,
@@ -797,6 +844,17 @@ const identityLinks = computed(() => {
 
 const copiedState = ref({ npub: false, pubkey: false, lightning: false });
 const copyTimeouts: Partial<Record<'npub' | 'pubkey' | 'lightning', number>> = {};
+const trustedMetrics = computed(() => creatorTrustedMetrics(creator.value as any));
+const trustedRankValue = computed(() => trustedMetrics.value?.rank ?? null);
+const trustedRankProviderText = computed(() =>
+  trustedRankProviderLine(trustedMetrics.value?.providerLabel),
+);
+const trustedRankFreshness = computed(() =>
+  formatTrustedRankFreshness(trustedMetrics.value?.createdAt),
+);
+const trustedRankInfoLinks = TRUSTED_RANK_INFO_LINKS.map((link) => ({
+  ...link,
+}));
 
 async function copyIdentity(value: string, key: 'npub' | 'pubkey' | 'lightning') {
   if (!value) {
@@ -907,7 +965,8 @@ const highlightStatusChips = computed(() => {
 
 const hasHighlights = computed(() =>
   Boolean(
-    followersDisplay.value ||
+      followersDisplay.value ||
+      trustedRankValue.value !== null ||
       lightningAddress.value ||
       websiteUrl.value ||
       highlightStatusChips.value.length,
@@ -1248,6 +1307,12 @@ function resetState() {
   height: 100%;
   max-height: min(98vh, 1600px);
   min-height: 0;
+}
+
+.profile-dialog--compact .profile-card {
+  width: min(100%, 1040px);
+  height: min(88vh, 920px);
+  max-height: min(88vh, 920px);
 }
 
 .profile-card--two-column {
@@ -1776,6 +1841,36 @@ function resetState() {
 .highlight-value--mono {
   font-family: var(--font-mono, 'Fira Code', monospace);
   font-size: 1rem;
+}
+
+.highlight-item--trusted {
+  background: color-mix(in srgb, var(--accent-200) 14%, var(--surface-1) 86%);
+  border-color: color-mix(in srgb, var(--accent-500) 24%, var(--surface-contrast-border));
+}
+
+.highlight-value--trusted {
+  color: var(--accent-500);
+}
+
+.highlight-meta {
+  line-height: 1.5;
+}
+
+.trusted-rank-info-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.trusted-rank-info-link {
+  color: var(--accent-500);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.trusted-rank-info-link:hover,
+.trusted-rank-info-link:focus-visible {
+  text-decoration: underline;
 }
 
 .highlight-copy {

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -55,6 +55,77 @@
               </q-input>
             </q-form>
 
+            <section class="trusted-rank-spotlight bg-surface-1 text-1">
+              <div class="trusted-rank-spotlight__eyebrow">
+                NIP-85 trust context
+              </div>
+              <div class="trusted-rank-spotlight__header">
+                <div class="stack-12 trusted-rank-spotlight__copy">
+                  <div class="text-subtitle1 text-weight-medium">
+                    Trusted rank is visible directly in creator discovery.
+                  </div>
+                  <p class="text-body2 text-2 q-mb-none">
+                    Fundstr surfaces provider-signed NIP-85 trust signals on
+                    creator cards, in preview modals, and in search sorting.
+                    Fundstr does not calculate this score, and it never
+                    controls payments, subscriptions, or access.
+                  </p>
+                </div>
+                <div
+                  v-if="trustedSpotlightCount"
+                  class="trusted-rank-spotlight__badge"
+                >
+                  <q-icon name="shield" size="16px" />
+                  <span>
+                    {{ trustedSpotlightCount }} visible trusted signal{{
+                      trustedSpotlightCount === 1 ? "" : "s"
+                    }}
+                  </span>
+                </div>
+              </div>
+
+              <div class="trusted-rank-spotlight__meta text-caption text-2">
+                <span>{{ trustedSpotlightSummary }}</span>
+                <span v-if="trustedSpotlightProviderText">
+                  {{ trustedSpotlightProviderText }}
+                </span>
+                <span v-if="trustedSpotlightFreshnessText">
+                  {{ trustedSpotlightFreshnessText }}
+                </span>
+              </div>
+
+              <div class="trusted-rank-spotlight__actions">
+                <q-btn
+                  outline
+                  no-caps
+                  color="accent"
+                  icon="swap_vert"
+                  label="Sort by trusted rank"
+                  :disable="!hasTrustedRankMetrics"
+                  @click="applyTrustedRankSort"
+                />
+                <q-btn
+                  flat
+                  no-caps
+                  color="accent"
+                  icon="shield"
+                  label="Show trusted only"
+                  :disable="!trustedSignalCount"
+                  @click="enableTrustedSignalFilter"
+                />
+                <a
+                  v-for="link in trustedRankInfoLinks"
+                  :key="link.id"
+                  class="trusted-rank-spotlight__link"
+                  :href="link.href"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {{ link.label }}
+                </a>
+              </div>
+            </section>
+
             <section
               class="column q-gutter-lg"
               role="region"
@@ -634,6 +705,18 @@
 
                       <div class="legend-item" role="listitem">
                         <div class="legend-chip">
+                          <span class="status-chip accent">
+                            <q-icon name="shield" size="14px" />
+                            <span>Trusted rank</span>
+                          </span>
+                        </div>
+                        <div class="legend-text text-2">
+                          Provider-signed NIP-85 trust signal
+                        </div>
+                      </div>
+
+                      <div class="legend-item" role="listitem">
+                        <div class="legend-chip">
                           <span class="status-chip warning">
                             <q-icon name="sensors" size="14px" />
                             <span>Signal only</span>
@@ -733,6 +816,17 @@
           </q-card-section>
         </q-card>
       </div>
+
+      <CreatorProfileModal
+        :show="profilePreviewVisible"
+        :pubkey="selectedPreviewPubkey"
+        :initial-profile="selectedPreviewProfile"
+        :initial-tab="profilePreviewInitialTab"
+        compact
+        @close="closeProfilePreview"
+        @message="startChat"
+        @donate="donate"
+      />
     </div>
   </q-page>
 </template>
@@ -750,6 +844,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useQuasar } from "quasar";
 import { nip19 } from "nostr-tools";
 import CreatorCard from "components/CreatorCard.vue";
+import CreatorProfileModal from "components/CreatorProfileModal.vue";
 import { useNostrStore } from "stores/nostr";
 import { useCreatorsStore, type CreatorProfile } from "stores/creators";
 import { useMessengerStore } from "stores/messenger";
@@ -773,7 +868,6 @@ import {
   creatorIsFundstrCreator,
   creatorIsSignalOnly,
 } from "stores/creators";
-import { preferredCreatorPublicIdentifier } from "src/utils/profileUrl";
 import {
   TRUSTED_RANK_INFO_LINKS,
   formatTrustedRankFreshness,
@@ -909,6 +1003,26 @@ const trustedProfiles = computed(() =>
   searchResults.value.filter((profile) => creatorHasTrustedSignal(profile)),
 );
 const trustedSignalCount = computed(() => trustedProfiles.value.length);
+const trustedSpotlightProfiles = computed(() => {
+  const combined = [...searchResults.value, ...featuredCreators.value];
+  const seen = new Set<string>();
+
+  return combined.filter((profile) => {
+    if (!creatorHasTrustedSignal(profile)) {
+      return false;
+    }
+
+    const key =
+      typeof profile.pubkey === "string" ? profile.pubkey.trim().toLowerCase() : "";
+    if (!key || seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+});
+const trustedSpotlightCount = computed(() => trustedSpotlightProfiles.value.length);
 const trustedProviderLabels = computed(() =>
   Array.from(
     new Set(
@@ -927,6 +1041,24 @@ const trustedProviderText = computed(() => {
   }
   return null;
 });
+const trustedSpotlightProviderLabels = computed(() =>
+  Array.from(
+    new Set(
+      trustedSpotlightProfiles.value
+        .map((profile) => creatorTrustedMetrics(profile)?.providerLabel?.trim())
+        .filter((label): label is string => Boolean(label)),
+    ),
+  ),
+);
+const trustedSpotlightProviderText = computed(() => {
+  if (trustedSpotlightProviderLabels.value.length === 1) {
+    return trustedRankProviderLine(trustedSpotlightProviderLabels.value[0]);
+  }
+  if (trustedSpotlightProviderLabels.value.length > 1) {
+    return `Current providers: ${trustedSpotlightProviderLabels.value.join(", ")}`;
+  }
+  return null;
+});
 const trustedLatestCreatedAt = computed(() => {
   const createdAts = trustedProfiles.value
     .map((profile) => creatorTrustedMetrics(profile)?.createdAt)
@@ -942,6 +1074,28 @@ const trustedLatestCreatedAt = computed(() => {
 const trustedFreshnessText = computed(() =>
   formatTrustedRankFreshness(trustedLatestCreatedAt.value),
 );
+const trustedSpotlightLatestCreatedAt = computed(() => {
+  const createdAts = trustedSpotlightProfiles.value
+    .map((profile) => creatorTrustedMetrics(profile)?.createdAt)
+    .filter(
+      (createdAt): createdAt is number =>
+        typeof createdAt === "number" && Number.isFinite(createdAt),
+    );
+  if (!createdAts.length) {
+    return null;
+  }
+  return Math.max(...createdAts);
+});
+const trustedSpotlightFreshnessText = computed(() =>
+  formatTrustedRankFreshness(trustedSpotlightLatestCreatedAt.value),
+);
+const trustedSpotlightSummary = computed(() => {
+  if (!trustedSpotlightCount.value) {
+    return "When a creator has provider-signed NIP-85 trust data, Fundstr can surface it before supporters click through.";
+  }
+
+  return `${trustedSpotlightCount.value} visible creator${trustedSpotlightCount.value === 1 ? " currently includes" : "s currently include"} provider-signed NIP-85 trust context.`;
+});
 const availableSortOptions = computed(() =>
   sortOptions.filter((option) => {
     if (option.value === "relevance") {
@@ -1449,6 +1603,14 @@ watch(searchWarnings, (warnings) => {
 const featuredSectionRef = ref<HTMLElement | ComponentPublicInstance | null>(
   null,
 );
+const profilePreviewVisible = ref(false);
+const selectedPreviewProfile = ref<CreatorProfile | null>(null);
+const profilePreviewInitialTab = ref<ProfileTab>("profile");
+const selectedPreviewPubkey = computed(() =>
+  typeof selectedPreviewProfile.value?.pubkey === "string"
+    ? selectedPreviewProfile.value.pubkey
+    : "",
+);
 const activeMintInfo = computed(() => mintsStore.activeInfo);
 const supportedNuts = computed(() =>
   resolveSupportedNuts(activeMintInfo.value),
@@ -1479,20 +1641,13 @@ function viewProfile(
     return;
   }
 
-  const npubOrHex =
-    preferredCreatorPublicIdentifier({
-      fallbackIdentifier:
-        (typeof profile.npub === "string" && profile.npub.trim()) ||
-        profile.pubkey,
-      nip05: typeof profile.nip05 === "string" ? profile.nip05 : null,
-      nip05Verified: creatorHasVerifiedNip05(profile),
-    }) || profile.pubkey;
+  selectedPreviewProfile.value = profile;
+  profilePreviewInitialTab.value = initialTab;
+  profilePreviewVisible.value = true;
+}
 
-  void router.push({
-    name: "PublicCreatorProfile",
-    params: { npubOrHex },
-    query: initialTab === "tiers" ? { tab: "tiers" } : undefined,
-  });
+function closeProfilePreview() {
+  profilePreviewVisible.value = false;
 }
 
 function startChat(pubkey: string) {
@@ -1597,6 +1752,25 @@ function toggleFilter(filterKey: FilterKey) {
   activeFilters.value = {
     ...activeFilters.value,
     [filterKey]: !activeFilters.value[filterKey],
+  };
+}
+
+function applyTrustedRankSort() {
+  if (!hasTrustedRankMetrics.value) {
+    return;
+  }
+
+  sortOption.value = "trustedRank";
+}
+
+function enableTrustedSignalFilter() {
+  if (!trustedSignalCount.value) {
+    return;
+  }
+
+  activeFilters.value = {
+    ...activeFilters.value,
+    trustedSignal: true,
   };
 }
 
@@ -1821,6 +1995,12 @@ onMounted(() => {
   border-color: color-mix(in srgb, var(--accent-500) 40%, transparent);
 }
 
+.status-chip.success {
+  color: #1a8f5f;
+  background: color-mix(in srgb, #1a8f5f 14%, var(--chip-bg));
+  border-color: color-mix(in srgb, #1a8f5f 28%, transparent);
+}
+
 .status-chip.muted {
   background: color-mix(in srgb, var(--chip-bg) 80%, transparent);
   color: var(--text-2);
@@ -1916,6 +2096,84 @@ h1 {
   display: flex;
   flex-direction: column;
   gap: 24px;
+}
+
+.trusted-rank-spotlight {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--accent-500) 18%, var(--surface-contrast-border));
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent-200) 16%, var(--surface-1) 84%) 0%,
+    color-mix(in srgb, var(--surface-1) 94%, var(--surface-2) 6%) 100%
+  );
+}
+
+.trusted-rank-spotlight__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent-200) 32%, transparent);
+  color: var(--accent-600);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.trusted-rank-spotlight__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.trusted-rank-spotlight__copy {
+  min-width: 0;
+}
+
+.trusted-rank-spotlight__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-1) 75%, var(--accent-200) 25%);
+  border: 1px solid color-mix(in srgb, var(--accent-500) 24%, transparent);
+  color: var(--accent-600);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.trusted-rank-spotlight__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  line-height: 1.45;
+}
+
+.trusted-rank-spotlight__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.trusted-rank-spotlight__link {
+  color: var(--accent-500);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.trusted-rank-spotlight__link:hover,
+.trusted-rank-spotlight__link:focus-visible {
+  color: var(--accent-600);
+  text-decoration: underline;
 }
 
 .load-more-wrapper {
@@ -2119,12 +2377,20 @@ h1 {
 }
 
 @media (max-width: 1023px) {
+  .trusted-rank-spotlight__header {
+    flex-direction: column;
+  }
+
   .search-results-toolbar {
     align-items: stretch;
   }
 
   .toolbar-controls {
     justify-content: flex-start;
+  }
+
+  .trusted-rank-spotlight__actions {
+    align-items: stretch;
   }
 }
 

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -1895,7 +1895,8 @@ function toCreatorTrustedMetrics(
     return { ...value };
   }
 
-  const rank = value.rank;
+  const source = value as TrustedUserRank | CreatorTrustedMetrics;
+  const rank = source.rank;
   if (!Number.isInteger(rank) || rank < 0 || rank > 100) {
     return null;
   }
@@ -1903,11 +1904,11 @@ function toCreatorTrustedMetrics(
   return {
     rank,
     providerLabel:
-      typeof value.providerLabel === "string" ? value.providerLabel : null,
+      typeof source.providerLabel === "string" ? source.providerLabel : null,
     providerPubkey:
-      typeof value.providerPubkey === "string" ? value.providerPubkey : null,
-    relayUrl: typeof value.relayUrl === "string" ? value.relayUrl : null,
-    createdAt: typeof value.createdAt === "number" ? value.createdAt : null,
+      typeof source.providerPubkey === "string" ? source.providerPubkey : null,
+    relayUrl: typeof source.relayUrl === "string" ? source.relayUrl : null,
+    createdAt: typeof source.createdAt === "number" ? source.createdAt : null,
   };
 }
 
@@ -2145,6 +2146,9 @@ export function mergeCreatorProfileWithFallback(
   }
 
   const merged: CreatorProfile = { ...fallbackProfile, ...incomingProfile };
+  merged.trustedMetrics =
+    toCreatorTrustedMetrics(incomingProfile.trustedMetrics) ??
+    toCreatorTrustedMetrics(fallbackProfile.trustedMetrics);
   const applyNonEmptyString = (
     value: unknown,
     fallback: unknown,

--- a/test/vitest/__tests__/CreatorProfileModal.fallback.spec.ts
+++ b/test/vitest/__tests__/CreatorProfileModal.fallback.spec.ts
@@ -27,6 +27,7 @@ type CreatorProfile = {
   displayName?: string;
   about?: string | null;
   name?: string;
+  trustedMetrics?: Record<string, unknown> | null;
   profile?: Record<string, unknown> | null;
   tiers?: Array<Record<string, any>> | null;
 };
@@ -42,6 +43,7 @@ vi.mock("stores/creators", () => ({
   }),
   mergeCreatorProfileWithFallback: (fallback: any, profile: any) =>
     profile ?? fallback,
+  creatorTrustedMetrics: (profile: any) => profile?.trustedMetrics ?? null,
   creatorIsSignalOnly: () => false,
   FundstrProfileFetchError: class FundstrProfileFetchError extends Error {
     fallbackAttempted = false;
@@ -60,13 +62,20 @@ vi.mock("stores/nostr", () => ({
 }));
 
 describe("CreatorProfileModal fallback", () => {
-  const initialProfile: CreatorProfile = {
-    pubkey: "pubkey-123",
-    displayName: "Initial Creator",
-    about: "Fallback bio",
-    name: "initial_creator",
-    profile: { display_name: "Initial Creator", about: "Fallback bio" },
-    tiers: [
+    const initialProfile: CreatorProfile = {
+      pubkey: "pubkey-123",
+      displayName: "Initial Creator",
+      about: "Fallback bio",
+      name: "initial_creator",
+      trustedMetrics: {
+        rank: 89,
+        providerLabel: "nostr.band",
+        providerPubkey: "provider",
+        relayUrl: "wss://nip85.nostr.band",
+        createdAt: 1_712_765_600,
+      },
+      profile: { display_name: "Initial Creator", about: "Fallback bio" },
+      tiers: [
       {
         id: "starter",
         name: "Starter Tier",
@@ -82,6 +91,7 @@ describe("CreatorProfileModal fallback", () => {
     "q-dialog": { template: "<div><slot /></div>" },
     "q-card": { template: "<div><slot /></div>" },
     "q-card-section": { template: "<section><slot /></section>" },
+    "q-icon": { template: "<i><slot /></i>" },
     "q-btn": {
       props: ["label"],
       template: "<button><slot />{{ label }}</button>",
@@ -116,6 +126,9 @@ describe("CreatorProfileModal fallback", () => {
     expect(fetchCreatorMock).toHaveBeenCalledWith(initialProfile.pubkey, false);
     expect(wrapper.text()).toContain("Initial Creator");
     expect(wrapper.text()).toContain("Fallback bio");
+    expect(wrapper.text()).toContain("Trusted rank (NIP-85)");
+    expect(wrapper.text()).toContain("89");
+    expect(wrapper.text()).toContain("nostr.band");
     expect(wrapper.text()).toContain("Starter Tier");
     expect(wrapper.text()).toContain("Showing saved details.");
     expect(wrapper.text()).toContain("Retry");

--- a/test/vitest/__tests__/FindCreatorsPage.spec.ts
+++ b/test/vitest/__tests__/FindCreatorsPage.spec.ts
@@ -24,7 +24,12 @@ vi.mock("src/api/fundstrDiscovery", () => ({
 }));
 
 vi.mock("components/CreatorProfileModal.vue", () => ({
-  default: { name: "CreatorProfileModal", template: "<div />" },
+  default: {
+    name: "CreatorProfileModal",
+    props: ["show", "pubkey", "initialProfile", "initialTab", "compact"],
+    template:
+      '<div class="creator-profile-modal-stub" :data-show="String(show)" :data-pubkey="pubkey || \"\"" :data-tab="initialTab || \"\"" :data-compact="String(compact)"></div>',
+  },
 }));
 vi.mock("components/DonateDialog.vue", () => ({
   default: { name: "DonateDialog", template: "<div />" },
@@ -79,18 +84,23 @@ describe("FindCreators.vue", () => {
     });
     creatorsStore = reactive({
       searchResults: [],
+      unfilteredSearchResults: [],
       featuredCreators: [],
       searching: false,
+      isRefreshing: false,
       loadingFeatured: false,
       error: "",
+      searchStatusMessage: "",
       searchWarnings: [],
       featuredError: "",
+      featuredStatusMessage: "",
       tiersMap: reactive({}),
       tierFetchError: false,
       ensureCreatorCacheFromDexie: vi.fn().mockResolvedValue(undefined),
       saveProfileCache: vi.fn().mockResolvedValue(undefined),
       loadFeaturedCreators: vi.fn().mockResolvedValue(undefined),
       searchCreators: vi.fn().mockResolvedValue(undefined),
+      applySearchFilters: vi.fn(),
     });
   });
 
@@ -171,5 +181,33 @@ describe("FindCreators.vue", () => {
       .find((node) => node.text() === "Could not load featured");
 
     expect(bannerText).toBeTruthy();
+  });
+
+  it("opens the creator preview modal when a creator card emits view-profile", async () => {
+    creatorsStore.featuredCreators = [
+      {
+        pubkey: "a".repeat(64),
+        profile: {},
+        followers: 12,
+        following: 3,
+        joined: 1,
+      },
+    ];
+
+    const wrapper = mountComponent();
+    await flushPromises();
+
+    const card = wrapper.findComponent({ name: "CreatorCard" });
+    card.vm.$emit("view-profile", {
+      pubkey: "a".repeat(64),
+      initialTab: "profile",
+    });
+    await nextTick();
+
+    const modal = wrapper.get(".creator-profile-modal-stub");
+    expect(modal.attributes("data-show")).toBe("true");
+    expect(modal.attributes("data-pubkey")).toBe("a".repeat(64));
+    expect(modal.attributes("data-tab")).toBe("profile");
+    expect(modal.attributes("data-compact")).toBe("true");
   });
 });

--- a/test/vitest/__tests__/creatorCard.discovery.spec.ts
+++ b/test/vitest/__tests__/creatorCard.discovery.spec.ts
@@ -154,6 +154,11 @@ describe("CreatorCard donation eligibility signals", () => {
   const hasDonateButton = (wrapper: ReturnType<typeof mountCard>) =>
     wrapper.findAll('[data-label="Donate"]').length > 0;
 
+  it("shows donate button for any profile with a public key", () => {
+    const wrapper = mountCard();
+    expect(hasDonateButton(wrapper)).toBe(true);
+  });
+
   it("shows donate button when lightning address is present", () => {
     const wrapper = mountCard({ profile: { lud16: "tip@example.com" } });
     expect(hasDonateButton(wrapper)).toBe(true);
@@ -189,8 +194,8 @@ describe("CreatorCard donation eligibility signals", () => {
     expect(hasDonateButton(wrapper)).toBe(true);
   });
 
-  it("hides donate button when no donation signals exist", () => {
-    const wrapper = mountCard();
+  it("hides donate button when the public key is missing", () => {
+    const wrapper = mountCard({ pubkey: "" });
     expect(hasDonateButton(wrapper)).toBe(false);
   });
 


### PR DESCRIPTION
Make NIP-85 trust signals easier to inspect on Find Creators and replace page jumps with inline creator previews. Show Donate for any valid creator pubkey so supporter flows stay available even when lightning metadata is missing.