### PR TITLE
feat(pwa): detect live deploys and guard risky refreshes

### DIFF
--- a/src-pwa/register-service-worker.js
+++ b/src-pwa/register-service-worker.js
@@ -2,6 +2,11 @@
 import { register } from "register-service-worker";
 import { Notify } from "quasar";
 import { notifyNetworkRequired } from "../src/pwa/networkMessaging";
+import {
+  isNewerLiveDeploy,
+  isSensitiveUpdatePath,
+  parseDeployMarker,
+} from "../src/pwa/updateLifecycle";
 
 if (import.meta.env.PROD) {
   const rawBase =
@@ -18,7 +23,13 @@ if (import.meta.env.PROD) {
     buildId ? `sw.js?v=${encodeURIComponent(buildId)}` : "sw.js",
     base,
   ).toString();
+  const deployMarkerUrl = new URL("deploy.txt", base).toString();
   const reloadGuardKey = "fundstr.pwa.lastUpdateReloadAt";
+  const liveDeployCheckIntervalMs = 10 * 60 * 1000;
+  let liveDeployCheckInFlight = false;
+  let pendingLiveDeploySha = null;
+  let dismissUpdateNotice = null;
+  let lastNotifiedDeploySha = null;
 
   const shouldReloadForUpdate = () => {
     try {
@@ -40,6 +51,109 @@ if (import.meta.env.PROD) {
     return true;
   };
 
+  const dismissPendingUpdateNotice = () => {
+    if (typeof dismissUpdateNotice === "function") {
+      dismissUpdateNotice();
+      dismissUpdateNotice = null;
+    }
+  };
+
+  const reloadToLatestVersion = (registration) => {
+    const safeReload = () => {
+      dismissPendingUpdateNotice();
+      if (shouldReloadForUpdate()) {
+        window.location.reload();
+      }
+    };
+
+    if (registration && registration.waiting) {
+      registration.waiting.postMessage({ type: "SKIP_WAITING" });
+      safeReload();
+      return;
+    }
+
+    Promise.resolve(registration?.update?.())
+      .catch(() => {})
+      .finally(safeReload);
+  };
+
+  const showDeferredUpdateNotice = (registration, liveDeploySha) => {
+    if (
+      liveDeploySha &&
+      lastNotifiedDeploySha === liveDeploySha &&
+      typeof dismissUpdateNotice === "function"
+    ) {
+      return;
+    }
+
+    dismissPendingUpdateNotice();
+    lastNotifiedDeploySha = liveDeploySha || null;
+
+    try {
+      dismissUpdateNotice = Notify.create({
+        message:
+          "A newer version of Fundstr is ready. Refresh after you finish this wallet or messaging flow.",
+        caption: liveDeploySha
+          ? `Live deploy ${liveDeploySha.slice(0, 7)} is available.`
+          : "Refresh when you are ready for the latest fixes.",
+        type: "warning",
+        timeout: 0,
+        position: "top",
+        multiLine: true,
+        actions: [
+          {
+            label: "Refresh now",
+            color: "white",
+            handler: () => reloadToLatestVersion(registration),
+          },
+          {
+            label: "Later",
+            color: "white",
+          },
+        ],
+      });
+    } catch (error) {
+      console.warn("[PWA] failed to show deferred update notice", error);
+    }
+  };
+
+  const maybeHandleLiveDeploy = (registration, liveDeploySha) => {
+    if (!isNewerLiveDeploy(buildId, liveDeploySha)) {
+      return;
+    }
+
+    pendingLiveDeploySha = liveDeploySha;
+    registration.update().catch(() => {});
+
+    if (isSensitiveUpdatePath(window.location.pathname)) {
+      showDeferredUpdateNotice(registration, liveDeploySha);
+    }
+  };
+
+  const checkLiveDeployMarker = async (registration) => {
+    if (!registration || !buildId || liveDeployCheckInFlight) {
+      return;
+    }
+
+    liveDeployCheckInFlight = true;
+    try {
+      const response = await fetch(deployMarkerUrl, {
+        cache: "no-store",
+        credentials: "same-origin",
+      });
+      if (!response.ok) {
+        return;
+      }
+
+      const marker = parseDeployMarker(await response.text());
+      maybeHandleLiveDeploy(registration, marker?.sha || "");
+    } catch (error) {
+      console.warn("[PWA] failed to check live deploy marker", error);
+    } finally {
+      liveDeployCheckInFlight = false;
+    }
+  };
+
   register(swUrl, {
     registrationOptions: { scope: base.pathname },
     ready() {
@@ -55,7 +169,14 @@ if (import.meta.env.PROD) {
       console.log("[PWA] update found");
     },
     updated(reg) {
-      console.log("[PWA] updated, forcing activation");
+      console.log("[PWA] updated, handling latest version");
+
+      if (isSensitiveUpdatePath(window.location.pathname)) {
+        showDeferredUpdateNotice(reg, pendingLiveDeploySha || "");
+        return;
+      }
+
+      dismissPendingUpdateNotice();
       if (reg && reg.waiting) reg.waiting.postMessage({ type: "SKIP_WAITING" });
       try {
         Notify.create({
@@ -96,13 +217,19 @@ if (import.meta.env.PROD) {
     try {
       const registration = await navigator.serviceWorker.ready;
       const triggerUpdate = () => registration.update().catch(() => {});
+      const triggerDeployCheck = () => checkLiveDeployMarker(registration);
       triggerUpdate();
+      void triggerDeployCheck();
       document.addEventListener("visibilitychange", () => {
         if (document.visibilityState === "visible") {
           triggerUpdate();
+          void triggerDeployCheck();
         }
       });
       setInterval(triggerUpdate, 60 * 60 * 1000);
+      setInterval(() => {
+        void triggerDeployCheck();
+      }, liveDeployCheckIntervalMs);
     } catch (error) {
       console.warn("[PWA] failed to schedule SW updates", error);
     }

--- a/src/components/CreatorProfileModal.vue
+++ b/src/components/CreatorProfileModal.vue
@@ -31,7 +31,7 @@
                   <div class="hero-meta">
                     <div class="hero-name">{{ displayName }}</div>
                     <div v-if="nip05" class="hero-handle">{{ nip05 }}</div>
-                    <div v-if="creatorPubkey" class="hero-identity">
+                    <div v-if="creatorPubkey && !props.compact" class="hero-identity">
                       <div class="hero-identity__row">
                         <span class="hero-identity__label text-2">npub</span>
                         <span class="hero-identity__value">{{ creatorNpub }}</span>
@@ -150,6 +150,59 @@
                         <q-icon name="bolt" size="14px" />
                         <span>Lightning ready</span>
                       </div>
+                    </div>
+                    <div v-if="creatorPubkey && props.compact" class="hero-identity hero-identity--compact">
+                      <div v-if="identityLinks.length" class="hero-identity__links hero-identity__links--compact">
+                        <a
+                          v-for="link in identityLinks"
+                          :key="link.label"
+                          class="hero-identity__link"
+                          :href="link.url"
+                          target="_blank"
+                          rel="noopener"
+                        >
+                          {{ link.label }}
+                        </a>
+                      </div>
+                      <details class="hero-identity__details">
+                        <summary class="hero-identity__summary">View public keys and copy tools</summary>
+                        <div class="hero-identity__details-body">
+                          <div class="hero-identity__row">
+                            <span class="hero-identity__label text-2">npub</span>
+                            <span class="hero-identity__value">{{ creatorNpub }}</span>
+                            <q-btn
+                              flat
+                              dense
+                              round
+                              icon="content_copy"
+                              class="hero-identity__copy"
+                              aria-label="Copy creator npub to clipboard"
+                              @click="copyIdentity(creatorNpub, 'npub')"
+                            >
+                              <q-tooltip v-model="copiedState.npub" anchor="top middle" self="bottom middle">
+                                Copied
+                              </q-tooltip>
+                            </q-btn>
+                          </div>
+                          <div class="hero-identity__row">
+                            <span class="hero-identity__label text-2">pubkey</span>
+                            <span class="hero-identity__value">{{ creatorPubkey }}</span>
+                            <q-btn
+                              flat
+                              dense
+                              round
+                              icon="content_copy"
+                              class="hero-identity__copy"
+                              aria-label="Copy creator pubkey to clipboard"
+                              @click="copyIdentity(creatorPubkey, 'pubkey')"
+                            >
+                              <q-tooltip v-model="copiedState.pubkey" anchor="top middle" self="bottom middle">
+                                Copied
+                              </q-tooltip>
+                            </q-btn>
+                          </div>
+                        </div>
+                      </details>
                     </div>
                   </div>
                 </div>
@@ -371,11 +424,25 @@
                       No highlights available yet
                     </div>
                   </div>
-                  <div class="notes-section">
-                    <div class="section-heading">Latest notes</div>
+                  <div
+                    v-if="showNotesSection"
+                    class="notes-section"
+                    :class="{ 'notes-section--compact': props.compact }"
+                  >
+                    <div class="notes-section__header">
+                      <div class="section-heading">{{ notesSectionHeading }}</div>
+                      <div v-if="props.compact" class="notes-section__helper text-body2 text-2">
+                        One recent public post to help you scan activity without turning the preview into a feed.
+                      </div>
+                    </div>
                     <div class="notes-list" role="list">
                       <template v-if="notesLoading">
-                        <div v-for="index in 3" :key="`note-skeleton-${index}`" class="note-card note-card--skeleton">
+                        <div
+                          v-for="index in notesSkeletonCount"
+                          :key="`note-skeleton-${index}`"
+                          class="note-card note-card--skeleton"
+                          :class="{ 'note-card--compact': props.compact }"
+                        >
                           <q-skeleton type="text" width="85%" />
                           <q-skeleton type="text" width="72%" />
                           <q-skeleton type="text" width="58%" />
@@ -386,9 +453,10 @@
                       </template>
                       <template v-else>
                         <div
-                          v-for="note in recentNotes"
+                          v-for="note in visibleRecentNotes"
                           :key="note.id"
                           class="note-card"
+                          :class="{ 'note-card--compact': props.compact }"
                           role="listitem"
                         >
                           <div class="note-content text-1">
@@ -406,7 +474,7 @@
                             </a>
                           </div>
                         </div>
-                        <div v-if="!recentNotes.length" class="notes-empty text-2">
+                        <div v-if="!visibleRecentNotes.length" class="notes-empty text-2">
                           No recent notes yet
                           <div v-if="notesError" class="notes-empty__error">
                             {{ notesError }}
@@ -595,12 +663,16 @@ const tiers = ref<TierDetails[]>([]);
 const showLocal = ref(false);
 const isMobileViewport = computed(() => $q.screen.lt.sm);
 const isDesktopViewport = computed(() => $q.screen.gt.sm);
-const isTwoColumnViewport = computed(() => !props.compact && $q.screen.width >= 1280);
+const compactTwoColumnBreakpoint = 1100;
+const isTwoColumnViewport = computed(() =>
+  $q.screen.width >= (props.compact ? compactTwoColumnBreakpoint : 1280),
+);
 const isDialogMaximized = computed(() => isMobileViewport.value || (!props.compact && isDesktopViewport.value));
 const relayFallbackStatus = ref(getFreeRelayFallbackStatus());
 let relayFallbackUnsubscribe: (() => void) | null = null;
 const dialogClasses = computed(() => ({
   'profile-dialog--compact': props.compact === true,
+  'profile-dialog--compact-wide': props.compact === true && isTwoColumnViewport.value,
   'profile-dialog--maximized': isDialogMaximized.value,
   'profile-dialog--mobile': isMobileViewport.value,
   'profile-dialog--desktop': isDesktopViewport.value,
@@ -620,6 +692,20 @@ let notesRequestId = 0;
 const recentNotes = ref<Array<{ content: string; created_at: number; id: string }>>([]);
 const notesLoading = ref(false);
 const notesError = ref<string | null>(null);
+const notesRequestLimit = computed(() => (props.compact ? 1 : 3));
+const notesSkeletonCount = computed(() => (props.compact ? 1 : 3));
+const visibleRecentNotes = computed(() =>
+  recentNotes.value.slice(0, notesRequestLimit.value),
+);
+const notesSectionHeading = computed(() =>
+  props.compact ? 'Latest note' : 'Latest notes',
+);
+const showNotesSection = computed(() => {
+  if (!props.compact) {
+    return true;
+  }
+  return notesLoading.value || visibleRecentNotes.value.length > 0;
+});
 
 function resolveInitialTab(tab?: string | null): 'profile' | 'tiers' {
   return tab === 'tiers' ? 'tiers' : 'profile';
@@ -926,7 +1012,7 @@ const tierFetchFailed = computed(() => creator.value?.tierFetchFailed === true);
 const showStickyFooter = computed(
   () => hasTiers.value && $q.screen.lt.md && activeTab.value === 'tiers',
 );
-const isHeroActionsInline = computed(() => $q.screen.gt.sm);
+const isHeroActionsInline = computed(() => $q.screen.gt.sm && !props.compact);
 
 const primaryTierId = computed(() => tiers.value[0]?.id ?? '');
 
@@ -1113,6 +1199,16 @@ watch(
       return;
     }
     activeTab.value = resolveInitialTab(nextTab);
+  },
+);
+
+watch(
+  () => props.compact,
+  () => {
+    if (!showLocal.value || !props.pubkey) {
+      return;
+    }
+    void loadRecentNotes(props.pubkey);
   },
 );
 
@@ -1310,7 +1406,10 @@ async function loadRecentNotes(pubkey: string) {
   notesError.value = null;
 
   try {
-    const notes = await nostrStore.fetchRecentNotes(pubkey, 3);
+    const notes = await nostrStore.fetchRecentNotes(
+      pubkey,
+      notesRequestLimit.value,
+    );
     if (requestId !== notesRequestId) {
       return;
     }
@@ -1409,43 +1508,49 @@ function resetState() {
 }
 
 .profile-dialog--compact .profile-card {
-  width: min(100%, 1040px);
-  height: min(88vh, 920px);
-  max-height: min(88vh, 920px);
+  width: min(100%, 1280px);
+  height: min(94vh, 980px);
+  max-height: min(94vh, 980px);
 }
 
 .profile-dialog--compact .profile-layout__body {
-  gap: 18px;
+  gap: 22px;
+  padding: clamp(16px, 2.8vh, 26px) clamp(16px, 3vw, 26px);
 }
 
 .profile-dialog--compact .hero-panel {
-  padding: clamp(24px, 3vw, 32px) clamp(24px, 3.4vw, 34px)
-    clamp(20px, 2.6vw, 24px);
+  padding: clamp(22px, 2.6vw, 30px) clamp(22px, 3vw, 30px)
+    clamp(18px, 2.4vw, 22px);
 }
 
 .profile-dialog--compact .hero-meta {
-  gap: 12px;
+  gap: 10px;
 }
 
 .profile-dialog--compact .hero-name {
-  font-size: clamp(2.8rem, 4vw, 4.2rem);
+  font-size: clamp(2.25rem, 2vw + 1.55rem, 3.35rem);
 }
 
 .profile-dialog--compact .hero-handle {
-  font-size: clamp(1.15rem, 0.55vw + 1rem, 1.4rem);
+  font-size: clamp(1.08rem, 0.4vw + 1rem, 1.28rem);
 }
 
 .profile-dialog--compact .hero-about {
-  font-size: clamp(1.05rem, 0.4vw + 0.98rem, 1.22rem);
-  line-height: 1.6;
+  font-size: clamp(0.98rem, 0.25vw + 0.95rem, 1.12rem);
+  line-height: 1.55;
+}
+
+.profile-dialog--compact .hero-about--clamped {
+  -webkit-line-clamp: 3;
 }
 
 .profile-dialog--compact .hero-actions {
-  margin-top: 18px;
+  margin-top: 16px;
+  gap: 10px;
 }
 
 .profile-dialog--compact .profile-tabs-section {
-  padding-top: 4px;
+  padding-top: 2px;
 }
 
 .profile-card--two-column {
@@ -1673,6 +1778,11 @@ function resetState() {
   border: 1px solid color-mix(in srgb, var(--surface-contrast-border) 70%, transparent);
 }
 
+.hero-identity--compact {
+  gap: 10px;
+  margin-top: 2px;
+}
+
 .hero-identity__row {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
@@ -1704,6 +1814,10 @@ function resetState() {
   padding-left: 2px;
 }
 
+.hero-identity__links--compact {
+  padding-left: 0;
+}
+
 .hero-identity__link {
   font-size: 0.9rem;
   color: var(--accent-500);
@@ -1714,6 +1828,39 @@ function resetState() {
 .hero-identity__link:hover,
 .hero-identity__link:focus-visible {
   text-decoration: underline;
+}
+
+.hero-identity__details {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.hero-identity__summary {
+  cursor: pointer;
+  list-style: none;
+  color: var(--accent-500);
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.hero-identity__summary::-webkit-details-marker {
+  display: none;
+}
+
+.hero-identity__summary::before {
+  content: '+';
+  margin-right: 0.45rem;
+}
+
+.hero-identity__details[open] .hero-identity__summary::before {
+  content: '-';
+}
+
+.hero-identity__details-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .hero-about {
@@ -1944,6 +2091,21 @@ function resetState() {
   gap: 16px;
 }
 
+.notes-section--compact {
+  gap: 14px;
+}
+
+.notes-section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.notes-section__helper {
+  max-width: 38rem;
+  line-height: 1.55;
+}
+
 .notes-list {
   display: flex;
   flex-direction: column;
@@ -1960,6 +2122,11 @@ function resetState() {
   border: 1px solid color-mix(in srgb, var(--surface-contrast-border) 75%, transparent);
 }
 
+.note-card--compact {
+  padding: 16px 18px;
+  gap: 12px;
+}
+
 .note-card--skeleton {
   gap: 8px;
 }
@@ -1970,6 +2137,10 @@ function resetState() {
   -webkit-box-orient: vertical;
   overflow: hidden;
   line-height: 1.5;
+}
+
+.note-card--compact .note-content {
+  -webkit-line-clamp: 4;
 }
 
 .note-meta {
@@ -2415,7 +2586,7 @@ function resetState() {
   }
 
   .profile-dialog--compact .hero-name {
-    font-size: clamp(2.35rem, 10vw, 3.3rem);
+    font-size: clamp(2.15rem, 9vw, 3.05rem);
   }
 
   .profile-dialog--compact .hero-handle {
@@ -2461,6 +2632,10 @@ function resetState() {
   }
 
   .highlights-section {
+    padding: 10px 16px 20px;
+  }
+
+  .notes-section {
     padding: 10px 16px 20px;
   }
 
@@ -2590,6 +2765,10 @@ function resetState() {
     grid-column: 1 / -1;
   }
 
+  .profile-dialog--compact .note-card {
+    max-width: none;
+  }
+
   .profile-layout--two-column .profile-layout__body {
     padding: clamp(18px, 3vh, 28px) 0;
   }
@@ -2619,6 +2798,30 @@ function resetState() {
 
   .empty-state {
     padding: 32px 48px;
+  }
+}
+@media (min-width: 1100px) {
+  .profile-dialog--compact-wide .profile-layout--two-column {
+    grid-template-columns: minmax(360px, 420px) minmax(0, 1fr);
+    grid-template-rows: 1fr;
+    column-gap: clamp(28px, 2.8vw, 40px);
+  }
+
+  .profile-dialog--compact-wide .profile-layout__hero--desktop .hero-panel {
+    min-height: 100%;
+    padding: clamp(24px, 2.6vw, 32px);
+  }
+
+  .profile-dialog--compact-wide .profile-layout__hero--desktop .hero-rail {
+    padding-right: clamp(8px, 1vw, 14px);
+  }
+
+  .profile-dialog--compact-wide .profile-layout__content--desktop {
+    padding-right: 0;
+  }
+
+  .profile-dialog--compact-wide .profile-layout__body {
+    padding: clamp(18px, 3vh, 28px) 0;
   }
 }
 @media (min-width: 1280px) {

--- a/src/pwa/updateLifecycle.js
+++ b/src/pwa/updateLifecycle.js
@@ -1,0 +1,65 @@
+const SENSITIVE_UPDATE_PREFIXES = [
+  "/wallet",
+  "/nostr-messenger",
+  "/creator-studio",
+  "/restore",
+  "/unlock",
+];
+
+export function parseDeployMarker(rawMarker) {
+  if (typeof rawMarker !== "string") {
+    return null;
+  }
+
+  const lines = rawMarker
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (!lines.length) {
+    return null;
+  }
+
+  const marker = {};
+  for (const line of lines) {
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex <= 0) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    if (!key) {
+      continue;
+    }
+
+    marker[key] = value;
+  }
+
+  return marker;
+}
+
+export function isSensitiveUpdatePath(pathname) {
+  if (typeof pathname !== "string") {
+    return false;
+  }
+
+  const normalizedPath = pathname.trim() || "/";
+  return SENSITIVE_UPDATE_PREFIXES.some(
+    (prefix) =>
+      normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`),
+  );
+}
+
+export function isNewerLiveDeploy(currentBuildId, liveDeploySha) {
+  if (
+    typeof currentBuildId !== "string" ||
+    typeof liveDeploySha !== "string" ||
+    !currentBuildId.trim() ||
+    !liveDeploySha.trim()
+  ) {
+    return false;
+  }
+
+  return currentBuildId.trim() !== liveDeploySha.trim();
+}

--- a/test/vitest/__tests__/CreatorProfileModal.fallback.spec.ts
+++ b/test/vitest/__tests__/CreatorProfileModal.fallback.spec.ts
@@ -33,6 +33,7 @@ type CreatorProfile = {
 };
 
 const fetchCreatorMock = vi.fn();
+const fetchRecentNotesMock = vi.fn();
 
 vi.mock("stores/creators", () => ({
   useCreatorsStore: () => ({
@@ -57,7 +58,7 @@ vi.mock("stores/nostr", () => ({
     npub: "npub1test",
     connected: false,
     relays: [],
-    fetchRecentNotes: vi.fn().mockResolvedValue([]),
+    fetchRecentNotes: fetchRecentNotesMock,
   }),
 }));
 
@@ -111,6 +112,8 @@ describe("CreatorProfileModal fallback", () => {
 
   beforeEach(() => {
     fetchCreatorMock.mockReset();
+    fetchRecentNotesMock.mockReset();
+    fetchRecentNotesMock.mockResolvedValue([]);
   });
 
   it("keeps the initial profile when fetching fails", async () => {
@@ -151,5 +154,39 @@ describe("CreatorProfileModal fallback", () => {
     expect(wrapper.text()).toContain("Fallback bio");
     expect(wrapper.text()).toContain("Starter Tier");
     expect(wrapper.text()).toContain("Showing saved details.");
+  });
+
+  it("renders a lighter recent activity preview in compact mode", async () => {
+    fetchCreatorMock.mockResolvedValue(null);
+    fetchRecentNotesMock.mockResolvedValue([
+      {
+        id: "note-1",
+        content: "Newest note",
+        created_at: 1_712_765_600,
+      },
+      {
+        id: "note-2",
+        content: "Older note",
+        created_at: 1_712_700_000,
+      },
+    ]);
+
+    const wrapper = mount(CreatorProfileModal, {
+      props: {
+        show: true,
+        pubkey: initialProfile.pubkey,
+        initialProfile,
+        compact: true,
+      },
+      global: { stubs: globalStubs },
+    });
+
+    await flushPromises();
+
+    expect(fetchRecentNotesMock).toHaveBeenCalledWith(initialProfile.pubkey, 1);
+    expect(wrapper.text()).toContain("Latest note");
+    expect(wrapper.text()).toContain("Newest note");
+    expect(wrapper.text()).not.toContain("Older note");
+    expect(wrapper.text()).toContain("View public keys and copy tools");
   });
 });

--- a/test/vitest/__tests__/pwaUpdateLifecycle.spec.ts
+++ b/test/vitest/__tests__/pwaUpdateLifecycle.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  isNewerLiveDeploy,
+  isSensitiveUpdatePath,
+  parseDeployMarker,
+} from "src/pwa/updateLifecycle";
+
+describe("parseDeployMarker", () => {
+  it("extracts deploy marker fields from text", () => {
+    expect(
+      parseDeployMarker(`env=production
+sha=abc123
+ref=main
+built_at=2026-04-20T08:04:16Z
+run_id=12345
+`),
+    ).toEqual({
+      env: "production",
+      sha: "abc123",
+      ref: "main",
+      built_at: "2026-04-20T08:04:16Z",
+      run_id: "12345",
+    });
+  });
+
+  it("returns null for non-string or empty markers", () => {
+    expect(parseDeployMarker(undefined as unknown as string)).toBeNull();
+    expect(parseDeployMarker("")).toBeNull();
+  });
+});
+
+describe("isSensitiveUpdatePath", () => {
+  it("flags wallet and publishing paths as sensitive", () => {
+    expect(isSensitiveUpdatePath("/wallet")).toBe(true);
+    expect(isSensitiveUpdatePath("/wallet/send")).toBe(true);
+    expect(isSensitiveUpdatePath("/nostr-messenger")).toBe(true);
+    expect(isSensitiveUpdatePath("/creator-studio/drafts")).toBe(true);
+    expect(isSensitiveUpdatePath("/restore")).toBe(true);
+    expect(isSensitiveUpdatePath("/unlock")).toBe(true);
+  });
+
+  it("does not flag passive discovery pages", () => {
+    expect(isSensitiveUpdatePath("/find-creators")).toBe(false);
+    expect(isSensitiveUpdatePath("/creator/npub1test/profile")).toBe(false);
+    expect(isSensitiveUpdatePath("/settings")).toBe(false);
+  });
+});
+
+describe("isNewerLiveDeploy", () => {
+  it("detects when the live deploy SHA differs from the current build", () => {
+    expect(isNewerLiveDeploy("abc123", "def456")).toBe(true);
+  });
+
+  it("ignores identical or missing build identifiers", () => {
+    expect(isNewerLiveDeploy("abc123", "abc123")).toBe(false);
+    expect(isNewerLiveDeploy("", "abc123")).toBe(false);
+    expect(isNewerLiveDeploy("abc123", "")).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
       "test/vitest/__tests__/welcome.interaction.spec.ts",
       "test/vitest/__tests__/validateMedia.spec.ts",
       "test/vitest/__tests__/safeRedirect.spec.ts",
+      "test/vitest/__tests__/pwaUpdateLifecycle.spec.ts",
       "test/creatorStudio/tierComposerUtils.spec.ts",
       "test/creatorStudio/TierComposer.interaction.spec.ts",
       "test/cashu-sendQueue.spec.ts",


### PR DESCRIPTION
## Summary
- check the live deploy marker on load, focus, and a short interval so active Fundstr clients can notice newer deployments faster
- reuse the existing service-worker update flow for passive pages while deferring refreshes behind a persistent banner on wallet, messaging, restore, unlock, and creator-studio routes
- add focused tests for deploy-marker parsing and risky-route detection, and include them in the repo's explicit Vitest allowlist

## Testing
- pnpm vitest run test/vitest/__tests__/pwaUpdateLifecycle.spec.ts
- pnpm build